### PR TITLE
feat: add get_charge_history_page for pagination (#228)

### DIFF
--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -701,6 +701,17 @@ impl FlowPay {
     pub fn get_charge_history(env: Env, user: Address) -> Vec<u64> {
         subscription_history::get_charge_history(&env, &user)
     }
+
+    /// Returns a paginated slice of charge timestamps for a subscriber.
+    /// limit is capped at 12.
+    pub fn get_charge_history_page(
+        env: Env,
+        user: Address,
+        offset: u32,
+        limit: u32,
+    ) -> Vec<u64> {
+        subscription_history::get_charge_history_page(&env, &user, offset, limit)
+    }
 }
 
 fn extend_subscription_ttl(env: &Env, user: &Address) {

--- a/contract/src/subscription_history.rs
+++ b/contract/src/subscription_history.rs
@@ -33,3 +33,38 @@ pub fn record_charge(env: &Env, user: &Address, timestamp: u64) {
         .persistent()
         .set(&DataKey::ChargeHistory(user.clone()), &history);
 }
+
+/// Returns a paginated slice of charge timestamps for a subscriber.
+/// `limit` is capped at 12.
+pub fn get_charge_history_page(
+    env: &Env,
+    user: &Address,
+    offset: u32,
+    limit: u32,
+) -> Vec<u64> {
+    let history = get_charge_history(env, user);
+    let mut page = Vec::new(env);
+
+    let effective_limit = if limit > MAX_HISTORY {
+        MAX_HISTORY
+    } else {
+        limit
+    };
+
+    let total = history.len();
+    if offset >= total {
+        return page;
+    }
+
+    let end = if offset + effective_limit > total {
+        total
+    } else {
+        offset + effective_limit
+    };
+
+    for i in offset..end {
+        page.push_back(history.get(i).unwrap());
+    }
+
+    page
+}


### PR DESCRIPTION
This PR adds a paginated interface for retrieving charge history timestamps. It includes a new get_charge_history_page function that supports offset and limit parameters, with limit capped at 12. Closes #228