### PR TITLE
AllowanceDisplay in SubscribeForm + clickable tx-hash link in toasts

### DIFF
--- a/frontend/src/__tests__/stellar.test.ts
+++ b/frontend/src/__tests__/stellar.test.ts
@@ -137,6 +137,11 @@ describe("getMerchantSubscribers", () => {
 
     const { getMerchantSubscribers } = await import("../stellar");
     const result = await getMerchantSubscribers("merchant_A");
+
+    expect(result).toEqual([]);
+  });
+});
+
 describe("getChargeHistory", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -45,7 +45,7 @@ export default function Dashboard({ userKey, onSign, refreshTrigger, announce }:
         const xdr = await buildCancelTx(userKey);
         return onSign(xdr);
       });
-      addToast(`Cancelled. tx: ${hash.slice(0, 12)}…`, "success");
+      addToast("Cancelled.", "success", hash);
       announce("Transaction confirmed");
       refresh();
     } catch (e: unknown) {
@@ -62,7 +62,7 @@ export default function Dashboard({ userKey, onSign, refreshTrigger, announce }:
         const xdr = await buildPayPerUseTx(userKey, stroops);
         return onSign(xdr);
       });
-      addToast(`Paid! tx: ${hash.slice(0, 12)}…`, "success");
+      addToast("Paid!", "success", hash);
       announce("Transaction confirmed");
     } catch (e: unknown) {
       const msg = `Error: ${friendlyError(e instanceof Error ? e.message : String(e))}`;

--- a/frontend/src/components/SubscribeForm.tsx
+++ b/frontend/src/components/SubscribeForm.tsx
@@ -43,7 +43,7 @@ export default function SubscribeForm({ userKey, onSign, onSuccess, announce }: 
     });
 
     if (hash) {
-      addToast(`Subscribed! tx: ${hash.slice(0, 12)}…`, "success");
+      addToast("Subscribed!", "success", hash);
       announce("Transaction confirmed");
       onSuccess();
     } else if (tx.error) {

--- a/frontend/src/components/SubscribeForm.tsx
+++ b/frontend/src/components/SubscribeForm.tsx
@@ -1,10 +1,11 @@
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import { buildSubscribeTx } from "../stellar";
 import { friendlyError } from "../utils/errors";
 import { STROOPS_PER_XLM, BILLING_INTERVALS } from "../constants";
 import { useFormValidation } from "../hooks/useFormValidation";
 import { useToast } from "../hooks/useToast";
 import { useTransaction } from "../hooks/useTransaction";
+import AllowanceDisplay from "./AllowanceDisplay";
 import ToastContainer from "./Toast";
 
 interface Props {
@@ -52,6 +53,12 @@ export default function SubscribeForm({ userKey, onSign, onSuccess, announce }: 
     }
   }
 
+  const amountStroops = useMemo(() => {
+    const parsed = parseFloat(amount);
+    if (!amount || Number.isNaN(parsed) || parsed <= 0) return 0n;
+    return BigInt(Math.round(parsed * STROOPS_PER_XLM));
+  }, [amount]);
+
   const pending = tx.status === "pending";
 
   return (
@@ -81,6 +88,13 @@ export default function SubscribeForm({ userKey, onSign, onSuccess, announce }: 
           required
         />
         {errors.amount && <span className="text-error">{errors.amount}</span>}
+        {userKey && (
+          <AllowanceDisplay
+            userKey={userKey}
+            subscriptionAmount={amountStroops}
+            refreshTrigger={0}
+          />
+        )}
       </label>
 
       <label className="form-group">

--- a/frontend/src/components/Toast.tsx
+++ b/frontend/src/components/Toast.tsx
@@ -1,4 +1,6 @@
 import type { Toast } from "../hooks/useToast";
+import { explorerTxUrl } from "../stellar";
+import { formatAddress } from "../utils/format";
 
 interface Props {
   toasts: Toast[];
@@ -11,7 +13,24 @@ export default function ToastContainer({ toasts, onRemove }: Props) {
     <div className="toast-container">
       {toasts.map((t) => (
         <div key={t.id} className={`toast toast--${t.variant} fade-in`}>
-          <span>{t.message}</span>
+          <span>
+            {t.message}
+            {t.txHash && (
+              <>
+                {" "}
+                <a
+                  href={explorerTxUrl(t.txHash)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="toast__tx-link"
+                  title={t.txHash}
+                  style={{ textDecoration: "underline" }}
+                >
+                  tx: {formatAddress(t.txHash)}
+                </a>
+              </>
+            )}
+          </span>
           <button className="btn-secondary toast__dismiss" onClick={() => onRemove(t.id)}>
             ×
           </button>

--- a/frontend/src/hooks/useToast.ts
+++ b/frontend/src/hooks/useToast.ts
@@ -6,6 +6,7 @@ export interface Toast {
   id: number;
   message: string;
   variant: ToastVariant;
+  txHash?: string;
 }
 
 let nextId = 0;
@@ -13,11 +14,14 @@ let nextId = 0;
 export function useToast() {
   const [toasts, setToasts] = useState<Toast[]>([]);
 
-  const addToast = useCallback((message: string, variant: ToastVariant = "info") => {
-    const id = ++nextId;
-    setToasts((prev) => [...prev, { id, message, variant }]);
-    setTimeout(() => removeToast(id), 5000);
-  }, []);
+  const addToast = useCallback(
+    (message: string, variant: ToastVariant = "info", txHash?: string) => {
+      const id = ++nextId;
+      setToasts((prev) => [...prev, { id, message, variant, txHash }]);
+      setTimeout(() => removeToast(id), 5000);
+    },
+    []
+  );
 
   const removeToast = useCallback((id: number) => {
     setToasts((prev) => prev.filter((t) => t.id !== id));

--- a/frontend/src/stellar.ts
+++ b/frontend/src/stellar.ts
@@ -33,6 +33,12 @@ export const DEFAULT_TOKEN = import.meta.env.VITE_DEFAULT_TOKEN ?? "CAAAAAAAAAAA
 
 export const server = new Server(RPC_URL);
 
+// Stellar.expert explorer link for a transaction, on the active network.
+export function explorerTxUrl(hash: string): string {
+  const network = NETWORK_PASSPHRASE === Networks.PUBLIC ? "public" : "testnet";
+  return `https://stellar.expert/explorer/${network}/tx/${hash}`;
+}
+
 export interface MerchantSubscriber {
   subscriber: string;
   amount: string;


### PR DESCRIPTION

**Title:**
`feat: AllowanceDisplay in SubscribeForm + clickable tx-hash link in toasts`

**Body:**
## Summary
Two user-facing improvements from the `kingksjo` fork:

1. **Allowance in the subscribe flow** (#277): `AllowanceDisplay` is now rendered below the Amount field in `SubscribeForm`, fed the entered amount so its existing "Low allowance" badge warns when the allowance is insufficient. It resolves the token contract internally via `getAllowance(userKey)`, matching the `Dashboard` usage.
2. 
   ```tsx
   {userKey && (
     <AllowanceDisplay userKey={userKey} subscriptionAmount={amountStroops} refreshTrigger={0} />
   )}
   ```

3. **Clickable tx-hash links in toasts** (#270): success toasts now render the tx hash as a link to stellar.expert, opened in a new tab with `rel="noopener noreferrer"`. The explorer network is derived from `NETWORK_PASSPHRASE`:
   ```ts
   export function explorerTxUrl(hash: string): string {
     const network = NETWORK_PASSPHRASE === Networks.PUBLIC ? "public" : "testnet";
     return `https://stellar.expert/explorer/${network}/tx/${hash}`;
   }
   ```
   `Toast` gained an optional `txHash` field (`addToast(message, variant, txHash?)`); callers in `SubscribeForm`/`Dashboard` now pass the full hash instead of slicing it into the message string.

Also includes a small fix closing an unterminated `it(...)` block in `stellar.test.ts` that broke parsing of the test file.

Closes #270
Closes #277

## Notes
- Both features were verified in-browser (testnet + mainnet explorer URLs; allowance shown with/without the low-allowance warning).
- This repo has pre-existing `tsc` errors on `master` unrelated to these changes; no new lint/type errors are introduced in the touched files.