### PR TITLE
style: improve wallet address copy button layout (#268)

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -749,3 +749,9 @@ input::placeholder {
     align-items: flex-start;
   }
 }
+
+.wallet-bar__address-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}


### PR DESCRIPTION
This PR adds the missing CSS for '.wallet-bar__address-row' to ensure the address and copy button are correctly aligned with a proper gap. Closes #268