### PR TITLE
Add 'p' keyboard shortcut to focus pay-per-use amount input

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -98,6 +98,15 @@ export default function App() {
           // We include it here solely for documentation in the Help Modal.
         },
       },
+      {
+        key: "p",
+        description: "Focus pay-per-use amount input",
+        action: () => {
+          // This shortcut is handled specifically in Dashboard.tsx
+          // where it has access to the subscription state and input ref.
+          // We include it here solely for documentation in the Help Modal.
+        },
+      },
     ],
   });
 

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { buildCancelTx, buildPayPerUseTx } from "../stellar";
 import { friendlyError } from "../utils/errors";
 import SubscriptionCard from "./SubscriptionCard";
@@ -33,13 +33,13 @@ export default function Dashboard({ userKey, onSign, refreshTrigger, announce }:
   const [showIncreaseAllowance, setShowIncreaseAllowance] = useState(false);
   const [allowanceRefresh, setAllowanceRefresh] = useState(0);
   const [dailyLimitRefresh, setDailyLimitRefresh] = useState(0);
+  const ppuInputRef = useRef<HTMLInputElement>(null);
 
   usePolling({ callback: refresh, interval: 30000, enabled: !!sub?.active });
 
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
-      if (e.key.toLowerCase() !== "x") return;
-
+      const key = e.key.toLowerCase();
       const target = e.target as HTMLElement;
       if (
         target.tagName === "INPUT" ||
@@ -49,9 +49,14 @@ export default function Dashboard({ userKey, onSign, refreshTrigger, announce }:
         return;
       }
 
-      if (sub?.active && !showConfirm) {
+      if (key === "x" && sub?.active && !showConfirm) {
         e.preventDefault();
         setShowConfirm(true);
+      }
+
+      if (key === "p" && sub?.active) {
+        e.preventDefault();
+        ppuInputRef.current?.focus();
       }
     }
 
@@ -140,7 +145,7 @@ export default function Dashboard({ userKey, onSign, refreshTrigger, announce }:
               </div>
 
               <SubscriptionHistory userKey={userKey} />
-              <PayPerUseForm onPay={handlePayPerUse} loading={ppuPending} />
+              <PayPerUseForm ref={ppuInputRef} onPay={handlePayPerUse} loading={ppuPending} />
               {ppuPending && (
                 <p className="status-text status-text--pending">Confirming payment…</p>
               )}

--- a/frontend/src/components/PayPerUseForm.tsx
+++ b/frontend/src/components/PayPerUseForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, forwardRef } from "react";
 import Spinner from "./Spinner";
 
 interface PayPerUseFormProps {
@@ -6,40 +6,44 @@ interface PayPerUseFormProps {
   loading: boolean;
 }
 
-export default function PayPerUseForm({
-  onPay,
-  loading,
-}: PayPerUseFormProps) {
-  const [amount, setAmount] = useState("");
+const PayPerUseForm = forwardRef<HTMLInputElement, PayPerUseFormProps>(
+  ({ onPay, loading }, ref) => {
+    const [amount, setAmount] = useState("");
 
-  async function handleSubmit() {
-    if (!amount) return;
-    const stroops = BigInt(Math.round(parseFloat(amount) * 10_000_000));
-    await onPay(stroops);
-    setAmount("");
-  }
+    async function handleSubmit() {
+      if (!amount) return;
+      const stroops = BigInt(Math.round(parseFloat(amount) * 10_000_000));
+      await onPay(stroops);
+      setAmount("");
+    }
 
-  return (
-    <div className="card">
-      <h3 className="ppu-card__title">Pay-per-use</h3>
-      <div className="ppu-card__row">
-        <input
-          type="number"
-          min="0.0000001"
-          step="0.0000001"
-          placeholder="Amount in XLM"
-          value={amount}
-          onChange={(e) => setAmount(e.target.value)}
-          disabled={loading}
-        />
-        <button
-          onClick={handleSubmit}
-          disabled={!amount || loading}
-          className="btn-primary ppu-card__pay-btn"
-        >
-          {loading ? <Spinner size="sm" /> : "Pay now"}
-        </button>
+    return (
+      <div className="card">
+        <h3 className="ppu-card__title">Pay-per-use</h3>
+        <div className="ppu-card__row">
+          <input
+            ref={ref}
+            type="number"
+            min="0.0000001"
+            step="0.0000001"
+            placeholder="Amount in XLM"
+            value={amount}
+            onChange={(e) => setAmount(e.target.value)}
+            disabled={loading}
+          />
+          <button
+            onClick={handleSubmit}
+            disabled={!amount || loading}
+            className="btn-primary ppu-card__pay-btn"
+          >
+            {loading ? <Spinner size="sm" /> : "Pay now"}
+          </button>
+        </div>
       </div>
-    </div>
-  );
-}
+    );
+  }
+);
+
+PayPerUseForm.displayName = "PayPerUseForm";
+
+export default PayPerUseForm;

--- a/frontend/src/components/SubscribeForm.tsx
+++ b/frontend/src/components/SubscribeForm.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo, useState } from "react";
 import { StrKey } from "@stellar/stellar-sdk";
-import { StrKey } from "@stellar/stellar-sdk";
-import { buildSubscribeTx, DEFAULT_TOKEN, DEFAULT_TOKEN } from "../stellar";
+import { buildSubscribeTx, DEFAULT_TOKEN } from "../stellar";
 import { friendlyError } from "../utils/errors";
 import { STROOPS_PER_XLM, BILLING_INTERVALS } from "../constants";
 import { useFormValidation } from "../hooks/useFormValidation";


### PR DESCRIPTION
Closes #279

---

Adds the 'p' keyboard shortcut to focus the pay-per-use amount input when an active subscription exists, and adds the shortcut to the help modal. Also fixes pre-existing duplicate import errors in SubscribeForm.tsx.