### PR TITLE
closes #226 closes #242 closes #271 closes #278: pause tests, last_charged test, CSV export, IntervalSelector

### DIFF
--- a/contract/src/test.rs
+++ b/contract/src/test.rs
@@ -2493,3 +2493,142 @@ fn test_next_charge_at_none_for_unknown_address() {
     let random = Address::generate(&env);
     assert!(client.next_charge_at(&random).is_none());
 }
+
+// ─────────────────────────────────────────────
+// Issue #242: last_charged accuracy after multiple charges
+// ─────────────────────────────────────────────
+
+/// After three charge cycles at different timestamps, last_charged must equal
+/// the ledger timestamp of the **most recent** successful charge exactly.
+/// It must not accumulate offsets or reflect any earlier charge time.
+#[test]
+fn test_last_charged_accuracy_after_multiple_charges() {
+    let (env, contract_id, token_addr, user, merchant) = setup();
+    let client = FlowPayClient::new(&env, &contract_id);
+
+    let amount: i128 = 1_0000000;
+    let interval: u64 = 86_400; // 1 day
+
+    client.subscribe(&user, &merchant, &amount, &interval, &token_addr, &None, &None);
+
+    // ── Charge 1 ──────────────────────────────────────────────────────────────
+    env.ledger().with_mut(|l| { l.timestamp += interval + 1; });
+    let ts_charge_1 = env.ledger().timestamp();
+    client.charge(&user);
+    let sub_1 = client.get_subscription(&user).unwrap();
+    assert_eq!(
+        sub_1.last_charged, ts_charge_1,
+        "after charge 1: last_charged should equal the charge timestamp"
+    );
+
+    // ── Charge 2 (at a different offset to rule out coincidental equality) ───
+    env.ledger().with_mut(|l| { l.timestamp += interval + 7_777; });
+    let ts_charge_2 = env.ledger().timestamp();
+    assert_ne!(ts_charge_2, ts_charge_1, "charge 2 must be at a different timestamp");
+    client.charge(&user);
+    let sub_2 = client.get_subscription(&user).unwrap();
+    assert_eq!(
+        sub_2.last_charged, ts_charge_2,
+        "after charge 2: last_charged should equal the second charge timestamp"
+    );
+
+    // ── Charge 3 ──────────────────────────────────────────────────────────────
+    env.ledger().with_mut(|l| { l.timestamp += interval + 999; });
+    let ts_charge_3 = env.ledger().timestamp();
+    assert_ne!(ts_charge_3, ts_charge_2, "charge 3 must be at a different timestamp");
+    client.charge(&user);
+    let sub_3 = client.get_subscription(&user).unwrap();
+    assert_eq!(
+        sub_3.last_charged, ts_charge_3,
+        "after charge 3: last_charged should equal the third charge timestamp, not an accumulated offset"
+    );
+
+    // Confirm it does NOT equal earlier charge timestamps
+    assert_ne!(sub_3.last_charged, ts_charge_1, "last_charged must not be ts_charge_1");
+    assert_ne!(sub_3.last_charged, ts_charge_2, "last_charged must not be ts_charge_2");
+}
+
+// ─────────────────────────────────────────────
+// Issue #226: pause_contract() emergency stop
+// ─────────────────────────────────────────────
+
+/// charge() is blocked while the contract is paused and succeeds after unpause.
+#[test]
+fn test_charge_blocked_when_contract_paused() {
+    let (env, contract_id, token_addr, user, merchant) = setup();
+    let client = FlowPayClient::new(&env, &contract_id);
+
+    // Set caller as admin so pause/unpause are authorised
+    env.as_contract(&contract_id, || {
+        storage::set_admin(&env, &user);
+    });
+
+    let amount: i128 = 1_0000000;
+    let interval: u64 = 86_400;
+
+    client.subscribe(&user, &merchant, &amount, &interval, &token_addr, &None, &None);
+
+    // Advance past interval so a charge would normally be valid
+    env.ledger().with_mut(|l| { l.timestamp += interval + 1; });
+
+    // Pause the contract
+    client.pause_contract();
+    assert!(client.is_contract_paused(), "contract should be paused");
+
+    // charge() must panic with ContractPaused while paused
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.charge(&user);
+    }));
+    assert!(result.is_err(), "charge() should panic when contract is paused");
+}
+
+/// charge() succeeds immediately after the contract is unpaused.
+#[test]
+fn test_charge_succeeds_after_unpause() {
+    let (env, contract_id, token_addr, user, merchant) = setup();
+    let client = FlowPayClient::new(&env, &contract_id);
+
+    env.as_contract(&contract_id, || {
+        storage::set_admin(&env, &user);
+    });
+
+    let amount: i128 = 1_0000000;
+    let interval: u64 = 86_400;
+
+    client.subscribe(&user, &merchant, &amount, &interval, &token_addr, &None, &None);
+
+    env.ledger().with_mut(|l| { l.timestamp += interval + 1; });
+
+    // Pause then immediately unpause
+    client.pause_contract();
+    assert!(client.is_contract_paused());
+    client.unpause_contract();
+    assert!(!client.is_contract_paused(), "contract should be unpaused");
+
+    // charge() must succeed after unpause
+    client.charge(&user);
+    let sub = client.get_subscription(&user).unwrap();
+    assert!(sub.last_charged > 0, "last_charged should be updated after successful charge post-unpause");
+}
+
+/// pay_per_use() is also blocked while the contract is paused.
+#[test]
+fn test_pay_per_use_blocked_when_contract_paused() {
+    let (env, contract_id, token_addr, user, merchant) = setup();
+    let client = FlowPayClient::new(&env, &contract_id);
+
+    env.as_contract(&contract_id, || {
+        storage::set_admin(&env, &user);
+    });
+
+    client.subscribe(&user, &merchant, &1_0000000, &86_400, &token_addr, &None, &None);
+
+    client.pause_contract();
+    assert!(client.is_contract_paused());
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.pay_per_use(&user, &5_000_000);
+    }));
+    assert!(result.is_err(), "pay_per_use() should panic when contract is paused");
+}
+

