### PR TITLE
feat: implement v1 to v2 contract storage migration to include paused state for subscriptions

### DIFF
--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -663,8 +663,8 @@ impl FlowPay {
 
     /// Migrates contract storage to the latest schema version.
     /// Safe to call multiple times — subsequent calls are no-ops.
-    pub fn migrate(env: Env) {
-        migration::migrate(&env);
+    pub fn migrate(env: Env, users: Vec<Address>) {
+        migration::migrate(&env, users);
     }
 
     /// Returns the current storage schema version.

--- a/contract/src/migration.rs
+++ b/contract/src/migration.rs
@@ -1,6 +1,21 @@
-use soroban_sdk::Env;
+use soroban_sdk::{Address, Env, Vec};
 
-use crate::DataKey;
+use crate::{DataKey, Subscription};
+
+/// v1 Subscription format (missing `paused` field)
+#[soroban_sdk::contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct SubscriptionV1 {
+    pub merchant: Address,
+    pub amount: i128,
+    pub interval: u64,
+    pub last_charged: u64,
+    pub active: bool,
+    pub token: Address,
+    pub referrer: Option<Address>,
+    pub label: soroban_sdk::Symbol,
+    pub trial_duration: u64,
+}
 
 /// Current storage schema version.
 pub const CURRENT_VERSION: u32 = 2;
@@ -22,12 +37,11 @@ fn set_schema_version(env: &Env, version: u32) {
 
 /// Migrates contract storage from v1 to v2.
 ///
-/// v1 → v2: Introduces `SchemaVersion` tracking. No data shape changes;
-/// this migration simply stamps the version so future upgrades have a
-/// reliable baseline to branch from.
+/// v1 → v2: Introduces `SchemaVersion` tracking and transforms v1 Subscriptions to v2
+/// (adding `paused: false`).
 ///
 /// Safe to call multiple times — subsequent calls are no-ops.
-pub fn migrate(env: &Env) {
+pub fn migrate(env: &Env, users: Vec<Address>) {
     let version = get_schema_version(env);
 
     if version < 2 {
@@ -35,5 +49,26 @@ pub fn migrate(env: &Env) {
         set_schema_version(env, 2);
     }
 
-    // Future migrations: add `if version < 3 { ... }` blocks here.
+    // Transform provided users' data from v1 to v2
+    for user in users.into_iter() {
+        let key = DataKey::Subscription(user.clone());
+        
+        // Attempt to read the entry as a V1 subscription
+        if let Some(v1_sub) = env.storage().persistent().get::<_, SubscriptionV1>(&key) {
+            let v2_sub = Subscription {
+                merchant: v1_sub.merchant,
+                amount: v1_sub.amount,
+                interval: v1_sub.interval,
+                last_charged: v1_sub.last_charged,
+                active: v1_sub.active,
+                paused: false, // new field in v2
+                token: v1_sub.token,
+                referrer: v1_sub.referrer,
+                label: v1_sub.label,
+                trial_duration: v1_sub.trial_duration,
+            };
+            
+            env.storage().persistent().set(&key, &v2_sub);
+        }
+    }
 }

--- a/contract/src/test.rs
+++ b/contract/src/test.rs
@@ -805,6 +805,48 @@ fn test_contract_pause_events_emitted() {
     assert_last_event(&env, "contract_unpaused");
 }
 
+// ─────────────────────────────────────────────
+// Migration tests
+// ─────────────────────────────────────────────
+
+#[test]
+fn test_migrate_v1_to_v2() {
+    let (env, contract_id, token_addr, user, merchant) = setup();
+    let client = FlowPayClient::new(&env, &contract_id);
+
+    // Manually construct and store a V1 subscription
+    let v1_sub = crate::migration::SubscriptionV1 {
+        merchant: merchant.clone(),
+        amount: 1_0000000,
+        interval: 86400,
+        last_charged: env.ledger().timestamp(),
+        active: true,
+        token: token_addr.clone(),
+        referrer: None,
+        label: Symbol::new(&env, "v1_label"),
+        trial_duration: 0,
+    };
+    
+    env.as_contract(&contract_id, || {
+        env.storage()
+            .persistent()
+            .set(&crate::DataKey::Subscription(user.clone()), &v1_sub);
+    });
+
+    let mut users = soroban_sdk::Vec::new(&env);
+    users.push_back(user.clone());
+
+    client.migrate(&users);
+
+    // Verify it was upgraded to V2
+    let v2_sub = client.get_subscription(&user).unwrap();
+    assert_eq!(v2_sub.merchant, merchant);
+    assert_eq!(v2_sub.amount, 1_0000000);
+    assert_eq!(v2_sub.active, true);
+    assert_eq!(v2_sub.paused, false); // This is the newly added field
+    assert_eq!(v2_sub.label, Symbol::new(&env, "v1_label"));
+}
+
 #[test]
 fn test_upgrade_event_emitted() {
     let (env, contract_id, _token_addr, user, _merchant) = setup();

--- a/test_migration.rs
+++ b/test_migration.rs
@@ -1,0 +1,15 @@
+use soroban_sdk::{contracttype, Address, Symbol};
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct SubscriptionV1 {
+    pub merchant: Address,
+    pub amount: i128,
+    pub interval: u64,
+    pub last_charged: u64,
+    pub active: bool,
+    pub token: Address,
+    pub referrer: Option<Address>,
+    pub label: Symbol,
+    pub trial_duration: u64,
+}


### PR DESCRIPTION
I have successfully implemented the data transformation logic for the contract migration as requested. First, I checked out the `feat/migration-data-transform` branch. Then, I updated `contract/src/migration.rs` to include a `SubscriptionV1` struct (which represents the old schema without the `paused` field) and modified the `migrate` function to accept a batch of `users: Vec<Address>`. This function now iterates over the provided users, attempts to read their data as `SubscriptionV1`, and if successful, upgrades them to the current v2 `Subscription` struct by setting `paused: false`. I updated the main contract entry point in `contract/src/lib.rs` to expose this new parameter. Finally, I added a comprehensive test, `test_migrate_v1_to_v2`, in `contract/src/test.rs` that explicitly creates and stores a v1-style entry, calls the new `migrate` function, and asserts that the resulting storage is successfully transformed into the v2 format.


Close #223