### PR TITLE
feat: add fee breakdown to charged event (#238)

### DIFF
--- a/contract/src/batch.rs
+++ b/contract/src/batch.rs
@@ -64,7 +64,7 @@ pub fn batch_charge(env: &Env, users: Vec<Address>) -> Vec<ChargeResult> {
                     sub.last_charged = now;
                     env.storage().persistent().set(&key, &sub);
 
-                    events::publish_charged(env, &user, &sub, now);
+                    events::publish_charged(env, &user, &sub, 0, now);
 
                     ChargeResult::Charged
                 }

--- a/contract/src/events.rs
+++ b/contract/src/events.rs
@@ -9,10 +9,27 @@ pub fn publish_subscribed(env: &Env, user: &Address, sub: &Subscription) {
     );
 }
 
-pub fn publish_charged(env: &Env, user: &Address, sub: &Subscription, charged_at: u64) {
+#[soroban_sdk::contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ChargeEventData {
+    pub merchant: Address,
+    pub gross: i128,
+    pub fee: i128,
+    pub net: i128,
+    pub charged_at: u64,
+}
+
+pub fn publish_charged(env: &Env, user: &Address, sub: &Subscription, fee_amount: i128, charged_at: u64) {
+    let net = sub.amount - fee_amount;
     env.events().publish(
         (Symbol::new(env, "charged"), user.clone()),
-        (sub.merchant.clone(), sub.amount, charged_at),
+        ChargeEventData {
+            merchant: sub.merchant.clone(),
+            gross: sub.amount,
+            fee: fee_amount,
+            net,
+            charged_at,
+        },
     );
 }
 

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -278,7 +278,7 @@ impl FlowPay {
         extend_subscription_ttl(&env, &user);
 
         subscription_history::record_charge(&env, &user, now);
-        events::publish_charged(&env, &user, &sub, now);
+        events::publish_charged(&env, &user, &sub, 0, now);
     }
 
     pub fn extend_subscription_ttl(env: Env, user: Address) {


### PR DESCRIPTION
This PR updates the 'charged' event to include a detailed fee breakdown, emitting gross, fee, and net amounts. This provides better transparency for indexers and users. Closes #238