### PR TITLE
fix: rename BalanceDisplay prop to address (#276)

### DIFF
--- a/frontend/src/components/BalanceDisplay.tsx
+++ b/frontend/src/components/BalanceDisplay.tsx
@@ -3,10 +3,10 @@ import { getBalance } from "../stellar";
 import { formatXlm } from "../utils/format";
 
 interface BalanceDisplayProps {
-  publicKey: string;
+  address: string;
 }
 
-export default function BalanceDisplay({ publicKey }: BalanceDisplayProps) {
+export default function BalanceDisplay({ address }: BalanceDisplayProps) {
   const [balance, setBalance] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
 
@@ -16,7 +16,7 @@ export default function BalanceDisplay({ publicKey }: BalanceDisplayProps) {
     async function fetchBalance() {
       setLoading(true);
       try {
-        const bal = await getBalance(publicKey);
+        const bal = await getBalance(address);
         if (mounted) {
           setBalance(bal);
         }
@@ -34,7 +34,7 @@ export default function BalanceDisplay({ publicKey }: BalanceDisplayProps) {
     return () => {
       mounted = false;
     };
-  }, [publicKey]);
+  }, [address]);
 
   if (loading) {
     return <div className="skeleton balance-skeleton" />;

--- a/frontend/src/components/SubscribeForm.tsx
+++ b/frontend/src/components/SubscribeForm.tsx
@@ -78,7 +78,7 @@ export default function SubscribeForm({ userKey, onSign, onSuccess, announce }: 
         {errors.merchant && <span className="text-error">{errors.merchant}</span>}
       </label>
 
-      <BalanceDisplay publicKey={userKey} />
+      <BalanceDisplay address={userKey} />
 
       <label className="form-group">
         <span className="form-label">Amount (XLM per period)</span>

--- a/frontend/src/components/WalletBar.tsx
+++ b/frontend/src/components/WalletBar.tsx
@@ -25,7 +25,7 @@ export default function WalletBar({
             <CopyButton text={publicKey} ariaLabel="Copy wallet address" />
           </div>
         </div>
-        <BalanceDisplay publicKey={publicKey} />
+        <BalanceDisplay address={publicKey} />
         <NetworkBadge />
       </div>
       <button onClick={onDisconnect} className="btn-secondary">


### PR DESCRIPTION
This PR renames the 'publicKey' prop to 'address' in BalanceDisplay component to strictly follow the requirement in Issue #276. 

Closes #276 