### PR TITLE
test: add test snapshots for contract functionality and update test suite

### DIFF
--- a/contract/src/test.rs
+++ b/contract/src/test.rs
@@ -575,6 +575,29 @@ fn test_batch_charge_inactive() {
     assert_eq!(results.get(0).unwrap(), crate::ChargeResult::Inactive);
 }
 
+#[test]
+fn test_batch_charge_grace_period_elapsed() {
+    let (env, contract_id, token_addr, user, merchant) = setup();
+    let client = FlowPayClient::new(&env, &contract_id);
+
+    env.as_contract(&contract_id, || {
+        storage::set_admin(&env, &user);
+    });
+    client.set_grace_period(&86400);
+
+    let interval: u64 = 86400;
+    client.subscribe(&user, &merchant, &1_0000000, &interval, &token_addr, &None, &None);
+
+    // Advance ledger beyond interval + grace period
+    env.ledger().with_mut(|l| { l.timestamp += interval + 86400 + 1; });
+
+    let mut users = soroban_sdk::Vec::new(&env);
+    users.push_back(user.clone());
+
+    let results = client.batch_charge(&users);
+    assert_eq!(results.get(0).unwrap(), crate::ChargeResult::GracePeriodElapsed);
+}
+
 // ─────────────────────────────────────────────
 // subscription_count tests
 // ─────────────────────────────────────────────
@@ -1194,6 +1217,8 @@ fn test_custom_sac_token_end_to_end_flow() {
     // Verify subscription is still active after pay_per_use
     let sub_final = client.get_subscription(&user).unwrap();
     assert!(sub_final.active, "subscription should remain active after pay_per_use");
+}
+
 // ─────────────────────────────────────────────────────────────
 // Issue #237: get_token() read function tests
 // ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
I checked out the new `test/batch-charge-grace` branch and reviewed `contract/src/batch.rs`, confirming that the `ChargeResult::GracePeriodElapsed` variant and the logic to return it when the charge window expires were already correctly implemented. I then focused on the untested path by adding a new unit test, `test_batch_charge_grace_period_elapsed`, in `contract/src/test.rs` to verify that `batch_charge` properly returns this variant after the grace period has passed. During the process, I also fixed an existing syntax error (an unclosed delimiter) in `test.rs` and ran `cargo test` to ensure all 69 tests pass successfully.

Close #215