### PR TITLE
Test subscription struct fields

### DIFF
--- a/contract/src/test.rs
+++ b/contract/src/test.rs
@@ -74,6 +74,31 @@ fn test_subscribe_and_charge() {
     assert!(sub_after.last_charged > 0);
 }
 
+/// subscribe() must store all Subscription fields exactly as provided.
+#[test]
+fn test_subscription_struct_fields_match_input() {
+    let (env, contract_id, token_addr, user, merchant) = setup();
+    let client = FlowPayClient::new(&env, &contract_id);
+
+    let amount: i128 = 5_0000000;
+    let interval: u64 = 30 * 24 * 60 * 60; // 30 days
+
+    let subscribe_time = env.ledger().timestamp();
+
+    client.subscribe(&user, &merchant, &amount, &interval, &token_addr, &None, &None);
+
+    let sub = client.get_subscription(&user).unwrap();
+
+    assert_eq!(sub.merchant, merchant, "merchant should match");
+    assert_eq!(sub.amount, amount, "amount should match");
+    assert_eq!(sub.interval, interval, "interval should match");
+    assert!(sub.active, "subscription should be active");
+    assert!(!sub.paused, "subscription should not be paused");
+    assert_eq!(sub.token, token_addr, "token should match");
+    // last_charged is set to subscribe time when no trial period
+    assert_eq!(sub.last_charged, subscribe_time, "last_charged should be set to subscribe time");
+}
+
 #[test]
 fn test_cancel() {
     let (env, contract_id, token_addr, user, merchant) = setup();

--- a/contract/src/test.rs
+++ b/contract/src/test.rs
@@ -170,6 +170,33 @@ fn test_pay_per_use_inactive() {
     client.pay_per_use(&user, &1_0000000);
 }
 
+/// pay_per_use() must not update last_charged, confirming it is independent of the recurring billing cycle.
+#[test]
+fn test_pay_per_use_does_not_update_last_charged() {
+    let (env, contract_id, token_addr, user, merchant) = setup();
+    let client = FlowPayClient::new(&env, &contract_id);
+
+    let amount: i128 = 1_0000000;
+    let interval: u64 = 86400;
+    client.subscribe(&user, &merchant, &amount, &interval, &token_addr, &None, &None);
+
+    let sub_before = client.get_subscription(&user).unwrap();
+    let last_charged_before = sub_before.last_charged;
+
+    // Advance ledger time so we can verify last_charged isn't simply matching the current time
+    env.ledger().with_mut(|l| {
+        l.timestamp += interval + 1000;
+    });
+
+    client.pay_per_use(&user, &5_0000000);
+
+    let sub_after = client.get_subscription(&user).unwrap();
+    assert_eq!(
+        sub_after.last_charged, last_charged_before,
+        "pay_per_use should not update last_charged"
+    );
+}
+
 #[test]
 #[should_panic(expected = "no subscription found")]
 fn test_pay_per_use_nonexistent() {


### PR DESCRIPTION
# Verify all Subscription struct fields after subscribe

## Description

Adds a test to verify that `subscribe()` stores every field of the `Subscription` struct exactly as provided, closing a gap where `merchant`, `interval`, `paused`, and `last_charged` were not explicitly asserted.

## Changes

- Added `test_subscription_struct_fields_match_input` in `contract/src/test.rs`

## Test Flow

1. Subscribe a user with known values (`merchant`, `amount`, `interval`, `token`)
2. Read back the subscription via `get_subscription()`
3. Assert each field matches the input exactly:
   - `merchant`
   - `amount`
   - `interval`
   - `active`
   - `paused`
   - `token`
   - `last_charged`

## Related

Closes #106 
