### PR TITLE
fix: prevent self-referral in subscribe() (#236)

### DIFF
--- a/contract/src/errors.rs
+++ b/contract/src/errors.rs
@@ -24,4 +24,6 @@ pub enum ContractError {
     GracePeriodElapsed = 9,
     /// Returned when a merchant is not whitelisted
     MerchantNotWhitelisted = 10,
+    /// Returned when a user attempts to refer themselves
+    SelfReferral = 11,
 }

--- a/contract/src/referral.rs
+++ b/contract/src/referral.rs
@@ -12,6 +12,9 @@ pub fn get_referrer(env: &Env, user: &Address) -> Option<Address> {
 /// Stores the referrer for a subscriber. No-op if referrer is None.
 pub fn store_referral(env: &Env, user: &Address, referrer: &Option<Address>) {
     if let Some(ref r) = referrer {
+        if r == user {
+            panic!("self referral not allowed");
+        }
         env.storage()
             .persistent()
             .set(&DataKey::Referral(user.clone()), r);


### PR DESCRIPTION
This PR adds a guard to prevent users from setting themselves as their own referrer, which could be used to game future reward programs. Closes #236