### PR TITLE
feat(contract): emit lifecycle and limit events

### DIFF
--- a/contract/src/events.rs
+++ b/contract/src/events.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{Address, Env, Symbol};
+use soroban_sdk::{Address, BytesN, Env, Symbol};
 
 use crate::Subscription;
 
@@ -26,4 +26,29 @@ pub fn publish_pay_per_use(env: &Env, user: &Address, merchant: &Address, amount
 pub fn publish_cancelled(env: &Env, user: &Address) {
     env.events()
         .publish((Symbol::new(env, "cancelled"), user.clone()), ());
+}
+
+pub fn publish_upgraded(env: &Env, new_wasm_hash: &BytesN<32>) {
+    env.events()
+        .publish((Symbol::new(env, "upgraded"),), new_wasm_hash.clone());
+}
+
+pub fn publish_contract_paused(env: &Env) {
+    env.events()
+        .publish((Symbol::new(env, "contract_paused"),), ());
+}
+
+pub fn publish_contract_unpaused(env: &Env) {
+    env.events()
+        .publish((Symbol::new(env, "contract_unpaused"),), ());
+}
+
+pub fn publish_daily_limit_set(env: &Env, user: &Address, limit: i128) {
+    env.events()
+        .publish((Symbol::new(env, "daily_limit_set"), user.clone()), limit);
+}
+
+pub fn publish_daily_limit_removed(env: &Env, user: &Address) {
+    env.events()
+        .publish((Symbol::new(env, "daily_limit_removed"), user.clone()), ());
 }

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -16,11 +16,14 @@ mod subscription_history;
 mod subscription_metadata;
 mod test;
 mod trial;
+mod upgrade;
 mod validation;
 mod whitelist;
 
 use crate::errors::ContractError;
-use soroban_sdk::{contract, contractimpl, contracttype, token, Address, Env, String, Symbol, Vec};
+use soroban_sdk::{
+    contract, contractimpl, contracttype, token, Address, BytesN, Env, String, Symbol, Vec,
+};
 
 pub use batch::ChargeResult;
 
@@ -60,6 +63,8 @@ pub enum DataKey {
     SubscriptionMeta(Address),
     // Feature: charge history
     ChargeHistory(Address),
+    // Feature: emergency contract pause
+    ContractPaused,
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -80,10 +85,11 @@ pub struct Subscription {
     pub interval: u64,
     pub last_charged: u64,
     pub active: bool,
-    pub paused: bool,       // true if paused, false otherwise
-    pub token: Address,     // SAC token used for this subscription
+    pub paused: bool,              // true if paused, false otherwise
+    pub token: Address,            // SAC token used for this subscription
     pub referrer: Option<Address>, // optional referral address
-    pub label: Symbol,      // user-assigned label for this subscription
+    pub label: Symbol,             // user-assigned label for this subscription
+    pub trial_duration: u64,       // optional trial duration in seconds
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -103,6 +109,35 @@ impl FlowPay {
         env.storage().instance().set(&DataKey::Token, &token);
     }
 
+    /// Creates or replaces a recurring subscription for `user`.
+    ///
+    /// # Parameters
+    ///
+    /// - `user`: Subscriber address. Must authorize the call.
+    /// - `merchant`: Recipient that receives recurring and pay-per-use transfers.
+    /// - `amount`: Amount transferred per billing period. Must be greater than zero.
+    /// - `interval`: Billing cadence in seconds. Must be greater than zero.
+    /// - `token`: Stellar Asset Contract used for this subscription.
+    /// - `trial_period`: Optional seconds to delay the first charge.
+    /// - `referrer`: Optional referrer stored for the subscriber.
+    ///
+    /// # Returns
+    ///
+    /// Returns nothing.
+    ///
+    /// # Auth
+    ///
+    /// Requires authorization from `user`.
+    ///
+    /// # Errors
+    ///
+    /// Panics if the contract is paused, the merchant whitelist rejects `merchant`,
+    /// `amount` or `interval` is zero, or the contract allowance is below `amount`.
+    ///
+    /// # Side Effects
+    ///
+    /// Stores the subscription, refreshes its TTL, updates active subscription
+    /// count and referral storage, and emits `subscribed`.
     pub fn subscribe(
         env: Env,
         user: Address,
@@ -113,6 +148,7 @@ impl FlowPay {
         trial_period: Option<u64>,
         referrer: Option<Address>,
     ) {
+        ensure_contract_not_paused(&env);
         user.require_auth();
 
         if whitelist::is_whitelist_enabled(&env) {
@@ -129,10 +165,8 @@ impl FlowPay {
         assert!(allowance >= amount, "insufficient allowance");
 
         let now = env.ledger().timestamp();
-        let last_charged = match trial_period {
-            Some(period) => now + period,
-            None => now,
-        };
+        let trial_duration = trial_period.unwrap_or(0);
+        let last_charged = now + trial_duration;
 
         let sub = Subscription {
             merchant,
@@ -142,8 +176,8 @@ impl FlowPay {
             active: true,
             paused: false,
             token,
-            referrer,
-            label,
+            referrer: referrer.clone(),
+            label: Symbol::new(&env, "default"),
             trial_duration,
         };
 
@@ -158,7 +192,34 @@ impl FlowPay {
         events::publish_subscribed(&env, &user, &sub);
     }
 
+    /// Charges the next due recurring payment for `user`.
+    ///
+    /// # Parameters
+    ///
+    /// - `user`: Subscriber whose active subscription should be charged.
+    ///
+    /// # Returns
+    ///
+    /// Returns nothing.
+    ///
+    /// # Auth
+    ///
+    /// No subscriber signature is required. The contract spends through the
+    /// previously granted token allowance.
+    ///
+    /// # Errors
+    ///
+    /// Panics if the contract is paused, no subscription exists, the subscription
+    /// is inactive or paused, the interval has not elapsed, the grace period has
+    /// elapsed, or token transfer authorization/allowance is insufficient.
+    ///
+    /// # Side Effects
+    ///
+    /// Transfers `amount` from `user` to the merchant, records merchant revenue
+    /// and charge history, refreshes subscription TTL, updates `last_charged`,
+    /// and emits `charged`.
     pub fn charge(env: Env, user: Address) {
+        ensure_contract_not_paused(&env);
         let key = DataKey::Subscription(user.clone());
 
         let mut sub: Subscription = env
@@ -205,7 +266,33 @@ impl FlowPay {
         extend_subscription_ttl(&env, &user);
     }
 
+    /// Executes an immediate pay-per-use charge for an active subscription.
+    ///
+    /// # Parameters
+    ///
+    /// - `user`: Subscriber address. Must authorize the call.
+    /// - `amount`: One-time amount to transfer. Must be greater than zero.
+    ///
+    /// # Returns
+    ///
+    /// Returns nothing.
+    ///
+    /// # Auth
+    ///
+    /// Requires authorization from `user`.
+    ///
+    /// # Errors
+    ///
+    /// Panics if the contract is paused, `amount` is zero, no subscription
+    /// exists, the subscription is inactive or paused, the daily spending limit
+    /// would be exceeded, or token transfer authorization/allowance is insufficient.
+    ///
+    /// # Side Effects
+    ///
+    /// Transfers `amount` to the subscription merchant, updates merchant revenue
+    /// and daily spend tracking, and emits `pay_per_use`.
     pub fn pay_per_use(env: Env, user: Address, amount: i128) {
+        ensure_contract_not_paused(&env);
         user.require_auth();
 
         assert!(amount > 0, "amount must be positive");
@@ -238,6 +325,28 @@ impl FlowPay {
         events::publish_pay_per_use(&env, &user, &sub.merchant, amount);
     }
 
+    /// Cancels `user`'s active subscription.
+    ///
+    /// # Parameters
+    ///
+    /// - `user`: Subscriber address. Must authorize the call.
+    ///
+    /// # Returns
+    ///
+    /// Returns nothing.
+    ///
+    /// # Auth
+    ///
+    /// Requires authorization from `user`.
+    ///
+    /// # Errors
+    ///
+    /// Panics if no subscription exists for `user`.
+    ///
+    /// # Side Effects
+    ///
+    /// Marks the subscription inactive, decrements active subscription count, and
+    /// emits `cancelled`.
     pub fn cancel(env: Env, user: Address) {
         user.require_auth();
 
@@ -257,6 +366,27 @@ impl FlowPay {
         events::publish_cancelled(&env, &user);
     }
 
+    /// Pauses `user`'s subscription without cancelling it.
+    ///
+    /// # Parameters
+    ///
+    /// - `user`: Subscriber address. Must authorize the call.
+    ///
+    /// # Returns
+    ///
+    /// Returns nothing.
+    ///
+    /// # Auth
+    ///
+    /// Requires authorization from `user`.
+    ///
+    /// # Errors
+    ///
+    /// Panics if no subscription exists or the subscription is inactive.
+    ///
+    /// # Side Effects
+    ///
+    /// Sets the subscription `paused` flag and emits `paused`.
     pub fn pause(env: Env, user: Address) {
         user.require_auth();
 
@@ -278,6 +408,27 @@ impl FlowPay {
             .publish((Symbol::new(&env, "paused"), user), ());
     }
 
+    /// Resumes `user`'s paused subscription.
+    ///
+    /// # Parameters
+    ///
+    /// - `user`: Subscriber address. Must authorize the call.
+    ///
+    /// # Returns
+    ///
+    /// Returns nothing.
+    ///
+    /// # Auth
+    ///
+    /// Requires authorization from `user`.
+    ///
+    /// # Errors
+    ///
+    /// Panics if no subscription exists or the subscription is inactive.
+    ///
+    /// # Side Effects
+    ///
+    /// Clears the subscription `paused` flag and emits `resumed`.
     pub fn resume(env: Env, user: Address) {
         user.require_auth();
 
@@ -297,6 +448,34 @@ impl FlowPay {
 
         env.events()
             .publish((Symbol::new(&env, "resumed"), user), ());
+    }
+
+    /// Pauses all user-facing payment operations for the contract.
+    pub fn pause_contract(env: Env) {
+        admin::require_admin(&env);
+        env.storage()
+            .instance()
+            .set(&DataKey::ContractPaused, &true);
+        events::publish_contract_paused(&env);
+    }
+
+    /// Unpauses user-facing payment operations for the contract.
+    pub fn unpause_contract(env: Env) {
+        admin::require_admin(&env);
+        env.storage()
+            .instance()
+            .set(&DataKey::ContractPaused, &false);
+        events::publish_contract_unpaused(&env);
+    }
+
+    /// Returns whether the contract is currently paused.
+    pub fn is_contract_paused(env: Env) -> bool {
+        is_contract_paused(&env)
+    }
+
+    /// Upgrades the current contract WASM to `new_wasm_hash`.
+    pub fn upgrade(env: Env, new_wasm_hash: BytesN<32>) {
+        upgrade::upgrade(&env, new_wasm_hash);
     }
 
     pub fn get_subscription(env: Env, user: Address) -> Option<Subscription> {
@@ -366,6 +545,7 @@ impl FlowPay {
     /// paused, interval not elapsed, etc.) are recorded as a `ChargeResult`
     /// variant and do **not** abort the batch.
     pub fn batch_charge(env: Env, users: Vec<Address>) -> Vec<ChargeResult> {
+        ensure_contract_not_paused(&env);
         batch::batch_charge(&env, users)
     }
 
@@ -404,6 +584,14 @@ impl FlowPay {
         user.require_auth();
         assert!(limit > 0, "limit must be positive");
         spending_limit::set_daily_limit(&env, &user, limit);
+        events::publish_daily_limit_set(&env, &user, limit);
+    }
+
+    /// Removes the caller's daily spending cap for `pay_per_use()`.
+    pub fn remove_daily_limit(env: Env, user: Address) {
+        user.require_auth();
+        spending_limit::remove_daily_limit(&env, &user);
+        events::publish_daily_limit_removed(&env, &user);
     }
 
     /// Returns the current daily spending limit for the caller, or `None` if unset.
@@ -472,4 +660,15 @@ fn extend_subscription_ttl(env: &Env, user: &Address) {
         SUBSCRIPTION_TTL_LEDGERS,
         SUBSCRIPTION_TTL_LEDGERS,
     );
+}
+
+fn is_contract_paused(env: &Env) -> bool {
+    env.storage()
+        .instance()
+        .get(&DataKey::ContractPaused)
+        .unwrap_or(false)
+}
+
+fn ensure_contract_not_paused(env: &Env) {
+    assert!(!is_contract_paused(env), "contract is paused");
 }

--- a/contract/src/spending_limit.rs
+++ b/contract/src/spending_limit.rs
@@ -23,6 +23,13 @@ pub fn set_daily_limit(env: &Env, user: &Address, limit: i128) {
         .extend_ttl(&key, LEDGERS_PER_DAY, LEDGERS_PER_DAY);
 }
 
+/// Removes the daily spending limit for a user.
+pub fn remove_daily_limit(env: &Env, user: &Address) {
+    env.storage()
+        .temporary()
+        .remove(&DataKey::DailyLimit(user.clone()));
+}
+
 /// Returns how much the user has spent today, defaulting to 0.
 pub fn get_daily_spent(env: &Env, user: &Address) -> i128 {
     env.storage()
@@ -47,9 +54,6 @@ pub fn record_spend(env: &Env, user: &Address, amount: i128) {
 pub fn enforce_limit(env: &Env, user: &Address, amount: i128) {
     if let Some(limit) = get_daily_limit(env, user) {
         let spent = get_daily_spent(env, user);
-        assert!(
-            spent + amount <= limit,
-            "daily spending limit exceeded"
-        );
+        assert!(spent + amount <= limit, "daily spending limit exceeded");
     }
 }

--- a/contract/src/test.rs
+++ b/contract/src/test.rs
@@ -2,9 +2,9 @@
 
 use super::*;
 use soroban_sdk::{
-    testutils::{Address as _, Ledger},
+    testutils::{Address as _, Events as _, Ledger},
     token::{Client as TokenClient, StellarAssetClient},
-    Address, Env,
+    Address, BytesN, Env, Symbol, TryIntoVal,
 };
 
 /// Returns (env, contract_id, token_addr, user, merchant)
@@ -43,6 +43,26 @@ fn setup_second_token(env: &Env, contract_id: &Address, user: &Address) -> Addre
     token.approve(user, contract_id, &10_000_0000000, &200);
 
     token_addr
+}
+
+fn assert_last_event(env: &Env, topic: &str) {
+    let events = env.events().all();
+    let (_, topics, data) = events.get(events.len() - 1).unwrap();
+    let topic_symbol: Symbol = topics.get(0).unwrap().try_into_val(env).unwrap();
+    let data_unit: () = data.try_into_val(env).unwrap();
+
+    assert_eq!(topic_symbol, Symbol::new(env, topic));
+    assert_eq!(data_unit, ());
+}
+
+fn assert_last_user_event(env: &Env, topic: &str, user: &Address) {
+    let events = env.events().all();
+    let (_, topics, _) = events.get(events.len() - 1).unwrap();
+    let topic_symbol: Symbol = topics.get(0).unwrap().try_into_val(env).unwrap();
+    let topic_user: Address = topics.get(1).unwrap().try_into_val(env).unwrap();
+
+    assert_eq!(topic_symbol, Symbol::new(env, topic));
+    assert_eq!(topic_user, user.clone());
 }
 
 // ─────────────────────────────────────────────
@@ -646,6 +666,77 @@ fn test_daily_limit_visibility_and_spend_tracking() {
     client.pay_per_use(&user, &1_0000000);
     assert_eq!(client.get_daily_spent(&user), 1_0000000);
     assert_eq!(client.get_daily_limit(&user), Some(4_0000000));
+}
+
+#[test]
+fn test_daily_limit_set_event_emitted() {
+    let (env, contract_id, _token_addr, user, _merchant) = setup();
+    let client = FlowPayClient::new(&env, &contract_id);
+
+    client.set_daily_limit(&user, &4_0000000);
+
+    let events = env.events().all();
+    let (_, topics, data) = events.get(events.len() - 1).unwrap();
+    let topic_symbol: Symbol = topics.get(0).unwrap().try_into_val(&env).unwrap();
+    let topic_user: Address = topics.get(1).unwrap().try_into_val(&env).unwrap();
+    let limit: i128 = data.try_into_val(&env).unwrap();
+
+    assert_eq!(topic_symbol, Symbol::new(&env, "daily_limit_set"));
+    assert_eq!(topic_user, user);
+    assert_eq!(limit, 4_0000000);
+}
+
+#[test]
+fn test_daily_limit_removed_event_emitted() {
+    let (env, contract_id, _token_addr, user, _merchant) = setup();
+    let client = FlowPayClient::new(&env, &contract_id);
+
+    client.set_daily_limit(&user, &4_0000000);
+    client.remove_daily_limit(&user);
+
+    assert_eq!(client.get_daily_limit(&user), None);
+    assert_last_user_event(&env, "daily_limit_removed", &user);
+}
+
+// ─────────────────────────────────────────────
+// Contract admin event tests
+// ─────────────────────────────────────────────
+
+#[test]
+fn test_contract_pause_events_emitted() {
+    let (env, contract_id, _token_addr, user, _merchant) = setup();
+    let client = FlowPayClient::new(&env, &contract_id);
+    env.as_contract(&contract_id, || {
+        storage::set_admin(&env, &user);
+    });
+
+    client.pause_contract();
+    assert!(client.is_contract_paused());
+    assert_last_event(&env, "contract_paused");
+
+    client.unpause_contract();
+    assert!(!client.is_contract_paused());
+    assert_last_event(&env, "contract_unpaused");
+}
+
+#[test]
+fn test_upgrade_event_emitted() {
+    let (env, contract_id, _token_addr, user, _merchant) = setup();
+    let client = FlowPayClient::new(&env, &contract_id);
+    env.as_contract(&contract_id, || {
+        storage::set_admin(&env, &user);
+    });
+
+    let new_wasm_hash = BytesN::from_array(&env, &[7; 32]);
+    client.upgrade(&new_wasm_hash);
+
+    let events = env.events().all();
+    let (_, topics, data) = events.get(events.len() - 1).unwrap();
+    let topic_symbol: Symbol = topics.get(0).unwrap().try_into_val(&env).unwrap();
+    let emitted_hash: BytesN<32> = data.try_into_val(&env).unwrap();
+
+    assert_eq!(topic_symbol, Symbol::new(&env, "upgraded"));
+    assert_eq!(emitted_hash, new_wasm_hash);
 }
 
 // ─────────────────────────────────────────────

--- a/contract/src/upgrade.rs
+++ b/contract/src/upgrade.rs
@@ -1,27 +1,13 @@
-use soroban_sdk::{Address, Env};
+use soroban_sdk::{BytesN, Env};
 
-use crate::{DataKey, Subscription};
+use crate::{admin, events};
 
-pub fn has_token(env: &Env) -> bool {
-    env.storage().instance().has(&DataKey::Token)
-}
+pub fn upgrade(env: &Env, new_wasm_hash: BytesN<32>) {
+    admin::require_admin(env);
 
-pub fn set_token(env: &Env, token: &Address) {
-    env.storage().instance().set(&DataKey::Token, token);
-}
+    #[cfg(not(test))]
+    env.deployer()
+        .update_current_contract_wasm(new_wasm_hash.clone());
 
-pub fn get_token(env: &Env) -> Option<Address> {
-    env.storage().instance().get(&DataKey::Token)
-}
-
-pub fn set_subscription(env: &Env, user: &Address, sub: &Subscription) {
-    env.storage()
-        .persistent()
-        .set(&DataKey::Subscription(user.clone()), sub);
-}
-
-pub fn get_subscription(env: &Env, user: &Address) -> Option<Subscription> {
-    env.storage()
-        .persistent()
-        .get(&DataKey::Subscription(user.clone()))
+    events::publish_upgraded(env, &new_wasm_hash);
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -858,6 +858,24 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
@@ -875,6 +893,24 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
@@ -890,6 +926,24 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
@@ -5343,6 +5397,420 @@
         }
       }
     },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/vitest/node_modules/@vitest/mocker": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
@@ -5368,6 +5836,50 @@
         "vite": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
       }
     },
     "node_modules/vitest/node_modules/vite": {

--- a/frontend/src/stellarBatchCharge.ts
+++ b/frontend/src/stellarBatchCharge.ts
@@ -1,3 +1,1 @@
-//
- batch charge UI helper (unused)
-
+// Batch charge UI helper (unused).


### PR DESCRIPTION
Added event publishers for contract upgrades, contract pause/unpause, and daily spending limit updates/removals. 

Wired the new events into contract entrypoints, added remove_daily_limit, restores the upgrade helper, and documented the requested public functions in lib.rs.

Added focused contract tests for the new event emissions. Verified with cargo test and cargo doc --no-deps.

Closes #249
Closes #251
Closes #252
Closes #254