### PR TITLE
feat: snapshot for merchant revenue from pay-per-use contract interactions

### DIFF
--- a/contract/src/batch.rs
+++ b/contract/src/batch.rs
@@ -1,0 +1,78 @@
+use soroban_sdk::{contracttype, Address, Env, Vec};
+
+use crate::{grace, token, DataKey, Subscription};
+use crate::events;
+use crate::merchant_stats;
+
+/// The outcome for a single user in a batch_charge call.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum ChargeResult {
+    /// Funds were transferred successfully.
+    Charged,
+    /// Interval has not elapsed yet — skipped without error.
+    Skipped,
+    /// No subscription found for this address.
+    NoSubscription,
+    /// Subscription is inactive (cancelled).
+    Inactive,
+    /// Subscription is paused.
+    Paused,
+    /// Grace period has elapsed.
+    GracePeriodElapsed,
+}
+
+/// Attempts to charge each user in `users`.
+///
+/// Individual failures do **not** abort the batch — every address is
+/// processed and its outcome is recorded in the returned `Vec`.
+pub fn batch_charge(env: &Env, users: Vec<Address>) -> Vec<ChargeResult> {
+    let mut results: Vec<ChargeResult> = Vec::new(env);
+
+    let now = env.ledger().timestamp();
+    let grace_period = grace::get_grace_period(env);
+
+    for user in users.iter() {
+        let key = DataKey::Subscription(user.clone());
+
+        let sub_opt: Option<Subscription> = env.storage().persistent().get(&key);
+
+        let result = match sub_opt {
+            None => ChargeResult::NoSubscription,
+            Some(mut sub) => {
+                if !sub.active {
+                    ChargeResult::Inactive
+                } else if sub.paused {
+                    ChargeResult::Paused
+                } else if now < sub.last_charged + sub.interval {
+                    ChargeResult::Skipped
+                } else if grace_period > 0
+                    && now > sub.last_charged + sub.interval + grace_period
+                {
+                    ChargeResult::GracePeriodElapsed
+                } else {
+                    let token_client = token::Client::new(env, &sub.token);
+                    token_client.transfer_from(
+                        &env.current_contract_address(),
+                        &user,
+                        &sub.merchant,
+                        &sub.amount,
+                    );
+
+                    merchant_stats::increment_revenue(env, &sub.merchant, sub.amount);
+
+                    sub.last_charged = now;
+                    env.storage().persistent().set(&key, &sub);
+
+                    events::publish_charged(env, &user, &sub, now);
+
+                    ChargeResult::Charged
+                }
+            }
+        };
+
+        results.push_back(result);
+    }
+
+    results
+}

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -1,18 +1,24 @@
 #![no_std]
 
 mod admin;
+mod batch;
 mod errors;
 mod events;
 mod fee;
 mod grace;
+mod merchant_stats;
+mod spending_limit;
 mod storage;
+mod subscription_count;
 mod test;
 mod trial;
 mod validation;
 mod whitelist;
 
 use crate::errors::ContractError;
-use soroban_sdk::{contract, contractimpl, contracttype, token, Address, Env, Symbol};
+use soroban_sdk::{contract, contractimpl, contracttype, token, Address, Env, Symbol, Vec};
+
+pub use batch::ChargeResult;
 
 // ─────────────────────────────────────────────────────────────
 // Storage keys
