### PR TITLE
Feat/subscriber count

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { useFreighterAvailable } from "./hooks/useFreighterAvailable";
 import { useNetworkCheck } from "./hooks/useNetworkCheck";
 import { useContractId } from "./hooks/useContractId";
 import { useRpcHealth } from "./hooks/useRpcHealth";
+import { useSubscriberCount } from "./hooks/useSubscriberCount";
 import SubscribeForm from "./components/SubscribeForm";
 import Dashboard from "./components/Dashboard";
 import MerchantDashboard from "./components/MerchantDashboard";
@@ -43,6 +44,7 @@ export default function App() {
   const { networkMatch, walletNetwork } = useNetworkCheck();
   const { valid: contractIdValid, error: contractIdError } = useContractId();
   const { healthy: rpcHealthy, error: rpcError } = useRpcHealth();
+  const { count: subscriberCount, loading: subscriberCountLoading } = useSubscriberCount();
   const [tab, setTab] = useState<"subscribe" | "dashboard" | "merchant">("dashboard");
   const [refresh, setRefresh] = useState(0);
 
@@ -52,7 +54,14 @@ export default function App() {
       <div className="app-header">
         <div>
           <h1 className="app-header__title">⚡ FlowPay</h1>
-          <p className="app-header__subtitle">Decentralized recurring payments on Stellar</p>
+          <p className="app-header__subtitle">
+            Decentralized recurring payments on Stellar
+            {!subscriberCountLoading && (
+              <span style={{ marginLeft: "8px", opacity: 0.7 }}>
+                • {subscriberCount} active subscriber{subscriberCount !== 1 ? "s" : ""}
+              </span>
+            )}
+          </p>
         </div>
         <button className="btn-secondary theme-toggle" onClick={toggle} aria-label={`Switch to ${theme === "dark" ? "light" : "dark"} mode`}>
           {theme === "dark" ? <SunIcon /> : <MoonIcon />}

--- a/frontend/src/hooks/useSubscriberCount.ts
+++ b/frontend/src/hooks/useSubscriberCount.ts
@@ -1,0 +1,84 @@
+import { useState, useEffect } from "react";
+import { server, CONTRACT_ID } from "../stellar";
+
+interface SubscriberCountResult {
+  count: number;
+  loading: boolean;
+}
+
+/**
+ * Fetches the total number of active subscribers from contract events.
+ * Counts unique addresses in "subscribed" events minus "cancelled" events.
+ */
+export function useSubscriberCount(): SubscriberCountResult {
+  const [count, setCount] = useState(0);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetchSubscriberCount() {
+      try {
+        setLoading(true);
+
+        const response = await server.getEvents({
+          startLedger: undefined,
+          filters: [
+            {
+              type: "contract",
+              contractIds: [CONTRACT_ID],
+            },
+          ],
+          limit: 1000, // Fetch more events to get accurate count
+        });
+
+        // Track unique subscribers
+        const subscribers = new Set<string>();
+        const cancelledUsers = new Set<string>();
+
+        for (const event of response.events) {
+          try {
+            if (!event.topic || event.topic.length < 2) continue;
+
+            const eventType = event.topic[0]?.toString();
+            const userAddress = event.topic[1]?.toString();
+
+            if (!userAddress) continue;
+
+            if (eventType === "subscribed") {
+              subscribers.add(userAddress);
+            } else if (eventType === "cancelled") {
+              cancelledUsers.add(userAddress);
+            }
+          } catch (e) {
+            console.warn("Event parsing failed:", e);
+          }
+        }
+
+        // Calculate active subscribers: subscribed minus cancelled
+        const activeSubscribers = new Set(
+          [...subscribers].filter((user) => !cancelledUsers.has(user))
+        );
+
+        if (!cancelled) {
+          setCount(activeSubscribers.size);
+          setLoading(false);
+        }
+      } catch (error) {
+        console.error("Error fetching subscriber count:", error);
+        if (!cancelled) {
+          setCount(0);
+          setLoading(false);
+        }
+      }
+    }
+
+    fetchSubscriberCount();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { count, loading };
+}


### PR DESCRIPTION
feat: Add useSubscriberCount Hook for Active Subscriber Display
Summary

Introduces a useSubscriberCount hook to fetch and display the total number of active subscribers directly from contract events. This provides real-time visibility into platform adoption by showing active subscriber count in the UI.

Changes
- Created frontend/src/hooks/useSubscriberCount.ts
- Implemented logic to count unique subscriber addresses from subscribed events
- Subtracted addresses with cancelled events to reflect only active subscribers
- Returned standardized hook state: { count, loading }
- Added subscriber count display to App.tsx header / connect screen

Impact
- Improves transparency by surfacing active subscriber metrics in the frontend
- Keeps subscriber count aligned with on-chain event history
- Enhances user trust and product visibility with live usage indicators

Acceptance Criteria
- [ ]  Count calculated from contract events
- [ ]  Subscriber count displayed in UI
- [ ]  npm run build passes successfully

Closes #172