### PR TITLE
refactor: extract useSubscription hook from Dashboard (#41)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { useWallet } from "./hooks/useWallet";
 import SubscribeForm from "./components/SubscribeForm";
 import Dashboard from "./components/Dashboard";
 import TabBar from "./components/TabBar";
+import ConnectWallet from "./components/ConnectWallet";
 
 export default function App() {
   const { publicKey, connect, signAndSubmit, error } = useWallet();

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -1,20 +1,13 @@
-import React, { useEffect, useState, useCallback } from "react";
-import { getSubscription, buildCancelTx, buildPayPerUseTx } from "../stellar";
+import React, { useState } from "react";
+import { buildCancelTx, buildPayPerUseTx } from "../stellar";
 import SubscriptionCardSkeleton from "./Skeleton";
+import { useSubscription } from "../hooks/useSubscription";
 
 interface Props {
   userKey: string;
   onSign: (xdr: string) => Promise<string>;
   refreshTrigger: number;
 }
-
-type Sub = {
-  merchant: string;
-  amount: string;
-  interval: number;
-  last_charged: number;
-  active: boolean;
-};
 
 function formatInterval(secs: number): string {
   if (secs >= 2_592_000) return `${Math.round(secs / 2_592_000)}mo`;
@@ -24,24 +17,9 @@ function formatInterval(secs: number): string {
 }
 
 export default function Dashboard({ userKey, onSign, refreshTrigger }: Props) {
-  const [sub, setSub] = useState<Sub | null>(null);
-  const [loading, setLoading] = useState(true);
+  const { subscription: sub, loading, refresh: load } = useSubscription(userKey, refreshTrigger);
   const [actionStatus, setActionStatus] = useState<string | null>(null);
   const [ppuAmount, setPpuAmount] = useState("");
-
-  const load = useCallback(async () => {
-    setLoading(true);
-    try {
-      const data = await getSubscription(userKey);
-      setSub(data);
-    } catch {
-      setSub(null);
-    } finally {
-      setLoading(false);
-    }
-  }, [userKey]);
-
-  useEffect(() => { load(); }, [load, refreshTrigger]);
 
   async function handleCancel() {
     setActionStatus(null);

--- a/frontend/src/hooks/useSubscription.ts
+++ b/frontend/src/hooks/useSubscription.ts
@@ -1,0 +1,36 @@
+import { useState, useCallback, useEffect } from "react";
+import { getSubscription } from "../stellar";
+
+type Subscription = {
+  merchant: string;
+  amount: string;
+  interval: number;
+  last_charged: number;
+  active: boolean;
+};
+
+export function useSubscription(userKey: string, refreshTrigger?: number) {
+  const [subscription, setSubscription] = useState<Subscription | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await getSubscription(userKey);
+      setSubscription(data);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e));
+      setSubscription(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [userKey]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh, refreshTrigger]);
+
+  return { subscription, loading, error, refresh };
+}


### PR DESCRIPTION
What's changed                                                                 
                                                                                 
  - src/hooks/useSubscription.ts (new) — encapsulates getSubscription call,      
  loading state, and error handling; exports { subscription, loading, error,     
  refresh }                                                                      
  - src/components/Dashboard.tsx — replaces inline useState/useEffect/useCallback
   fetch logic with a single useSubscription call; no UI changes                 
  - src/App.tsx — fix missing ConnectWallet import (pre-existing bug, build was  
  broken on master)                                                              
                                                                                 
  Verification                                                                   
                                                                                 
  npm run build  ✅ passes                                                       
                                                                                 
  Closes #41