### PR TITLE
feat: add referral tracking, state migration, subscription metadata, …

### DIFF
--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -7,16 +7,20 @@ mod events;
 mod fee;
 mod grace;
 mod merchant_stats;
+mod migration;
+mod referral;
 mod spending_limit;
 mod storage;
 mod subscription_count;
+mod subscription_history;
+mod subscription_metadata;
 mod test;
 mod trial;
 mod validation;
 mod whitelist;
 
 use crate::errors::ContractError;
-use soroban_sdk::{contract, contractimpl, contracttype, token, Address, Env, Symbol, Vec};
+use soroban_sdk::{contract, contractimpl, contracttype, token, Address, Env, String, Symbol, Vec};
 
 pub use batch::ChargeResult;
 
@@ -46,6 +50,14 @@ pub enum DataKey {
     // Feature: daily spending limits (temporary storage)
     DailyLimit(Address),
     DailySpent(Address),
+    // Feature: referral tracking
+    Referral(Address),
+    // Feature: state migration
+    SchemaVersion,
+    // Feature: subscription metadata labels
+    SubscriptionMeta(Address),
+    // Feature: charge history
+    ChargeHistory(Address),
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -89,6 +101,7 @@ impl FlowPay {
         interval: u64,
         token: Address,
         trial_period: Option<u64>,
+        referrer: Option<Address>,
     ) {
         user.require_auth();
 
@@ -126,6 +139,7 @@ impl FlowPay {
             .set(&DataKey::Subscription(user.clone()), &sub);
 
         subscription_count::increment(&env);
+        referral::store_referral(&env, &user, &referrer);
         events::publish_subscribed(&env, &user, &sub);
     }
 
@@ -167,6 +181,7 @@ impl FlowPay {
 
         env.storage().persistent().set(&key, &sub);
 
+        subscription_history::record_charge(&env, &user, now);
         events::publish_charged(&env, &user, &sub, now);
     }
 
@@ -363,5 +378,54 @@ impl FlowPay {
         user.require_auth();
         assert!(limit > 0, "limit must be positive");
         spending_limit::set_daily_limit(&env, &user, limit);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Referral tracking
+    // ─────────────────────────────────────────────────────────────
+
+    /// Returns the referrer address for a given subscriber, or `None`.
+    pub fn get_referrer(env: Env, user: Address) -> Option<Address> {
+        referral::get_referrer(&env, &user)
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // State migration
+    // ─────────────────────────────────────────────────────────────
+
+    /// Migrates contract storage to the latest schema version.
+    /// Safe to call multiple times — subsequent calls are no-ops.
+    pub fn migrate(env: Env) {
+        migration::migrate(&env);
+    }
+
+    /// Returns the current storage schema version.
+    pub fn get_schema_version(env: Env) -> u32 {
+        migration::get_schema_version(&env)
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Subscription metadata
+    // ─────────────────────────────────────────────────────────────
+
+    /// Attaches a short label (e.g. plan name) to the caller's subscription.
+    pub fn set_metadata(env: Env, user: Address, label: String) {
+        user.require_auth();
+        subscription_metadata::set_metadata(&env, &user, label);
+    }
+
+    /// Returns the metadata label for a subscriber, or `None` if not set.
+    pub fn get_metadata(env: Env, user: Address) -> Option<String> {
+        subscription_metadata::get_metadata(&env, &user)
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Charge history
+    // ─────────────────────────────────────────────────────────────
+
+    /// Returns the last (up to 12) charge timestamps for a subscriber,
+    /// ordered oldest → newest.
+    pub fn get_charge_history(env: Env, user: Address) -> Vec<u64> {
+        subscription_history::get_charge_history(&env, &user)
     }
 }

--- a/contract/src/migration.rs
+++ b/contract/src/migration.rs
@@ -1,0 +1,39 @@
+use soroban_sdk::Env;
+
+use crate::DataKey;
+
+/// Current storage schema version.
+pub const CURRENT_VERSION: u32 = 2;
+
+/// Returns the stored schema version, defaulting to 1 (pre-versioning).
+pub fn get_schema_version(env: &Env) -> u32 {
+    env.storage()
+        .instance()
+        .get(&DataKey::SchemaVersion)
+        .unwrap_or(1u32)
+}
+
+/// Writes the current schema version to instance storage.
+fn set_schema_version(env: &Env, version: u32) {
+    env.storage()
+        .instance()
+        .set(&DataKey::SchemaVersion, &version);
+}
+
+/// Migrates contract storage from v1 to v2.
+///
+/// v1 → v2: Introduces `SchemaVersion` tracking. No data shape changes;
+/// this migration simply stamps the version so future upgrades have a
+/// reliable baseline to branch from.
+///
+/// Safe to call multiple times — subsequent calls are no-ops.
+pub fn migrate(env: &Env) {
+    let version = get_schema_version(env);
+
+    if version < 2 {
+        // v1 → v2: stamp the schema version
+        set_schema_version(env, 2);
+    }
+
+    // Future migrations: add `if version < 3 { ... }` blocks here.
+}

--- a/contract/src/referral.rs
+++ b/contract/src/referral.rs
@@ -1,0 +1,22 @@
+use soroban_sdk::{Address, Env, Symbol};
+
+use crate::DataKey;
+
+/// Returns the referrer for a given subscriber, if one was recorded.
+pub fn get_referrer(env: &Env, user: &Address) -> Option<Address> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Referral(user.clone()))
+}
+
+/// Stores the referrer for a subscriber. No-op if referrer is None.
+pub fn store_referral(env: &Env, user: &Address, referrer: &Option<Address>) {
+    if let Some(ref r) = referrer {
+        env.storage()
+            .persistent()
+            .set(&DataKey::Referral(user.clone()), r);
+
+        env.events()
+            .publish((Symbol::new(env, "referred"), user.clone()), r.clone());
+    }
+}

--- a/contract/src/subscription_history.rs
+++ b/contract/src/subscription_history.rs
@@ -1,0 +1,35 @@
+use soroban_sdk::{Address, Env, Vec};
+
+use crate::DataKey;
+
+/// Maximum number of charge timestamps retained per subscriber.
+const MAX_HISTORY: u32 = 12;
+
+/// Returns the stored charge timestamps for a subscriber (oldest → newest).
+pub fn get_charge_history(env: &Env, user: &Address) -> Vec<u64> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::ChargeHistory(user.clone()))
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+/// Appends `timestamp` to the subscriber's charge history.
+/// Drops the oldest entry when the buffer exceeds `MAX_HISTORY`.
+pub fn record_charge(env: &Env, user: &Address, timestamp: u64) {
+    let mut history = get_charge_history(env, user);
+
+    if history.len() >= MAX_HISTORY {
+        // Remove the oldest entry (index 0)
+        let mut trimmed: Vec<u64> = Vec::new(env);
+        for i in 1..history.len() {
+            trimmed.push_back(history.get(i).unwrap());
+        }
+        history = trimmed;
+    }
+
+    history.push_back(timestamp);
+
+    env.storage()
+        .persistent()
+        .set(&DataKey::ChargeHistory(user.clone()), &history);
+}

--- a/contract/src/subscription_metadata.rs
+++ b/contract/src/subscription_metadata.rs
@@ -1,0 +1,18 @@
+use soroban_sdk::{Address, Env, String};
+
+use crate::DataKey;
+
+/// Stores a short metadata label for a subscriber (e.g. plan name).
+/// Overwrites any previously stored value.
+pub fn set_metadata(env: &Env, user: &Address, label: String) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::SubscriptionMeta(user.clone()), &label);
+}
+
+/// Returns the metadata label for a subscriber, or `None` if not set.
+pub fn get_metadata(env: &Env, user: &Address) -> Option<String> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::SubscriptionMeta(user.clone()))
+}

