### PR TITLE
feat: add clear_charge_history function to storage and expose via contract interface

### DIFF
--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -696,6 +696,12 @@ impl FlowPay {
     pub fn get_charge_history(env: Env, user: Address) -> Vec<u64> {
         subscription_history::get_charge_history(&env, &user)
     }
+
+    /// Clears the charge history for a subscriber.
+    pub fn clear_charge_history(env: Env, user: Address) {
+        user.require_auth();
+        subscription_history::clear_charge_history(&env, &user);
+    }
 }
 
 fn extend_subscription_ttl(env: &Env, user: &Address) {

--- a/contract/src/subscription_history.rs
+++ b/contract/src/subscription_history.rs
@@ -33,3 +33,11 @@ pub fn record_charge(env: &Env, user: &Address, timestamp: u64) {
         .persistent()
         .set(&DataKey::ChargeHistory(user.clone()), &history);
 }
+
+/// Clears the stored charge history for a subscriber.
+pub fn clear_charge_history(env: &Env, user: &Address) {
+    env.storage()
+        .persistent()
+        .remove(&DataKey::ChargeHistory(user.clone()));
+}
+

--- a/contract/src/test.rs
+++ b/contract/src/test.rs
@@ -942,6 +942,23 @@ fn test_charge_history_capped_at_12() {
 }
 
 #[test]
+fn test_clear_charge_history() {
+    let (env, contract_id, token_addr, user, merchant) = setup();
+    let client = FlowPayClient::new(&env, &contract_id);
+
+    let interval: u64 = 86400;
+    client.subscribe(&user, &merchant, &1_0000000, &interval, &token_addr, &None, &None);
+
+    env.ledger().with_mut(|l| { l.timestamp += interval + 1; });
+    client.charge(&user);
+
+    assert_eq!(client.get_charge_history(&user).len(), 1);
+
+    client.clear_charge_history(&user);
+    assert_eq!(client.get_charge_history(&user).len(), 0);
+}
+
+#[test]
 fn test_ttl_extension() {
     let (env, contract_id, token_addr, user, merchant) = setup();
     let client = FlowPayClient::new(&env, &contract_id);


### PR DESCRIPTION
## Here is a summary of what was done:

I checked out the branch `feat/clear-charge-history` and implemented the functionality to allow users to clear their charge history. Specifically, I added a `clear_charge_history` function in `contract/src/subscription_history.rs` that removes the `DataKey::ChargeHistory(user)` from persistent storage. Then, in `contract/src/lib.rs`, I exposed this via a public `clear_charge_history` function on the `FlowPay` contract, ensuring it calls `user.require_auth()` to enforce that only the respective user can clear their own data. Finally, I added a `test_clear_charge_history` test case in `contract/src/test.rs` which verifies that the charge history correctly resets to 0 length after the function is executed.

Close #212