--- a/frontend/src/components/SubscribeForm.tsx
+++ b/frontend/src/components/SubscribeForm.tsx
@@ -2,13 +2,14 @@ import React, { useMemo, useState } from "react";
 import { StrKey } from "@stellar/stellar-sdk";
 import { buildSubscribeTx, DEFAULT_TOKEN } from "../stellar";
 import { friendlyError } from "../utils/errors";
-import { STROOPS_PER_XLM, BILLING_INTERVALS } from "../constants";
+import { STROOPS_PER_XLM, BILLING_INTERVALS } from "../constants"; // BILLING_INTERVALS used for initial value
 import { useFormValidation } from "../hooks/useFormValidation";
 import { useToast } from "../hooks/useToast";
 import { useTransaction } from "../hooks/useTransaction";
 import BalanceDisplay from "./BalanceDisplay";
 import AllowanceDisplay from "./AllowanceDisplay";
 import ToastContainer from "./Toast";
+import IntervalSelector from "./IntervalSelector";
 
 interface Props {
   userKey: string;
@@ -103,17 +104,9 @@ export default function SubscribeForm({ userKey, onSign, onSuccess, announce, on
         )}
       </label>
 
-      <label className="form-group">
-        <span className="form-label">Billing interval</span>
-        <select value={interval} onChange={(e) => setInterval(Number(e.target.value))}>
-          {BILLING_INTERVALS.map((i) => (
-            <option key={i.value} value={i.value}>
-              {i.label}
-            </option>
-          ))}
-        </select>
-        {errors.interval && <span className="text-error">{errors.interval}</span>}
-      </label>
+      {/* #278 — Use dedicated IntervalSelector instead of inline <select> */}
+      <IntervalSelector value={interval} onChange={setInterval} />
+      {errors.interval && <span className="text-error">{errors.interval}</span>}
 
       <button type="submit" disabled={pending} className="btn-primary subscribe-form__submit">
         {pending ? "Confirming…" : "Subscribe"}

--- a/frontend/src/components/SubscriptionHistory.tsx
+++ b/frontend/src/components/SubscriptionHistory.tsx
@@ -27,6 +27,41 @@ function truncateHash(hash: string): string {
   return `${hash.slice(0, 6)}…${hash.slice(-4)}`;
 }
 
+// ─── CSV export helper ────────────────────────────────────────────────────────
+
+/** Wrap a cell value in double-quotes and escape any internal quotes. */
+function csvCell(value: string): string {
+  return `"${value.replace(/"/g, '""')}"`;
+}
+
+/**
+ * Build a CSV string from charge events and trigger a browser download.
+ * Columns: Date, Amount (XLM), TX Hash, Merchant
+ */
+function exportToCsv(events: ChargeEvent[]): void {
+  const header = ["Date", "Amount (XLM)", "TX Hash", "Merchant"].map(csvCell).join(",");
+
+  const rows = events.map((event) => {
+    const date = event.date.toISOString().slice(0, 10); // YYYY-MM-DD, locale-independent
+    const xlm = (Number(event.amount) / STROOPS_PER_XLM).toFixed(7);
+    return [date, xlm, event.txHash, event.merchant].map(csvCell).join(",");
+  });
+
+  const csv = [header, ...rows].join("\r\n");
+  const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+  const url = URL.createObjectURL(blob);
+
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = `payflow-charge-history-${new Date().toISOString().slice(0, 10)}.csv`;
+  link.click();
+
+  // Clean up the object URL after the download is triggered
+  URL.revokeObjectURL(url);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
 export default function SubscriptionHistory({ userKey }: Props) {
   const { events: contractEvents, loading, error, refresh } = useContractEvents("charged", userKey);
 
@@ -102,7 +137,29 @@ export default function SubscriptionHistory({ userKey }: Props) {
 
   return (
     <div className="card">
-      <h3 className="subscription-card__title">Charge History</h3>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          marginBottom: "var(--space-2)",
+        }}
+      >
+        <h3 className="subscription-card__title" style={{ margin: 0 }}>
+          Charge History
+        </h3>
+        {/* #271 — Export CSV button; disabled when no events */}
+        <button
+          className="btn-secondary"
+          onClick={() => exportToCsv(events)}
+          disabled={events.length === 0}
+          aria-label="Export charge history as CSV"
+          title="Download charge history as a CSV file"
+        >
+          Export CSV
+        </button>
+      </div>
+
       <div className="charge-history-list" role="list">
         {events.map((event, index) => (
           <div


### PR DESCRIPTION
closes #226
closes #242
closes #271
closes #278

## Summary

### closes #271 — Add SubscriptionHistory export to CSV
Adds `exportToCsv()` to `SubscriptionHistory.tsx`. Builds a four-column CSV (Date, Amount (XLM), TX Hash, Merchant) from `ChargeEvent[]` and triggers a browser download via Blob URL. Dates are YYYY-MM-DD (ISO, locale-independent). Cell values are double-quoted with internal quote escaping. Object URL is revoked immediately. An **Export CSV** button is added to the card header, disabled when `events.length === 0`.

### closes #278 — Add IntervalSelector to SubscribeForm
Replaces the duplicated inline `<select>` + `BILLING_INTERVALS.map()` block in `SubscribeForm.tsx` with the dedicated `<IntervalSelector>` component. `value` and `onChange` are wired directly to the existing `interval` state. The interval validation error span is preserved. Duplicate interval logic removed.

### closes #242 — Add charge() test for exact last_charged after multiple charges
Adds `test_last_charged_accuracy_after_multiple_charges` in `contract/src/test.rs`. Charges three times at deliberately distinct timestamps (`+interval+1`, `+interval+7777`, `+interval+999`) and asserts `last_charged` equals each charge timestamp exactly. After the third charge also asserts `last_charged != ts_charge_1` and `!= ts_charge_2`.

### closes #226 — Add pause_contract() emergency stop tests
Adds three tests:
- `test_charge_blocked_when_contract_paused` — advances past interval, pauses contract, asserts `charge()` panics.
- `test_charge_succeeds_after_unpause` — pauses then unpauses, asserts `charge()` succeeds and `last_charged` is updated.
- `test_pay_per_use_blocked_when_contract_paused` — asserts `pay_per_use()` also panics when paused, confirming all charge paths respect the global flag.

## Test plan
- [ ] `cd contract && cargo test` — all new and existing tests pass
- [ ] Open SubscriptionHistory with loaded events — Export CSV button is enabled and downloads a valid CSV
- [ ] Open SubscriptionHistory with no events — Export CSV button is disabled
- [ ] Open SubscribeForm — IntervalSelector renders with preset options and Custom input; form submits correctly
- [ ] Select Custom interval in SubscribeForm — custom days input appears and is used in the transaction