### PR TITLE
refactor: centralize network passphrase in NetworkBadge (#267)

### DIFF
--- a/frontend/src/components/NetworkBadge.tsx
+++ b/frontend/src/components/NetworkBadge.tsx
@@ -1,11 +1,12 @@
 import React from "react";
+import { NETWORK_PASSPHRASE } from "../stellar";
 
 /**
  * NetworkBadge: displays Testnet or Mainnet label derived from NETWORK_PASSPHRASE (#59)
  * Uses .badge-testnet / .badge-mainnet CSS classes — zero inline styles.
  */
 export default function NetworkBadge() {
-  const passphrase = import.meta.env.VITE_NETWORK_PASSPHRASE || "Test SDF Network ; September 2015";
+  const passphrase = NETWORK_PASSPHRASE;
   const isMainnet = passphrase.includes("Public Global");
   const networkName = isMainnet ? "Mainnet" : "Testnet";
 


### PR DESCRIPTION
This PR refactors NetworkBadge to use the central NETWORK_PASSPHRASE constant from stellar.ts for consistency and easier maintenance. Closes #267