### PR TITLE
Add test_charge_updates_last_charged test to verify timestamp update

### DIFF
--- a/contract/src/test.rs
+++ b/contract/src/test.rs
@@ -233,6 +233,38 @@ fn test_initialize_backward_compat() {
     assert_eq!(client.get_subscription(&user).unwrap().token, token_b);
 }
 
+// ── Issue #12: last_charged timestamp update ─────────────────────────────────
+
+/// charge() must update last_charged to the current ledger timestamp.
+#[test]
+fn test_charge_updates_last_charged() {
+    let (env, contract_id, token_addr, user, merchant) = setup();
+    let client = FlowPayClient::new(&env, &contract_id);
+
+    let amount: i128 = 5_0000000;
+    let interval: u64 = 30 * 24 * 60 * 60; // 30 days
+
+    client.subscribe(&user, &merchant, &amount, &interval, &token_addr);
+
+    // Record the timestamp before advancing time
+    let subscribe_time = env.ledger().timestamp();
+
+    // Advance ledger time past interval
+    env.ledger().with_mut(|l| {
+        l.timestamp += interval + 1000; // advance by interval + 1000 seconds
+    });
+
+    // Record the timestamp right before charge
+    let charge_time = env.ledger().timestamp();
+    assert!(charge_time > subscribe_time, "charge time should be after subscribe time");
+
+    client.charge(&user);
+
+    let sub_after = client.get_subscription(&user).unwrap();
+    // Verify last_charged is exactly equal to the charge_time
+    assert_eq!(sub_after.last_charged, charge_time, "last_charged should equal the ledger timestamp at charge time");
+}
+
 // ── Issue #7: input-validation guards ────────────────────────────────────────
 
 /// subscribe() must panic when amount = 0.


### PR DESCRIPTION
## Description

This PR adds a test that explicitly verifies last_charged is updated to the current ledger timestamp after a successful charge() call.

## Changes

- Added test_charge_updates_last_charged test in contract/src/test.rs
- Records the ledger timestamp before calling charge()
- Asserts sub.last_charged == recorded_timestamp after the call
- Uses env.ledger().timestamp() to get the expected value

## Current State

- test_subscribe_and_charge checks last_charged > 0 but doesn't verify the exact value
- The timestamp update is a critical correctness property that deserves explicit testing

## Testing

All tests pass:
- New test verifies exact last_charged value
- All existing tests continue to pass

Closes #12