--- a/contract/src/test.rs
+++ b/contract/src/test.rs
@@ -57,7 +57,7 @@ fn test_subscribe_and_charge() {
     let amount: i128 = 5_0000000;
     let interval: u64 = 30 * 24 * 60 * 60;
 
-    client.subscribe(&user, &merchant, &amount, &interval, &token_addr, &None);
+    client.subscribe(&user, &merchant, &amount, &interval, &token_addr, &None, &None);
 
     let sub = client.get_subscription(&user).unwrap();
     assert!(sub.active);
@@ -79,7 +79,7 @@ fn test_cancel() {
     let (env, contract_id, token_addr, user, merchant) = setup();
     let client = FlowPayClient::new(&env, &contract_id);
 
-    client.subscribe(&user, &merchant, &1_0000000, &86400, &token_addr, &None);
+    client.subscribe(&user, &merchant, &1_0000000, &86400, &token_addr, &None, &None);
     client.cancel(&user);
 
     let sub = client.get_subscription(&user).unwrap();
@@ -92,7 +92,7 @@ fn test_charge_too_early() {
     let (env, contract_id, token_addr, user, merchant) = setup();
     let client = FlowPayClient::new(&env, &contract_id);
 
-    client.subscribe(&user, &merchant, &1_0000000, &86400, &token_addr, &None);
+    client.subscribe(&user, &merchant, &1_0000000, &86400, &token_addr, &None, &None);
     client.charge(&user);
 }
 
@@ -111,8 +111,8 @@ fn test_multi_token_independent_subscriptions() {
     let amount: i128 = 1_0000000;
     let interval: u64 = 86400;
 
-    client.subscribe(&user_a, &merchant, &amount, &interval, &token_a, &None);
-    client.subscribe(&user_b, &merchant, &amount, &interval, &token_b, &None);
+    client.subscribe(&user_a, &merchant, &amount, &interval, &token_a, &None, &None);
+    client.subscribe(&user_b, &merchant, &amount, &interval, &token_b, &None, &None);
 
     let sub_a = client.get_subscription(&user_a).unwrap();
     let sub_b = client.get_subscription(&user_b).unwrap();
@@ -136,8 +136,8 @@ fn test_user_can_switch_token() {
     let token_b = setup_second_token(&env, &contract_id, &user);
     let interval: u64 = 86400;
 
-    client.subscribe(&user, &merchant, &1_0000000, &interval, &token_a, &None);
-    client.subscribe(&user, &merchant, &2_0000000, &interval, &token_b, &None);
+    client.subscribe(&user, &merchant, &1_0000000, &interval, &token_a, &None, &None);
+    client.subscribe(&user, &merchant, &2_0000000, &interval, &token_b, &None, &None);
 
     let sub = client.get_subscription(&user).unwrap();
     assert_eq!(sub.token, token_b);
@@ -149,7 +149,7 @@ fn test_pay_per_use() {
     let (env, contract_id, token_addr, user, merchant) = setup();
     let client = FlowPayClient::new(&env, &contract_id);
 
-    client.subscribe(&user, &merchant, &1_0000000, &86400, &token_addr, &None);
+    client.subscribe(&user, &merchant, &1_0000000, &86400, &token_addr, &None, &None);
 
     let token = TokenClient::new(&env, &token_addr);
     let before = token.balance(&merchant);
@@ -165,7 +165,7 @@ fn test_pay_per_use_inactive() {
     let (env, contract_id, token_addr, user, merchant) = setup();
     let client = FlowPayClient::new(&env, &contract_id);
 
-    client.subscribe(&user, &merchant, &1_0000000, &86400, &token_addr, &None);
+    client.subscribe(&user, &merchant, &1_0000000, &86400, &token_addr, &None, &None);
     client.cancel(&user);
     client.pay_per_use(&user, &1_0000000);
 }
@@ -180,7 +180,7 @@ fn test_pay_per_use_zero_amount() {
     let (env, contract_id, token_addr, user, merchant) = setup();
     let client = FlowPayClient::new(&env, &contract_id);
 
-    client.subscribe(&user, &merchant, &1_0000000, &86400, &token_addr, &None);
+    client.subscribe(&user, &merchant, &1_0000000, &86400, &token_addr, &None, &None);
     client.pay_per_use(&user, &0);
 }
 
@@ -194,7 +194,7 @@ fn test_initialize_backward_compat() {
     client.initialize(&token_addr);
 
     let token_b = setup_second_token(&env, &contract_id, &user);
-    client.subscribe(&user, &merchant, &1_0000000, &86400, &token_b, &None);
+    client.subscribe(&user, &merchant, &1_0000000, &86400, &token_b, &None, &None);
 
     // Subscription uses token_b, not the initialized default
     assert_eq!(client.get_subscription(&user).unwrap().token, token_b);
@@ -234,7 +234,7 @@ fn test_charge_updates_last_charged() {
     let amount: i128 = 5_0000000;
     let interval: u64 = 30 * 24 * 60 * 60; // 30 days
 
-    client.subscribe(&user, &merchant, &amount, &interval, &token_addr, &None);
+    client.subscribe(&user, &merchant, &amount, &interval, &token_addr, &None, &None);
 
     // Record the timestamp before advancing time
     let subscribe_time = env.ledger().timestamp();
@@ -261,7 +261,7 @@ fn test_zero_amount() {
     let (env, contract_id, token_addr, user, merchant) = setup();
     let client = FlowPayClient::new(&env, &contract_id);
 
-    client.subscribe(&user, &merchant, &0, &86400, &token_addr, &None);
+    client.subscribe(&user, &merchant, &0, &86400, &token_addr, &None, &None);
 }
 
 #[test]
@@ -270,7 +270,7 @@ fn test_zero_interval() {
     let (env, contract_id, token_addr, user, merchant) = setup();
     let client = FlowPayClient::new(&env, &contract_id);
 
-    client.subscribe(&user, &merchant, &1_0000000, &0, &token_addr, &None);
+    client.subscribe(&user, &merchant, &1_0000000, &0, &token_addr, &None, &None);
 }
 
 // ─────────────────────────────────────────────
@@ -295,8 +295,8 @@ fn test_multiple_users() {
     let amount_b: i128 = 2_0000000;
     let interval: u64 = 86400;
 
-    client.subscribe(&user_a, &merchant_a, &amount_a, &interval, &token_addr, &None);
-    client.subscribe(&user_b, &merchant_b, &amount_b, &interval, &token_addr, &None);
+    client.subscribe(&user_a, &merchant_a, &amount_a, &interval, &token_addr, &None, &None);
+    client.subscribe(&user_b, &merchant_b, &amount_b, &interval, &token_addr, &None, &None);
 
     env.ledger().with_mut(|l| {
         l.timestamp += interval + 1;
@@ -315,7 +315,7 @@ fn test_charge_after_cancel() {
     let (env, contract_id, token_addr, user, merchant) = setup();
     let client = FlowPayClient::new(&env, &contract_id);
 
-    client.subscribe(&user, &merchant, &1_0000000, &86400, &token_addr, &None);
+    client.subscribe(&user, &merchant, &1_0000000, &86400, &token_addr, &None, &None);
     client.cancel(&user);
 
     env.ledger().with_mut(|l| {
@@ -341,14 +341,14 @@ fn test_batch_charge_charged_and_skipped() {
     token.approve(&user_b, &contract_id, &10_000_0000000, &200);
 
     let interval: u64 = 86400;
-    client.subscribe(&user_a, &merchant, &1_0000000, &interval, &token_addr, &None);
-    client.subscribe(&user_b, &merchant, &1_0000000, &interval, &token_addr, &None);
+    client.subscribe(&user_a, &merchant, &1_0000000, &interval, &token_addr, &None, &None);
+    client.subscribe(&user_b, &merchant, &1_0000000, &interval, &token_addr, &None, &None);
 
     // Only advance past interval for user_a
     env.ledger().with_mut(|l| { l.timestamp += interval + 1; });
 
     // user_b re-subscribes at the new timestamp so their interval hasn't elapsed
-    client.subscribe(&user_b, &merchant, &1_0000000, &interval, &token_addr, &None);
+    client.subscribe(&user_b, &merchant, &1_0000000, &interval, &token_addr, &None, &None);
 
     let mut users = soroban_sdk::Vec::new(&env);
     users.push_back(user_a.clone());
@@ -378,7 +378,7 @@ fn test_batch_charge_inactive() {
     let client = FlowPayClient::new(&env, &contract_id);
 
     let interval: u64 = 86400;
-    client.subscribe(&user, &merchant, &1_0000000, &interval, &token_addr, &None);
+    client.subscribe(&user, &merchant, &1_0000000, &interval, &token_addr, &None, &None);
     client.cancel(&user);
 
     env.ledger().with_mut(|l| { l.timestamp += interval + 1; });
@@ -400,7 +400,7 @@ fn test_active_count_increments_on_subscribe() {
     let client = FlowPayClient::new(&env, &contract_id);
 
     assert_eq!(client.get_active_count(), 0);
-    client.subscribe(&user, &merchant, &1_0000000, &86400, &token_addr, &None);
+    client.subscribe(&user, &merchant, &1_0000000, &86400, &token_addr, &None, &None);
     assert_eq!(client.get_active_count(), 1);
 }
 
@@ -409,7 +409,7 @@ fn test_active_count_decrements_on_cancel() {
     let (env, contract_id, token_addr, user, merchant) = setup();
     let client = FlowPayClient::new(&env, &contract_id);
 
-    client.subscribe(&user, &merchant, &1_0000000, &86400, &token_addr, &None);
+    client.subscribe(&user, &merchant, &1_0000000, &86400, &token_addr, &None, &None);
     assert_eq!(client.get_active_count(), 1);
     client.cancel(&user);
     assert_eq!(client.get_active_count(), 0);
@@ -426,8 +426,8 @@ fn test_active_count_multiple_users() {
     let token = TokenClient::new(&env, &token_addr);
     token.approve(&user_b, &contract_id, &10_000_0000000, &200);
 
-    client.subscribe(&user_a, &merchant, &1_0000000, &86400, &token_addr, &None);
-    client.subscribe(&user_b, &merchant, &1_0000000, &86400, &token_addr, &None);
+    client.subscribe(&user_a, &merchant, &1_0000000, &86400, &token_addr, &None, &None);
+    client.subscribe(&user_b, &merchant, &1_0000000, &86400, &token_addr, &None, &None);
     assert_eq!(client.get_active_count(), 2);
 
     client.cancel(&user_a);
@@ -445,7 +445,7 @@ fn test_merchant_revenue_from_charge() {
 
     let amount: i128 = 5_0000000;
     let interval: u64 = 86400;
-    client.subscribe(&user, &merchant, &amount, &interval, &token_addr, &None);
+    client.subscribe(&user, &merchant, &amount, &interval, &token_addr, &None, &None);
 
     assert_eq!(client.get_merchant_revenue(&merchant), 0);
 
@@ -460,7 +460,7 @@ fn test_merchant_revenue_from_pay_per_use() {
     let (env, contract_id, token_addr, user, merchant) = setup();
     let client = FlowPayClient::new(&env, &contract_id);
 
-    client.subscribe(&user, &merchant, &1_0000000, &86400, &token_addr, &None);
+    client.subscribe(&user, &merchant, &1_0000000, &86400, &token_addr, &None, &None);
     client.pay_per_use(&user, &3_0000000);
 
     assert_eq!(client.get_merchant_revenue(&merchant), 3_0000000);
@@ -473,7 +473,7 @@ fn test_merchant_revenue_accumulates() {
 
     let amount: i128 = 2_0000000;
     let interval: u64 = 86400;
-    client.subscribe(&user, &merchant, &amount, &interval, &token_addr, &None);
+    client.subscribe(&user, &merchant, &amount, &interval, &token_addr, &None, &None);
 
     env.ledger().with_mut(|l| { l.timestamp += interval + 1; });
     client.charge(&user);
@@ -492,7 +492,7 @@ fn test_daily_limit_allows_spend_within_limit() {
     let (env, contract_id, token_addr, user, merchant) = setup();
     let client = FlowPayClient::new(&env, &contract_id);
 
-    client.subscribe(&user, &merchant, &1_0000000, &86400, &token_addr, &None);
+    client.subscribe(&user, &merchant, &1_0000000, &86400, &token_addr, &None, &None);
     client.set_daily_limit(&user, &10_0000000);
     // Should not panic
     client.pay_per_use(&user, &5_0000000);
@@ -504,7 +504,7 @@ fn test_daily_limit_blocks_overspend() {
     let (env, contract_id, token_addr, user, merchant) = setup();
     let client = FlowPayClient::new(&env, &contract_id);
 
-    client.subscribe(&user, &merchant, &1_0000000, &86400, &token_addr, &None);
+    client.subscribe(&user, &merchant, &1_0000000, &86400, &token_addr, &None, &None);
     client.set_daily_limit(&user, &3_0000000);
     client.pay_per_use(&user, &5_0000000);
 }
@@ -514,7 +514,7 @@ fn test_daily_limit_accumulates_across_calls() {
     let (env, contract_id, token_addr, user, merchant) = setup();
     let client = FlowPayClient::new(&env, &contract_id);
 
-    client.subscribe(&user, &merchant, &1_0000000, &86400, &token_addr, &None);
+    client.subscribe(&user, &merchant, &1_0000000, &86400, &token_addr, &None, &None);
     client.set_daily_limit(&user, &5_0000000);
     client.pay_per_use(&user, &2_0000000);
     client.pay_per_use(&user, &2_0000000);
@@ -527,8 +527,124 @@ fn test_daily_limit_blocks_cumulative_overspend() {
     let (env, contract_id, token_addr, user, merchant) = setup();
     let client = FlowPayClient::new(&env, &contract_id);
 
-    client.subscribe(&user, &merchant, &1_0000000, &86400, &token_addr, &None);
+    client.subscribe(&user, &merchant, &1_0000000, &86400, &token_addr, &None, &None);
     client.set_daily_limit(&user, &5_0000000);
     client.pay_per_use(&user, &3_0000000);
     client.pay_per_use(&user, &3_0000000); // 6 total > 5 limit
+}
+
+// ─────────────────────────────────────────────
+// Issue #96: referral tracking tests
+// ─────────────────────────────────────────────
+
+#[test]
+fn test_referral_stored_on_subscribe() {
+    let (env, contract_id, token_addr, user, merchant) = setup();
+    let client = FlowPayClient::new(&env, &contract_id);
+
+    let referrer = Address::generate(&env);
+    client.subscribe(&user, &merchant, &1_0000000, &86400, &token_addr, &None, &Some(referrer.clone()));
+
+    assert_eq!(client.get_referrer(&user), Some(referrer));
+}
+
+#[test]
+fn test_no_referral_returns_none() {
+    let (env, contract_id, token_addr, user, merchant) = setup();
+    let client = FlowPayClient::new(&env, &contract_id);
+
+    client.subscribe(&user, &merchant, &1_0000000, &86400, &token_addr, &None, &None);
+
+    assert!(client.get_referrer(&user).is_none());
+}
+
+// ─────────────────────────────────────────────
+// Issue #97: migration tests
+// ─────────────────────────────────────────────
+
+#[test]
+fn test_migrate_sets_schema_version() {
+    let (env, contract_id, _token_addr, _user, _merchant) = setup();
+    let client = FlowPayClient::new(&env, &contract_id);
+
+    // Before migration, version defaults to 1
+    assert_eq!(client.get_schema_version(), 1);
+
+    client.migrate();
+
+    assert_eq!(client.get_schema_version(), 2);
+}
+
+#[test]
+fn test_migrate_is_idempotent() {
+    let (env, contract_id, _token_addr, _user, _merchant) = setup();
+    let client = FlowPayClient::new(&env, &contract_id);
+
+    client.migrate();
+    client.migrate(); // second call should be a no-op
+
+    assert_eq!(client.get_schema_version(), 2);
+}
+
+// ─────────────────────────────────────────────
+// Issue #99: subscription metadata tests
+// ─────────────────────────────────────────────
+
+#[test]
+fn test_set_and_get_metadata() {
+    let (env, contract_id, token_addr, user, merchant) = setup();
+    let client = FlowPayClient::new(&env, &contract_id);
+
+    client.subscribe(&user, &merchant, &1_0000000, &86400, &token_addr, &None, &None);
+
+    let label = soroban_sdk::String::from_str(&env, "pro");
+    client.set_metadata(&user, &label);
+
+    assert_eq!(client.get_metadata(&user), Some(label));
+}
+
+#[test]
+fn test_get_metadata_none_when_not_set() {
+    let (env, contract_id, _token_addr, _user, _merchant) = setup();
+    let client = FlowPayClient::new(&env, &contract_id);
+
+    let random = Address::generate(&env);
+    assert!(client.get_metadata(&random).is_none());
+}
+
+// ─────────────────────────────────────────────
+// Issue #98: charge history tests
+// ─────────────────────────────────────────────
+
+#[test]
+fn test_charge_history_recorded() {
+    let (env, contract_id, token_addr, user, merchant) = setup();
+    let client = FlowPayClient::new(&env, &contract_id);
+
+    let interval: u64 = 86400;
+    client.subscribe(&user, &merchant, &1_0000000, &interval, &token_addr, &None, &None);
+
+    assert_eq!(client.get_charge_history(&user).len(), 0);
+
+    env.ledger().with_mut(|l| { l.timestamp += interval + 1; });
+    client.charge(&user);
+
+    assert_eq!(client.get_charge_history(&user).len(), 1);
+}
+
+#[test]
+fn test_charge_history_capped_at_12() {
+    let (env, contract_id, token_addr, user, merchant) = setup();
+    let client = FlowPayClient::new(&env, &contract_id);
+
+    let interval: u64 = 86400;
+    client.subscribe(&user, &merchant, &1_0000000, &interval, &token_addr, &None, &None);
+
+    // Perform 14 charges
+    for _ in 0..14 {
+        env.ledger().with_mut(|l| { l.timestamp += interval + 1; });
+        client.charge(&user);
+    }
+
+    assert_eq!(client.get_charge_history(&user).len(), 12);
 }

--- a/docs/API.md
+++ b/docs/API.md
@@ -625,3 +625,122 @@ All events can be indexed by listening to the Stellar RPC event stream for the F
 | `cancelled` | `("cancelled", user_address)` | `()` |
 | `paused` | `("paused", user_address)` | `()` |
 | `resumed` | `("resumed", user_address)` | `()` |
+
+---
+
+## New Modules (Issues #96–#99)
+
+---
+
+### `subscribe` (updated)
+
+The `subscribe` function now accepts an optional `referrer` parameter:
+
+```
+subscribe(env, user, merchant, amount, interval, token, trial_period, referrer: Option<Address>)
+```
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `referrer` | `Option<Address>` | Optional address of the referrer who introduced this subscriber. Stored in `DataKey::Referral(user)` and emits a `("referred", user)` event. |
+
+---
+
+### `get_referrer`
+
+Returns the referrer address recorded for a subscriber.
+
+```
+get_referrer(env: Env, user: Address) -> Option<Address>
+```
+
+**Auth:** None.
+
+**Returns:** `Option<Address>` — `None` if no referrer was recorded.
+
+**Storage read:** `DataKey::Referral(user)` in persistent storage.
+
+---
+
+### `migrate`
+
+Upgrades contract storage to the latest schema version. Safe to call multiple times.
+
+```
+migrate(env: Env)
+```
+
+**Auth:** None (admin restriction can be added in future versions).
+
+**Storage written:** `DataKey::SchemaVersion` in instance storage.
+
+---
+
+### `get_schema_version`
+
+Returns the current storage schema version.
+
+```
+get_schema_version(env: Env) -> u32
+```
+
+**Auth:** None.
+
+**Returns:** `u32` — defaults to `1` before the first `migrate()` call.
+
+---
+
+### `set_metadata`
+
+Attaches a short label string (e.g. plan name) to the caller's subscription.
+
+```
+set_metadata(env: Env, user: Address, label: String)
+```
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `user` | `Address` | The subscriber. Must match the transaction signer. |
+| `label` | `String` | Short display label (e.g. `"pro"`, `"basic"`). |
+
+**Auth:** `user.require_auth()`.
+
+**Storage written:** `DataKey::SubscriptionMeta(user)` in persistent storage.
+
+---
+
+### `get_metadata`
+
+Returns the metadata label for a subscriber.
+
+```
+get_metadata(env: Env, user: Address) -> Option<String>
+```
+
+**Auth:** None.
+
+**Returns:** `Option<String>` — `None` if no label has been set.
+
+---
+
+### `get_charge_history`
+
+Returns the last (up to 12) charge timestamps for a subscriber, ordered oldest → newest.
+
+```
+get_charge_history(env: Env, user: Address) -> Vec<u64>
+```
+
+**Auth:** None.
+
+**Returns:** `Vec<u64>` — UNIX timestamps of successful `charge()` calls. Empty if no charges have occurred.
+
+**Storage read:** `DataKey::ChargeHistory(user)` in persistent storage.
+
+---
+
+### Updated Events Reference
+
+| Event name | Topic | Data |
+| --- | --- | --- |
+| `referred` | `("referred", user_address)` | `referrer_address` |

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -20,3 +20,33 @@ Verify your setup:
 rustc --version        # rustc 1.70+
 soroban --version      # soroban 21.x
 node --version         # v18+
+
+```
+
+---
+
+## State Migration
+
+FlowPay uses a `SchemaVersion` key in instance storage to track the storage schema version. When upgrading the contract WASM to a new version that introduces storage layout changes, call `migrate()` once after deployment:
+
+```bash
+soroban contract invoke \
+  --id <CONTRACT_ID> \
+  --source deployer \
+  --network testnet \
+  -- migrate
+```
+
+### Migration History
+
+| Version | Changes |
+| --- | --- |
+| v1 | Initial schema (no version key) |
+| v2 | Introduced `SchemaVersion` tracking, `Referral`, `SubscriptionMeta`, `ChargeHistory` keys |
+
+### How It Works
+
+- `get_schema_version()` returns `1` by default (pre-versioning contracts).
+- `migrate()` checks the current version and applies any pending upgrades sequentially.
+- Subsequent calls to `migrate()` are no-ops once the contract is at the latest version.
+- Future schema changes should add a new `if version < N { ... }` block in `migration.rs`.


### PR DESCRIPTION
…and charge history

- #96: Add contract/src/referral.rs — stores referrer on subscribe(), emits referred event, exposes get_referrer()
- #97: Add contract/src/migration.rs — SchemaVersion tracking, migrate() helper (v1→v2), docs/DEPLOYMENT.md updated
- #98: Add contract/src/subscription_history.rs — circular buffer of last 12 charge timestamps, wired into charge(), exposes get_charge_history()
- #99: Add contract/src/subscription_metadata.rs — set_metadata()/get_metadata() for per-subscriber labels

Updated: contract/src/lib.rs (new DataKey variants, new contract fns, subscribe() referrer param)
Updated: contract/src/test.rs (all existing calls updated + new tests for each feature)
Updated: docs/API.md and docs/DEPLOYMENT.md

closes #96 
closes #97 
closes #98 
closes #99 