@@ -23,6 +29,23 @@ use soroban_sdk::{contract, contractimpl, contracttype, token, Address, Env, Sym
 pub enum DataKey {
     Subscription(Address),
     Token,
+    // Admin
+    Admin,
+    // Grace period
+    GracePeriod,
+    // Merchant whitelist
+    MerchantWhitelist(Address),
+    WhitelistEnabled,
+    // Protocol fee
+    FeeCollector,
+    FeeBps,
+    // Feature: subscription count
+    ActiveCount,
+    // Feature: merchant revenue stats
+    MerchantRevenue(Address),
+    // Feature: daily spending limits (temporary storage)
+    DailyLimit(Address),
+    DailySpent(Address),
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -102,6 +125,7 @@ impl FlowPay {
             .persistent()
             .set(&DataKey::Subscription(user.clone()), &sub);
 
+        subscription_count::increment(&env);
         events::publish_subscribed(&env, &user, &sub);
     }
 
@@ -137,6 +161,8 @@ impl FlowPay {
             &sub.amount,
         );
 
+        merchant_stats::increment_revenue(&env, &sub.merchant, sub.amount);
+
         sub.last_charged = now;
 
         env.storage().persistent().set(&key, &sub);
@@ -160,6 +186,8 @@ impl FlowPay {
         assert!(sub.active, "subscription is not active");
         assert!(!sub.paused, "subscription is paused");
 
+        spending_limit::enforce_limit(&env, &user, amount);
+
         let token = token::Client::new(&env, &sub.token);
 
         token.transfer_from(
@@ -168,6 +196,9 @@ impl FlowPay {
             &sub.merchant,
             &amount,
         );
+
+        merchant_stats::increment_revenue(&env, &sub.merchant, amount);
+        spending_limit::record_spend(&env, &user, amount);
 
         events::publish_pay_per_use(&env, &user, &sub.merchant, amount);
     }
@@ -187,6 +218,7 @@ impl FlowPay {
 
         env.storage().persistent().set(&key, &sub);
 
+        subscription_count::decrement(&env);
         events::publish_cancelled(&env, &user);
     }
 
@@ -287,5 +319,49 @@ impl FlowPay {
     pub fn set_fee(env: Env, collector: Address, bps: u32) {
         admin::require_admin(&env);
         fee::set_fee(&env, collector, bps);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Batch charge
+    // ─────────────────────────────────────────────────────────────
+
+    /// Charges multiple subscribers in a single transaction.
+    ///
+    /// Each user is processed independently — individual failures (inactive,
+    /// paused, interval not elapsed, etc.) are recorded as a `ChargeResult`
+    /// variant and do **not** abort the batch.
+    pub fn batch_charge(env: Env, users: Vec<Address>) -> Vec<ChargeResult> {
+        batch::batch_charge(&env, users)
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Subscription count
+    // ─────────────────────────────────────────────────────────────
+
+    /// Returns the current number of active subscriptions.
+    pub fn get_active_count(env: Env) -> u64 {
+        subscription_count::get_active_count(&env)
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Merchant revenue
+    // ─────────────────────────────────────────────────────────────
+
+    /// Returns the total amount charged to a merchant's subscribers
+    /// (sum of all successful `charge()` and `pay_per_use()` calls).
+    pub fn get_merchant_revenue(env: Env, merchant: Address) -> i128 {
+        merchant_stats::get_merchant_revenue(&env, &merchant)
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Daily spending limits
+    // ─────────────────────────────────────────────────────────────
+
+    /// Sets a daily spending cap for `pay_per_use()` for the calling user.
+    /// Stored in temporary storage; resets automatically after ~1 day.
+    pub fn set_daily_limit(env: Env, user: Address, limit: i128) {
+        user.require_auth();
+        assert!(limit > 0, "limit must be positive");
+        spending_limit::set_daily_limit(&env, &user, limit);
     }
 }

--- a/contract/src/merchant_stats.rs
+++ b/contract/src/merchant_stats.rs
@@ -1,0 +1,19 @@
+use soroban_sdk::{Address, Env};
+
+use crate::DataKey;
+
+/// Returns the total revenue accumulated for a merchant.
+pub fn get_merchant_revenue(env: &Env, merchant: &Address) -> i128 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::MerchantRevenue(merchant.clone()))
+        .unwrap_or(0i128)
+}
+
+/// Adds `amount` to the merchant's running revenue total.
+pub fn increment_revenue(env: &Env, merchant: &Address, amount: i128) {
+    let current = get_merchant_revenue(env, merchant);
+    env.storage()
+        .persistent()
+        .set(&DataKey::MerchantRevenue(merchant.clone()), &(current + amount));
+}

--- a/contract/src/spending_limit.rs
+++ b/contract/src/spending_limit.rs
@@ -1,0 +1,55 @@
+use soroban_sdk::{Address, Env};
+
+use crate::DataKey;
+
+/// Approximate number of ledgers in one day.
+/// Stellar closes ~1 ledger every 5 seconds → 17,280 ledgers/day.
+const LEDGERS_PER_DAY: u32 = 17_280;
+
+/// Returns the daily spending limit for a user, or `None` if not set.
+pub fn get_daily_limit(env: &Env, user: &Address) -> Option<i128> {
+    env.storage()
+        .temporary()
+        .get(&DataKey::DailyLimit(user.clone()))
+}
+
+/// Sets (or overwrites) the daily spending limit for a user.
+/// The entry lives in temporary storage with a TTL of ~1 day.
+pub fn set_daily_limit(env: &Env, user: &Address, limit: i128) {
+    let key = DataKey::DailyLimit(user.clone());
+    env.storage().temporary().set(&key, &limit);
+    env.storage()
+        .temporary()
+        .extend_ttl(&key, LEDGERS_PER_DAY, LEDGERS_PER_DAY);
+}
+
+/// Returns how much the user has spent today, defaulting to 0.
+pub fn get_daily_spent(env: &Env, user: &Address) -> i128 {
+    env.storage()
+        .temporary()
+        .get(&DataKey::DailySpent(user.clone()))
+        .unwrap_or(0i128)
+}
+
+/// Records `amount` as spent today for the user.
+/// Resets the TTL so the window stays anchored to the first spend of the day.
+pub fn record_spend(env: &Env, user: &Address, amount: i128) {
+    let key = DataKey::DailySpent(user.clone());
+    let spent = get_daily_spent(env, user);
+    env.storage().temporary().set(&key, &(spent + amount));
+    env.storage()
+        .temporary()
+        .extend_ttl(&key, LEDGERS_PER_DAY, LEDGERS_PER_DAY);
+}
+
+/// Checks whether `amount` would exceed the user's daily limit.
+/// Panics if the limit would be exceeded.
+pub fn enforce_limit(env: &Env, user: &Address, amount: i128) {
+    if let Some(limit) = get_daily_limit(env, user) {
+        let spent = get_daily_spent(env, user);
+        assert!(
+            spent + amount <= limit,
+            "daily spending limit exceeded"
+        );
+    }
+}

--- a/contract/src/storage.rs
+++ b/contract/src/storage.rs
@@ -17,3 +17,14 @@ pub fn get_subscription(env: &Env, user: &Address) -> Option<Subscription> {
 pub fn set_token(env: &Env, token: &Address) {
     env.storage().instance().set(&DataKey::Token, token);
 }
+
+pub fn get_admin(env: &Env) -> Address {
+    env.storage()
+        .instance()
+        .get(&DataKey::Admin)
+        .expect("admin not set")
+}
+
+pub fn set_admin(env: &Env, admin: &Address) {
+    env.storage().instance().set(&DataKey::Admin, admin);
+}

--- a/contract/src/subscription_count.rs
+++ b/contract/src/subscription_count.rs
@@ -1,0 +1,29 @@
+use soroban_sdk::Env;
+
+use crate::DataKey;
+
+/// Returns the current number of active subscriptions.
+pub fn get_active_count(env: &Env) -> u64 {
+    env.storage()
+        .instance()
+        .get(&DataKey::ActiveCount)
+        .unwrap_or(0u64)
+}
+
+/// Increments the active subscription counter by 1.
+pub fn increment(env: &Env) {
+    let count = get_active_count(env);
+    env.storage()
+        .instance()
+        .set(&DataKey::ActiveCount, &(count + 1));
+}
+
+/// Decrements the active subscription counter by 1 (floor 0).
+pub fn decrement(env: &Env) {
+    let count = get_active_count(env);
+    if count > 0 {
+        env.storage()
+            .instance()
+            .set(&DataKey::ActiveCount, &(count - 1));
+    }
+}

--- a/contract/src/test.rs
+++ b/contract/src/test.rs
@@ -92,7 +92,7 @@ fn test_charge_too_early() {
     let (env, contract_id, token_addr, user, merchant) = setup();
     let client = FlowPayClient::new(&env, &contract_id);
 
-    client.subscribe(&user, &merchant, &1_0000000, &86400, &token_addr);
+    client.subscribe(&user, &merchant, &1_0000000, &86400, &token_addr, &None);
     client.charge(&user);
 }
 
@@ -111,8 +111,8 @@ fn test_multi_token_independent_subscriptions() {
     let amount: i128 = 1_0000000;
     let interval: u64 = 86400;
 
-    client.subscribe(&user_a, &merchant, &amount, &interval, &token_a);
-    client.subscribe(&user_b, &merchant, &amount, &interval, &token_b);
+    client.subscribe(&user_a, &merchant, &amount, &interval, &token_a, &None);
+    client.subscribe(&user_b, &merchant, &amount, &interval, &token_b, &None);
 
     let sub_a = client.get_subscription(&user_a).unwrap();
     let sub_b = client.get_subscription(&user_b).unwrap();
@@ -136,8 +136,8 @@ fn test_user_can_switch_token() {
     let token_b = setup_second_token(&env, &contract_id, &user);
     let interval: u64 = 86400;
 
-    client.subscribe(&user, &merchant, &1_0000000, &interval, &token_a);
-    client.subscribe(&user, &merchant, &2_0000000, &interval, &token_b);
+    client.subscribe(&user, &merchant, &1_0000000, &interval, &token_a, &None);
+    client.subscribe(&user, &merchant, &2_0000000, &interval, &token_b, &None);
 
     let sub = client.get_subscription(&user).unwrap();
     assert_eq!(sub.token, token_b);
@@ -174,7 +174,13 @@ fn test_pay_per_use_inactive() {
 // Edge cases
 // ─────────────────────────────────────────────
 
-    client.subscribe(&user, &merchant, &1_0000000, &86400, &token_addr);
+#[test]
+#[should_panic(expected = "amount must be positive")]
+fn test_pay_per_use_zero_amount() {
+    let (env, contract_id, token_addr, user, merchant) = setup();
+    let client = FlowPayClient::new(&env, &contract_id);
+
+    client.subscribe(&user, &merchant, &1_0000000, &86400, &token_addr, &None);
     client.pay_per_use(&user, &0);
 }
 
@@ -200,6 +206,12 @@ fn test_initialize_backward_compat() {
 #[test]
 #[should_panic(expected = "no subscription found")]
 fn test_cancel_nonexistent() {
+    let (env, contract_id, _token_addr, _user, _merchant) = setup();
+    let client = FlowPayClient::new(&env, &contract_id);
+    let random = Address::generate(&env);
+    client.cancel(&random);
+}
+
 // ── Issue #13: get_subscription for nonexistent subscription ─────────────────
 
 /// get_subscription() must return None for an address with no subscription.
@@ -209,8 +221,8 @@ fn test_get_subscription_nonexistent() {
     let client = FlowPayClient::new(&env, &contract_id);
     
     let random = Address::generate(&env);
-    client.cancel(&random);
     assert!(client.get_subscription(&random).is_none(), "get_subscription should return None for unknown address");
+}
 // ── Issue #12: last_charged timestamp update ─────────────────────────────────
 
 /// charge() must update last_charged to the current ledger timestamp.
@@ -249,7 +261,7 @@ fn test_zero_amount() {
     let (env, contract_id, token_addr, user, merchant) = setup();
     let client = FlowPayClient::new(&env, &contract_id);
 
-    client.subscribe(&user, &merchant, &0, &86400, &token_addr);
+    client.subscribe(&user, &merchant, &0, &86400, &token_addr, &None);
 }
 
 #[test]
@@ -258,7 +270,7 @@ fn test_zero_interval() {
     let (env, contract_id, token_addr, user, merchant) = setup();
     let client = FlowPayClient::new(&env, &contract_id);
 
-    client.subscribe(&user, &merchant, &1_0000000, &0, &token_addr);
+    client.subscribe(&user, &merchant, &1_0000000, &0, &token_addr, &None);
 }
 
 // ─────────────────────────────────────────────
@@ -283,8 +295,8 @@ fn test_multiple_users() {
     let amount_b: i128 = 2_0000000;
     let interval: u64 = 86400;
 
-    client.subscribe(&user_a, &merchant_a, &amount_a, &interval, &token_addr);
-    client.subscribe(&user_b, &merchant_b, &amount_b, &interval, &token_addr);
+    client.subscribe(&user_a, &merchant_a, &amount_a, &interval, &token_addr, &None);
+    client.subscribe(&user_b, &merchant_b, &amount_b, &interval, &token_addr, &None);
 
     env.ledger().with_mut(|l| {
         l.timestamp += interval + 1;
@@ -303,7 +315,7 @@ fn test_charge_after_cancel() {
     let (env, contract_id, token_addr, user, merchant) = setup();
     let client = FlowPayClient::new(&env, &contract_id);
 
-    client.subscribe(&user, &merchant, &1_0000000, &86400, &token_addr);
+    client.subscribe(&user, &merchant, &1_0000000, &86400, &token_addr, &None);
     client.cancel(&user);
 
     env.ledger().with_mut(|l| {
@@ -311,4 +323,212 @@ fn test_charge_after_cancel() {
     });
 
     client.charge(&user);
+}
+
+// ─────────────────────────────────────────────
+// batch_charge tests
+// ─────────────────────────────────────────────
+
+#[test]
+fn test_batch_charge_charged_and_skipped() {
+    let (env, contract_id, token_addr, user_a, merchant) = setup();
+    let client = FlowPayClient::new(&env, &contract_id);
+
+    let user_b = Address::generate(&env);
+    let sac = StellarAssetClient::new(&env, &token_addr);
+    sac.mint(&user_b, &10_000_0000000);
+    let token = TokenClient::new(&env, &token_addr);
+    token.approve(&user_b, &contract_id, &10_000_0000000, &200);
+
+    let interval: u64 = 86400;
+    client.subscribe(&user_a, &merchant, &1_0000000, &interval, &token_addr, &None);
+    client.subscribe(&user_b, &merchant, &1_0000000, &interval, &token_addr, &None);
+
+    // Only advance past interval for user_a
+    env.ledger().with_mut(|l| { l.timestamp += interval + 1; });
+
+    // user_b re-subscribes at the new timestamp so their interval hasn't elapsed
+    client.subscribe(&user_b, &merchant, &1_0000000, &interval, &token_addr, &None);
+
+    let mut users = soroban_sdk::Vec::new(&env);
+    users.push_back(user_a.clone());
+    users.push_back(user_b.clone());
+
+    let results = client.batch_charge(&users);
+    assert_eq!(results.get(0).unwrap(), crate::ChargeResult::Charged);
+    assert_eq!(results.get(1).unwrap(), crate::ChargeResult::Skipped);
+}
+
+#[test]
+fn test_batch_charge_no_subscription() {
+    let (env, contract_id, _token_addr, _user, _merchant) = setup();
+    let client = FlowPayClient::new(&env, &contract_id);
+
+    let unknown = Address::generate(&env);
+    let mut users = soroban_sdk::Vec::new(&env);
+    users.push_back(unknown);
+
+    let results = client.batch_charge(&users);
+    assert_eq!(results.get(0).unwrap(), crate::ChargeResult::NoSubscription);
+}
+
+#[test]
+fn test_batch_charge_inactive() {
+    let (env, contract_id, token_addr, user, merchant) = setup();
+    let client = FlowPayClient::new(&env, &contract_id);
+
+    let interval: u64 = 86400;
+    client.subscribe(&user, &merchant, &1_0000000, &interval, &token_addr, &None);
+    client.cancel(&user);
+
+    env.ledger().with_mut(|l| { l.timestamp += interval + 1; });
+
+    let mut users = soroban_sdk::Vec::new(&env);
+    users.push_back(user.clone());
+
+    let results = client.batch_charge(&users);
+    assert_eq!(results.get(0).unwrap(), crate::ChargeResult::Inactive);
+}
+
+// ─────────────────────────────────────────────
+// subscription_count tests
+// ─────────────────────────────────────────────
+
+#[test]
+fn test_active_count_increments_on_subscribe() {
+    let (env, contract_id, token_addr, user, merchant) = setup();
+    let client = FlowPayClient::new(&env, &contract_id);
+
+    assert_eq!(client.get_active_count(), 0);
+    client.subscribe(&user, &merchant, &1_0000000, &86400, &token_addr, &None);
+    assert_eq!(client.get_active_count(), 1);
+}
+
+#[test]
+fn test_active_count_decrements_on_cancel() {
+    let (env, contract_id, token_addr, user, merchant) = setup();
+    let client = FlowPayClient::new(&env, &contract_id);
+
+    client.subscribe(&user, &merchant, &1_0000000, &86400, &token_addr, &None);
+    assert_eq!(client.get_active_count(), 1);
+    client.cancel(&user);
+    assert_eq!(client.get_active_count(), 0);
+}
+
+#[test]
+fn test_active_count_multiple_users() {
+    let (env, contract_id, token_addr, user_a, merchant) = setup();
+    let client = FlowPayClient::new(&env, &contract_id);
+
+    let user_b = Address::generate(&env);
+    let sac = StellarAssetClient::new(&env, &token_addr);
+    sac.mint(&user_b, &10_000_0000000);
+    let token = TokenClient::new(&env, &token_addr);
+    token.approve(&user_b, &contract_id, &10_000_0000000, &200);
+
+    client.subscribe(&user_a, &merchant, &1_0000000, &86400, &token_addr, &None);
+    client.subscribe(&user_b, &merchant, &1_0000000, &86400, &token_addr, &None);
+    assert_eq!(client.get_active_count(), 2);
+
+    client.cancel(&user_a);
+    assert_eq!(client.get_active_count(), 1);
+}
+
+// ─────────────────────────────────────────────
+// merchant_stats tests
+// ─────────────────────────────────────────────
+
+#[test]
+fn test_merchant_revenue_from_charge() {
+    let (env, contract_id, token_addr, user, merchant) = setup();
+    let client = FlowPayClient::new(&env, &contract_id);
+
+    let amount: i128 = 5_0000000;
+    let interval: u64 = 86400;
+    client.subscribe(&user, &merchant, &amount, &interval, &token_addr, &None);
+
+    assert_eq!(client.get_merchant_revenue(&merchant), 0);
+
+    env.ledger().with_mut(|l| { l.timestamp += interval + 1; });
+    client.charge(&user);
+
+    assert_eq!(client.get_merchant_revenue(&merchant), amount);
+}
+
+#[test]
+fn test_merchant_revenue_from_pay_per_use() {
+    let (env, contract_id, token_addr, user, merchant) = setup();
+    let client = FlowPayClient::new(&env, &contract_id);
+
+    client.subscribe(&user, &merchant, &1_0000000, &86400, &token_addr, &None);
+    client.pay_per_use(&user, &3_0000000);
+
+    assert_eq!(client.get_merchant_revenue(&merchant), 3_0000000);
+}
+
+#[test]
+fn test_merchant_revenue_accumulates() {
+    let (env, contract_id, token_addr, user, merchant) = setup();
+    let client = FlowPayClient::new(&env, &contract_id);
+
+    let amount: i128 = 2_0000000;
+    let interval: u64 = 86400;
+    client.subscribe(&user, &merchant, &amount, &interval, &token_addr, &None);
+
+    env.ledger().with_mut(|l| { l.timestamp += interval + 1; });
+    client.charge(&user);
+
+    client.pay_per_use(&user, &1_0000000);
+
+    assert_eq!(client.get_merchant_revenue(&merchant), 3_0000000);
+}
+
+// ─────────────────────────────────────────────
+// spending_limit tests
+// ─────────────────────────────────────────────
+
+#[test]
+fn test_daily_limit_allows_spend_within_limit() {
+    let (env, contract_id, token_addr, user, merchant) = setup();
+    let client = FlowPayClient::new(&env, &contract_id);
+
+    client.subscribe(&user, &merchant, &1_0000000, &86400, &token_addr, &None);
+    client.set_daily_limit(&user, &10_0000000);
+    // Should not panic
+    client.pay_per_use(&user, &5_0000000);
+}
+
+#[test]
+#[should_panic(expected = "daily spending limit exceeded")]
+fn test_daily_limit_blocks_overspend() {
+    let (env, contract_id, token_addr, user, merchant) = setup();
+    let client = FlowPayClient::new(&env, &contract_id);
+
+    client.subscribe(&user, &merchant, &1_0000000, &86400, &token_addr, &None);
+    client.set_daily_limit(&user, &3_0000000);
+    client.pay_per_use(&user, &5_0000000);
+}
+
+#[test]
+fn test_daily_limit_accumulates_across_calls() {
+    let (env, contract_id, token_addr, user, merchant) = setup();
+    let client = FlowPayClient::new(&env, &contract_id);
+
+    client.subscribe(&user, &merchant, &1_0000000, &86400, &token_addr, &None);
+    client.set_daily_limit(&user, &5_0000000);
+    client.pay_per_use(&user, &2_0000000);
+    client.pay_per_use(&user, &2_0000000);
+    // 4 total, limit is 5 — should pass
+}
+
+#[test]
+#[should_panic(expected = "daily spending limit exceeded")]
+fn test_daily_limit_blocks_cumulative_overspend() {
+    let (env, contract_id, token_addr, user, merchant) = setup();
+    let client = FlowPayClient::new(&env, &contract_id);
+
+    client.subscribe(&user, &merchant, &1_0000000, &86400, &token_addr, &None);
+    client.set_daily_limit(&user, &5_0000000);
+    client.pay_per_use(&user, &3_0000000);
+    client.pay_per_use(&user, &3_0000000); // 6 total > 5 limit
 }

--- a/docs/API.md
+++ b/docs/API.md
@@ -28,13 +28,17 @@ Internal storage keys. Not part of the public API but useful for understanding s
 
 ```rust
 pub enum DataKey {
-    Subscription(Address),  // persistent — one entry per subscriber
-    Token,                  // instance — the token contract address
-    GracePeriod,            // instance — seconds allowed for charge window
+    Subscription(Address),      // persistent — one entry per subscriber
+    Token,                      // instance — the token contract address
+    GracePeriod,                // instance — seconds allowed for charge window
     MerchantWhitelist(Address), // persistent — true if merchant is whitelisted
-    WhitelistEnabled,       // instance — true if whitelist is active
-    FeeCollector,           // instance — fee collector address
-    FeeBps,                 // instance — protocol fee in basis points
+    WhitelistEnabled,           // instance — true if whitelist is active
+    FeeCollector,               // instance — fee collector address
+    FeeBps,                     // instance — protocol fee in basis points
+    ActiveCount,                // instance — running total of active subscriptions
+    MerchantRevenue(Address),   // persistent — cumulative revenue per merchant
+    DailyLimit(Address),        // temporary — user-set daily pay_per_use cap
+    DailySpent(Address),        // temporary — amount spent today via pay_per_use
 }
 ```
 
@@ -440,6 +444,151 @@ soroban contract invoke \
   --network testnet \
   -- next_charge_at \
   --user <USER_ADDRESS>
+```
+
+---
+
+### `batch_charge`
+
+Charges multiple subscribers in a single transaction. Individual failures do not abort the batch — every address is processed and its outcome is returned.
+
+```
+batch_charge(env: Env, users: Vec<Address>) -> Vec<ChargeResult>
+```
+
+**Parameters**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `users` | `Vec<Address>` | List of subscriber addresses to attempt charging. |
+
+**Auth:** None. Same permissionless model as `charge()`.
+
+**Returns:** `Vec<ChargeResult>` — one entry per input address, in order.
+
+```rust
+pub enum ChargeResult {
+    Charged,            // funds transferred successfully
+    Skipped,            // interval has not elapsed yet
+    NoSubscription,     // no subscription found for this address
+    Inactive,           // subscription is cancelled
+    Paused,             // subscription is paused
+    GracePeriodElapsed, // charge window has closed
+}
+```
+
+**Storage written:** `DataKey::Subscription(user)` updated for each `Charged` result. `DataKey::MerchantRevenue(merchant)` incremented for each `Charged` result.
+
+**Events emitted:** `("charged", user)` for each successfully charged user.
+
+**CLI example**
+
+```bash
+soroban contract invoke \
+  --id <CONTRACT_ID> \
+  --source <KEEPER_KEY> \
+  --network testnet \
+  -- batch_charge \
+  --users '["<USER_A>","<USER_B>","<USER_C>"]'
+```
+
+---
+
+### `get_active_count`
+
+Returns the current number of active subscriptions. Incremented by `subscribe()`, decremented by `cancel()`.
+
+```
+get_active_count(env: Env) -> u64
+```
+
+**Auth:** None.
+
+**Returns:** `u64` — total active subscriptions.
+
+**Storage read:** `DataKey::ActiveCount` in instance storage.
+
+**CLI example**
+
+```bash
+soroban contract invoke \
+  --id <CONTRACT_ID> \
+  --network testnet \
+  -- get_active_count
+```
+
+---
+
+### `get_merchant_revenue`
+
+Returns the cumulative amount charged to a merchant's subscribers across all `charge()` and `pay_per_use()` calls.
+
+```
+get_merchant_revenue(env: Env, merchant: Address) -> i128
+```
+
+**Parameters**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `merchant` | `Address` | The merchant address to query. |
+
+**Auth:** None.
+
+**Returns:** `i128` — total stroops received by this merchant. Returns `0` if no charges have occurred.
+
+**Storage read:** `DataKey::MerchantRevenue(merchant)` in persistent storage.
+
+**CLI example**
+
+```bash
+soroban contract invoke \
+  --id <CONTRACT_ID> \
+  --network testnet \
+  -- get_merchant_revenue \
+  --merchant <MERCHANT_ADDRESS>
+```
+
+---
+
+### `set_daily_limit`
+
+Sets a daily spending cap for `pay_per_use()` for the calling user. The limit is stored in temporary storage and resets automatically after approximately one day (~17,280 ledgers at 5 s/ledger).
+
+```
+set_daily_limit(env: Env, user: Address, limit: i128)
+```
+
+**Parameters**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `user` | `Address` | The subscriber. Must match the transaction signer. |
+| `limit` | `i128` | Maximum stroops spendable via `pay_per_use()` per day. Must be > 0. |
+
+**Auth:** `user.require_auth()`.
+
+**Storage written:** `DataKey::DailyLimit(user)` in temporary storage with TTL of ~1 day.
+
+**Enforcement:** Every `pay_per_use()` call checks `DailySpent(user) + amount <= DailyLimit(user)` before transferring. The running total is tracked in `DataKey::DailySpent(user)` (also temporary, same TTL).
+
+**Errors**
+
+| Condition | Panic message |
+| --- | --- |
+| `limit <= 0` | `"limit must be positive"` |
+| Spend would exceed limit | `"daily spending limit exceeded"` |
+
+**CLI example**
+
+```bash
+soroban contract invoke \
+  --id <CONTRACT_ID> \
+  --source <USER_KEY> \
+  --network testnet \
+  -- set_daily_limit \
+  --user <USER_ADDRESS> \
+  --limit 50000000
 ```
 
 ---

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -57,11 +57,15 @@ There is no centralised backend. The only off-chain component required is a **ke
 | Function | Mutates State | Auth | Description |
 | --- | --- | --- | --- |
 | `initialize(token)` | Yes | None | One-time setup. Stores the token contract address. Panics if called again. |
-| `subscribe(user, merchant, amount, interval)` | Yes | `user` | Creates or overwrites a subscription for the caller. |
-| `charge(user)` | Yes | None | Permissionless. Transfers funds if the interval has elapsed. |
-| `pay_per_use(user, amount)` | No (token state only) | `user` | Instant transfer of any amount against an active subscription. |
-| `cancel(user)` | Yes | `user` | Sets `active = false`. Prevents future charges. |
+| `subscribe(user, merchant, amount, interval)` | Yes | `user` | Creates or overwrites a subscription for the caller. Increments `ActiveCount`. |
+| `charge(user)` | Yes | None | Permissionless. Transfers funds if the interval has elapsed. Tracks merchant revenue. |
+| `batch_charge(users)` | Yes | None | Permissionless. Charges multiple users in one transaction; skips ineligible users. |
+| `pay_per_use(user, amount)` | No (token state only) | `user` | Instant transfer against an active subscription. Enforces daily limit if set. Tracks merchant revenue. |
+| `cancel(user)` | Yes | `user` | Sets `active = false`. Decrements `ActiveCount`. |
 | `get_subscription(user)` | No | None | Read-only view. Returns `Option<Subscription>`. |
+| `get_active_count()` | No | None | Returns the running total of active subscriptions. |
+| `get_merchant_revenue(merchant)` | No | None | Returns cumulative revenue for a merchant address. |
+| `set_daily_limit(user, limit)` | Yes | `user` | Sets a daily spending cap for `pay_per_use()`. Stored in temporary storage. |
 
 ### Why `charge()` has no auth
 
@@ -93,8 +97,12 @@ pub struct Subscription {
 
 ```rust
 pub enum DataKey {
-    Subscription(Address),  // keyed by subscriber address
-    Token,                  // the token contract address (set at init)
+    Subscription(Address),      // keyed by subscriber address
+    Token,                      // the token contract address (set at init)
+    ActiveCount,                // running total of active subscriptions
+    MerchantRevenue(Address),   // cumulative revenue per merchant
+    DailyLimit(Address),        // user-set daily pay_per_use cap (temporary)
+    DailySpent(Address),        // amount spent today via pay_per_use (temporary)
 }
 ```
 
@@ -102,13 +110,13 @@ pub enum DataKey {
 
 ## Storage Strategy
 
-Soroban has three storage tiers. FlowPay uses two of them deliberately:
+Soroban has three storage tiers. FlowPay uses all three:
 
 | Tier | Used For | Why |
 | --- | --- | --- |
-| `instance` | `DataKey::Token` | The token address is contract-wide config. It's always needed and should never expire. Instance storage is tied to the contract's own TTL. |
-| `persistent` | `DataKey::Subscription(user)` | Subscription records must survive indefinitely until explicitly cancelled. Persistent storage has its own TTL that can be extended. |
-| `temporary` | Not used (yet) | Suitable for ephemeral data like daily spending limits — a future feature. |
+| `instance` | `DataKey::Token`, `DataKey::ActiveCount` | Contract-wide config and counters. Always needed, tied to the contract's own TTL. |
+| `persistent` | `DataKey::Subscription(user)`, `DataKey::MerchantRevenue(merchant)` | Records that must survive indefinitely. Persistent storage has its own TTL that can be extended. |
+| `temporary` | `DataKey::DailyLimit(user)`, `DataKey::DailySpent(user)` | Ephemeral per-user data. Daily spending limits and the running daily spend counter are stored here with a TTL of ~1 day (17,280 ledgers). They expire automatically — no cleanup needed. |
 
 **TTL note:** Persistent storage entries have a TTL on Stellar. In production, a keeper or the frontend should call `extend_ttl` on active subscriptions to prevent them from being evicted by the network. This is a planned improvement.
 
@@ -165,8 +173,10 @@ Because Soroban has no native scheduler, recurring charges require an external t
 
 1. Maintains a list of subscriber addresses (from contract events or a database)
 2. Runs on a schedule (cron, Lambda, etc.)
-3. Calls `charge(user)` for each subscriber whose interval has elapsed
+3. Calls `batch_charge(users)` with a batch of subscribers whose intervals have elapsed
 
-The contract itself enforces the interval — if the keeper calls too early, the transaction simply fails. There is no risk of double-charging.
+`batch_charge` processes each user independently — ineligible users (interval not elapsed, paused, cancelled) are skipped and recorded as `Skipped`/`Inactive`/`Paused` in the result vector without aborting the transaction. This is more efficient than individual `charge()` calls when managing many subscribers.
+
+The contract itself enforces the interval — if the keeper calls too early, the user is simply skipped. There is no risk of double-charging.
 
 See [DEPLOYMENT.md](DEPLOYMENT.md) for a reference keeper implementation.


### PR DESCRIPTION
Add snapshot for merchant revenue from pay-per-use contract interactions

- Introduced a new JSON snapshot capturing the sequence of contract function calls related to merchant revenue.
- Included actions such as setting admin, minting tokens, approving allowances, subscribing to services, and processing pay-per-use transactions.
- Documented the ledger state, including balances and contract data for involved addresses.
- Captured events for each function call, detailing diagnostics and contract interactions.

Closes: #93
Closes: #94
Closes: #95
Closes: #92