### PR TITLE
Test/charge exact transfer

### DIFF
--- a/contract/src/test.rs
+++ b/contract/src/test.rs
@@ -74,6 +74,31 @@ fn test_subscribe_and_charge() {
     assert!(sub_after.last_charged > 0);
 }
 
+/// subscribe() must store all Subscription fields exactly as provided.
+#[test]
+fn test_subscription_struct_fields_match_input() {
+    let (env, contract_id, token_addr, user, merchant) = setup();
+    let client = FlowPayClient::new(&env, &contract_id);
+
+    let amount: i128 = 5_0000000;
+    let interval: u64 = 30 * 24 * 60 * 60; // 30 days
+
+    let subscribe_time = env.ledger().timestamp();
+
+    client.subscribe(&user, &merchant, &amount, &interval, &token_addr, &None, &None);
+
+    let sub = client.get_subscription(&user).unwrap();
+
+    assert_eq!(sub.merchant, merchant, "merchant should match");
+    assert_eq!(sub.amount, amount, "amount should match");
+    assert_eq!(sub.interval, interval, "interval should match");
+    assert!(sub.active, "subscription should be active");
+    assert!(!sub.paused, "subscription should not be paused");
+    assert_eq!(sub.token, token_addr, "token should match");
+    // last_charged is set to subscribe time when no trial period
+    assert_eq!(sub.last_charged, subscribe_time, "last_charged should be set to subscribe time");
+}
+
 #[test]
 fn test_cancel() {
     let (env, contract_id, token_addr, user, merchant) = setup();

--- a/contract/src/test.rs
+++ b/contract/src/test.rs
@@ -74,6 +74,42 @@ fn test_subscribe_and_charge() {
     assert!(sub_after.last_charged > 0);
 }
 
+/// charge() must decrease user balance and increase merchant balance by exactly the subscription amount.
+#[test]
+fn test_charge_exact_transfer_amount() {
+    let (env, contract_id, token_addr, user, merchant) = setup();
+    let client = FlowPayClient::new(&env, &contract_id);
+    let token = TokenClient::new(&env, &token_addr);
+
+    let amount: i128 = 5_0000000;
+    let interval: u64 = 86400;
+
+    client.subscribe(&user, &merchant, &amount, &interval, &token_addr, &None, &None);
+
+    let user_balance_before = token.balance(&user);
+    let merchant_balance_before = token.balance(&merchant);
+
+    env.ledger().with_mut(|l| {
+        l.timestamp += interval + 1;
+    });
+
+    client.charge(&user);
+
+    let user_balance_after = token.balance(&user);
+    let merchant_balance_after = token.balance(&merchant);
+
+    assert_eq!(
+        user_balance_before - user_balance_after,
+        amount,
+        "user balance should decrease by exactly the subscription amount"
+    );
+    assert_eq!(
+        merchant_balance_after - merchant_balance_before,
+        amount,
+        "merchant balance should increase by exactly the subscription amount"
+    );
+}
+
 /// subscribe() must store all Subscription fields exactly as provided.
 #[test]
 fn test_subscription_struct_fields_match_input() {

--- a/contract/src/test.rs
+++ b/contract/src/test.rs
@@ -170,6 +170,33 @@ fn test_pay_per_use_inactive() {
     client.pay_per_use(&user, &1_0000000);
 }
 
+/// pay_per_use() must not update last_charged, confirming it is independent of the recurring billing cycle.
+#[test]
+fn test_pay_per_use_does_not_update_last_charged() {
+    let (env, contract_id, token_addr, user, merchant) = setup();
+    let client = FlowPayClient::new(&env, &contract_id);
+
+    let amount: i128 = 1_0000000;
+    let interval: u64 = 86400;
+    client.subscribe(&user, &merchant, &amount, &interval, &token_addr, &None, &None);
+
+    let sub_before = client.get_subscription(&user).unwrap();
+    let last_charged_before = sub_before.last_charged;
+
+    // Advance ledger time so we can verify last_charged isn't simply matching the current time
+    env.ledger().with_mut(|l| {
+        l.timestamp += interval + 1000;
+    });
+
+    client.pay_per_use(&user, &5_0000000);
+
+    let sub_after = client.get_subscription(&user).unwrap();
+    assert_eq!(
+        sub_after.last_charged, last_charged_before,
+        "pay_per_use should not update last_charged"
+    );
+}
+
 #[test]
 #[should_panic(expected = "no subscription found")]
 fn test_pay_per_use_nonexistent() {


### PR DESCRIPTION
# Verify exact transfer amounts during charge

## Description

Adds a comprehensive test to verify that `charge()` atomically decreases the user balance and increases the merchant balance by exactly the subscription amount. Previously, separate tests existed for each side but no single test confirmed both sides of the transfer in one atomic operation.

## Changes

- Added `test_charge_exact_transfer_amount` in `contract/src/test.rs`

## Test Flow

1. Subscribe a user with a known subscription `amount`
2. Record `user_balance_before` and `merchant_balance_before`
3. Advance ledger time past the interval
4. Call `charge()`
5. Record `user_balance_after` and `merchant_balance_after`
6. Assert:
   - `user_balance_before - user_balance_after == amount`
   - `merchant_balance_after - merchant_balance_before == amount`

## Related

Closes #104
