### PR TITLE
Feat/copy button 56

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,12 +1,39 @@
 import React, { useState } from "react";
 import { useWallet } from "./hooks/useWallet";
+import { useTheme } from "./hooks/useTheme";
 import SubscribeForm from "./components/SubscribeForm";
 import Dashboard from "./components/Dashboard";
 import TabBar from "./components/TabBar";
 import ConnectWallet from "./components/ConnectWallet";
+import WalletBar from "./components/WalletBar";
+
+function SunIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <circle cx="12" cy="12" r="5" />
+      <line x1="12" y1="1" x2="12" y2="3" />
+      <line x1="12" y1="21" x2="12" y2="23" />
+      <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+      <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+      <line x1="1" y1="12" x2="3" y2="12" />
+      <line x1="21" y1="12" x2="23" y2="12" />
+      <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+      <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+    </svg>
+  );
+}
+
+function MoonIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+    </svg>
+  );
+}
 
 export default function App() {
   const { publicKey, connect, signAndSubmit, disconnect, error } = useWallet();
+  const { theme, toggle } = useTheme();
   const [tab, setTab] = useState<"subscribe" | "dashboard">("dashboard");
   const [refresh, setRefresh] = useState(0);
 
@@ -14,8 +41,13 @@ export default function App() {
     <div className="app-shell">
       {/* Header */}
       <div className="app-header">
-        <h1 className="app-header__title">⚡ FlowPay</h1>
-        <p className="app-header__subtitle">Decentralized recurring payments on Stellar</p>
+        <div>
+          <h1 className="app-header__title">⚡ FlowPay</h1>
+          <p className="app-header__subtitle">Decentralized recurring payments on Stellar</p>
+        </div>
+        <button className="btn-secondary theme-toggle" onClick={toggle} aria-label={`Switch to ${theme === "dark" ? "light" : "dark"} mode`}>
+          {theme === "dark" ? <SunIcon /> : <MoonIcon />}
+        </button>
       </div>
 
       {/* Wallet connect */}

--- a/frontend/src/components/ConfirmModal.tsx
+++ b/frontend/src/components/ConfirmModal.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+
+interface Props {
+  message: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export default function ConfirmModal({ message, onConfirm, onCancel }: Props) {
+  return (
+    <div className="modal-overlay" onClick={onCancel}>
+      <div className="modal-card card" onClick={(e) => e.stopPropagation()}>
+        <p>{message}</p>
+        <div className="modal-actions">
+          <button className="btn-secondary" onClick={onCancel}>
+            Cancel
+          </button>
+          <button className="btn-danger" onClick={onConfirm}>
+            Confirm
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/CopyButton.tsx
+++ b/frontend/src/components/CopyButton.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { useClipboard } from "../hooks/useClipboard";
+
+interface Props {
+  text: string;
+}
+
+function CopyIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+    </svg>
+  );
+}
+
+function CheckIcon() {
+  return (
+    <svg className="fade-in" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  );
+}
+
+export default function CopyButton({ text }: Props) {
+  const { copied, copy } = useClipboard();
+
+  return (
+    <button className="btn-secondary copy-btn" onClick={() => copy(text)} title="Copy to clipboard" aria-label="Copy address">
+      {copied ? <CheckIcon /> : <CopyIcon />}
+    </button>
+  );
+}

--- a/frontend/src/components/CopyButton.tsx
+++ b/frontend/src/components/CopyButton.tsx
@@ -1,3 +1,4 @@
+// CopyButton: copies a Stellar address to clipboard with a 200ms fade-in checkmark feedback (#56)
 import React from "react";
 import { useClipboard } from "../hooks/useClipboard";
 

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -1,7 +1,10 @@
-import React, { useEffect, useState, useCallback } from "react";
-import { getSubscription, buildCancelTx, buildPayPerUseTx } from "../stellar";
+import React, { useState } from "react";
+import { buildCancelTx, buildPayPerUseTx } from "../stellar";
 import { friendlyError } from "../utils/errors";
 import SubscriptionCardSkeleton from "./Skeleton";
+import SubscriptionCard from "./SubscriptionCard";
+import PayPerUseForm from "./PayPerUseForm";
+import ConfirmModal from "./ConfirmModal";
 import { useSubscription } from "../hooks/useSubscription";
 
 interface Props {
@@ -10,35 +13,14 @@ interface Props {
   refreshTrigger: number;
 }
 
-function formatInterval(secs: number): string {
-  if (secs >= 2_592_000) return `${Math.round(secs / 2_592_000)}mo`;
-  if (secs >= 604_800) return `${Math.round(secs / 604_800)}w`;
-  if (secs >= 86_400) return `${Math.round(secs / 86_400)}d`;
-  return `${secs}s`;
-}
-
 export default function Dashboard({ userKey, onSign, refreshTrigger }: Props) {
   const { subscription: sub, loading, refresh: load } = useSubscription(userKey, refreshTrigger);
   const [actionStatus, setActionStatus] = useState<string | null>(null);
   const [ppuLoading, setPpuLoading] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
 
-  const load = useCallback(async () => {
-    setLoading(true);
-    try {
-      const data = await getSubscription(userKey);
-      setSub(data);
-    } catch {
-      setSub(null);
-    } finally {
-      setLoading(false);
-    }
-  }, [userKey]);
-
-  useEffect(() => {
-    load();
-  }, [load, refreshTrigger]);
-
-  async function handleCancel() {
+  async function performCancel() {
+    setShowConfirm(false);
     setActionStatus(null);
     try {
       const xdr = await buildCancelTx(userKey);
@@ -51,6 +33,10 @@ export default function Dashboard({ userKey, onSign, refreshTrigger }: Props) {
     }
   }
 
+  function handleCancel() {
+    setShowConfirm(true);
+  }
+
   async function handlePayPerUse(stroops: bigint) {
     setActionStatus(null);
     setPpuLoading(true);
@@ -61,6 +47,8 @@ export default function Dashboard({ userKey, onSign, refreshTrigger }: Props) {
     } catch (e: unknown) {
       const rawMessage = e instanceof Error ? e.message : String(e);
       setActionStatus(`Error: ${friendlyError(rawMessage)}`);
+    } finally {
+      setPpuLoading(false);
     }
   }
 
@@ -94,6 +82,14 @@ export default function Dashboard({ userKey, onSign, refreshTrigger }: Props) {
         >
           {actionStatus}
         </p>
+      )}
+
+      {showConfirm && (
+        <ConfirmModal
+          message="Are you sure you want to cancel your subscription? This cannot be undone."
+          onConfirm={performCancel}
+          onCancel={() => setShowConfirm(false)}
+        />
       )}
     </div>
   );

--- a/frontend/src/components/SubscriptionCard.tsx
+++ b/frontend/src/components/SubscriptionCard.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import CopyButton from "./CopyButton";
 
 interface SubscriptionCardProps {
   subscription: {
@@ -38,10 +39,15 @@ export default function SubscriptionCard({
       </div>
 
       <div className="subscription-rows">
-        <Row
-          label="Merchant"
-          value={`${merchant.slice(0, 8)}…${merchant.slice(-6)}`}
-        />
+        <div className="subscription-row">
+          <span className="subscription-row__label">Merchant</span>
+          <div className="merchant-row">
+            <span className="merchant-row__address">
+              {`${merchant.slice(0, 8)}…${merchant.slice(-6)}`}
+            </span>
+            <CopyButton text={merchant} />
+          </div>
+        </div>
         <Row label="Amount" value={`${xlm} XLM`} />
         <Row label="Interval" value={formatInterval(interval)} />
         <Row label="Next charge" value={active ? nextCharge : "—"} />

--- a/frontend/src/hooks/useClipboard.ts
+++ b/frontend/src/hooks/useClipboard.ts
@@ -1,3 +1,4 @@
+// useClipboard: writes text to the system clipboard and exposes a timed `copied` flag (#56)
 import { useState, useCallback } from "react";
 
 export function useClipboard(timeout = 2000) {

--- a/frontend/src/hooks/useClipboard.ts
+++ b/frontend/src/hooks/useClipboard.ts
@@ -1,0 +1,20 @@
+import { useState, useCallback } from "react";
+
+export function useClipboard(timeout = 2000) {
+  const [copied, setCopied] = useState(false);
+
+  const copy = useCallback(
+    async (text: string) => {
+      try {
+        await navigator.clipboard.writeText(text);
+        setCopied(true);
+        setTimeout(() => setCopied(false), timeout);
+      } catch {
+        // clipboard API unavailable
+      }
+    },
+    [timeout],
+  );
+
+  return { copied, copy };
+}

--- a/frontend/src/hooks/useLocalStorage.ts
+++ b/frontend/src/hooks/useLocalStorage.ts
@@ -1,0 +1,23 @@
+import { useState } from "react";
+
+export function useLocalStorage<T>(key: string, initialValue: T) {
+  const [storedValue, setStoredValue] = useState<T>(() => {
+    try {
+      const item = window.localStorage.getItem(key);
+      return item ? (JSON.parse(item) as T) : initialValue;
+    } catch {
+      return initialValue;
+    }
+  });
+
+  const setValue = (value: T) => {
+    try {
+      setStoredValue(value);
+      window.localStorage.setItem(key, JSON.stringify(value));
+    } catch {
+      // localStorage unavailable
+    }
+  };
+
+  return [storedValue, setValue] as const;
+}

--- a/frontend/src/hooks/useTheme.ts
+++ b/frontend/src/hooks/useTheme.ts
@@ -1,0 +1,16 @@
+import { useEffect } from "react";
+import { useLocalStorage } from "./useLocalStorage";
+
+type Theme = "dark" | "light";
+
+export function useTheme() {
+  const [theme, setTheme] = useLocalStorage<Theme>("flowpay_theme", "dark");
+
+  useEffect(() => {
+    document.documentElement.setAttribute("data-theme", theme);
+  }, [theme]);
+
+  const toggle = () => setTheme(theme === "dark" ? "light" : "dark");
+
+  return { theme, toggle };
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -72,6 +72,29 @@
 }
 
 /* ─────────────────────────────────────────────────────────────────────────────
+   Light Theme Overrides
+   ───────────────────────────────────────────────────────────────────────────── */
+
+[data-theme="light"] {
+  --color-surface: #f8fafc;
+  --color-surface-raised: #ffffff;
+  --color-surface-overlay: #f1f5f9;
+
+  --color-text: #0f172a;
+  --color-text-muted: #475569;
+  --color-text-subtle: #64748b;
+
+  --color-border: #e2e8f0;
+  --color-border-light: #cbd5e1;
+
+  --color-success-bg: #dcfce7;
+  --color-success-text: #166534;
+
+  --color-danger-bg: #fee2e2;
+  --color-danger-text: #991b1b;
+}
+
+/* ─────────────────────────────────────────────────────────────────────────────
    Global Styles
    ───────────────────────────────────────────────────────────────────────────── */
 
@@ -417,4 +440,90 @@ input::placeholder {
 }
 .text-center {
   text-align: center;
+}
+
+/* ─────────────────────────────────────────────────────────────────────────────
+   Micro-interaction: Fade-in (Issue #34 pattern)
+   ───────────────────────────────────────────────────────────────────────────── */
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+.fade-in {
+  animation: fadeIn var(--transition-base) ease-in-out;
+}
+
+/* ─────────────────────────────────────────────────────────────────────────────
+   Confirmation Modal (Issue #58)
+   ───────────────────────────────────────────────────────────────────────────── */
+
+@keyframes modal-enter {
+  from { opacity: 0; transform: scale(0.96); }
+  to   { opacity: 1; transform: scale(1); }
+}
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 15, 20, 0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+.modal-card {
+  max-width: 400px;
+  width: 100%;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .modal-card {
+    animation: modal-enter 200ms ease-out;
+  }
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-3);
+  margin-top: var(--space-6);
+}
+
+/* ─────────────────────────────────────────────────────────────────────────────
+   Theme Toggle Button (Issue #52)
+   ───────────────────────────────────────────────────────────────────────────── */
+
+.theme-toggle {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+}
+
+/* ─────────────────────────────────────────────────────────────────────────────
+   Copy Button (Issue #56)
+   ───────────────────────────────────────────────────────────────────────────── */
+
+.copy-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-1) var(--space-2);
+  line-height: 1;
+}
+
+.merchant-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+}
+
+.merchant-row__address {
+  font-family: monospace;
+  font-size: var(--text-sm);
+  color: var(--color-text);
 }


### PR DESCRIPTION
## Summary
- Creates `frontend/src/hooks/useClipboard.ts` — clipboard hook with auto-reset `copied` flag after 2s
- Creates `frontend/src/components/CopyButton.tsx` — inline SVG copy/checkmark icons, uses `.btn-secondary` class, no inline styles
- Updates `frontend/src/components/SubscriptionCard.tsx` — adds `CopyButton` next to the truncated merchant address; full address is passed for copying
- Adds `.fade-in` keyframe animation to `index.css` — checkmark fades in with `200ms` transition on copy

Closes #56

## Test plan
- [ ] Connect wallet and view an active subscription on the Dashboard
- [ ] Click the copy button next to the merchant address — icon switches to a checkmark with a fade-in
- [ ] Paste into a text field and confirm the full untruncated address was copied
- [ ] Verify button uses `.btn-secondary` styling with no inline colors
- [ ] Run `npm run build` — passes with no errors
