### PR TITLE
feat: add opt-in analytics and protocol fee enforcement

### DIFF
--- a/contract/src/admin.rs
+++ b/contract/src/admin.rs
@@ -8,6 +8,11 @@ pub fn require_admin(env: &Env) {
     admin.require_auth();
 }
 
+pub fn initialize_admin(env: &Env, admin: &Address) {
+    admin.require_auth();
+    set_admin(env, admin);
+}
+
 /// Step 1: current admin proposes a new admin.
 /// The proposed address must call accept_admin() to complete the transfer.
 pub fn transfer_admin(env: &Env, new_admin: &Address) {

--- a/contract/src/fee.rs
+++ b/contract/src/fee.rs
@@ -12,6 +12,17 @@ pub fn get_fee_bps(env: &Env) -> u32 {
     env.storage().instance().get(&DataKey::FeeBps).unwrap_or(0)
 }
 
+/// Returns fee settings when both collector and non-zero bps are configured.
+pub fn get_fee(env: &Env) -> Option<(Address, u32)> {
+    let collector = get_fee_collector(env)?;
+    let bps = get_fee_bps(env);
+    if bps == 0 {
+        None
+    } else {
+        Some((collector, bps))
+    }
+}
+
 /// Sets the fee collector and basis points.
 pub fn set_fee(env: &Env, collector: Address, bps: u32) {
     env.storage().instance().set(&DataKey::FeeCollector, &collector);

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -105,12 +105,13 @@ pub struct FlowPay;
 
 #[contractimpl]
 impl FlowPay {
-    pub fn initialize(env: Env, token: Address) {
+    pub fn initialize(env: Env, token: Address, admin: Address) {
         if env.storage().instance().has(&DataKey::Token) {
             panic!("already initialized");
         }
 
         env.storage().instance().set(&DataKey::Token, &token);
+        admin::initialize_admin(&env, &admin);
     }
 
     /// Creates or replaces a recurring subscription for `user`.
@@ -265,14 +266,28 @@ impl FlowPay {
 
         let token = token::Client::new(&env, &sub.token);
 
+        let mut merchant_amount = sub.amount;
+        if let Some((collector, bps)) = fee::get_fee(&env) {
+            let fee_amount = (sub.amount * (bps as i128)) / 10_000;
+            if fee_amount > 0 {
+                token.transfer_from(
+                    &env.current_contract_address(),
+                    &user,
+                    &collector,
+                    &fee_amount,
+                );
+                merchant_amount = sub.amount - fee_amount;
+            }
+        }
+
         token.transfer_from(
             &env.current_contract_address(),
             &user,
             &sub.merchant,
-            &sub.amount,
+            &merchant_amount,
         );
 
-        merchant_stats::increment_revenue_with_daily(&env, &sub.merchant, sub.amount);
+        merchant_stats::increment_revenue_with_daily(&env, &sub.merchant, merchant_amount);
 
         sub.last_charged = now;
 
@@ -336,14 +351,28 @@ impl FlowPay {
 
         let token = token::Client::new(&env, &sub.token);
 
+        let mut merchant_amount = amount;
+        if let Some((collector, bps)) = fee::get_fee(&env) {
+            let fee_amount = (amount * (bps as i128)) / 10_000;
+            if fee_amount > 0 {
+                token.transfer_from(
+                    &env.current_contract_address(),
+                    &user,
+                    &collector,
+                    &fee_amount,
+                );
+                merchant_amount = amount - fee_amount;
+            }
+        }
+
         token.transfer_from(
             &env.current_contract_address(),
             &user,
             &sub.merchant,
-            &amount,
+            &merchant_amount,
         );
 
-        merchant_stats::increment_revenue_with_daily(&env, &sub.merchant, amount);
+        merchant_stats::increment_revenue_with_daily(&env, &sub.merchant, merchant_amount);
         spending_limit::record_spend(&env, &user, amount);
 
         events::publish_pay_per_use(&env, &user, &sub.merchant, amount);

--- a/contract/src/test.rs
+++ b/contract/src/test.rs
@@ -139,6 +139,68 @@ fn test_charge_exact_transfer_amount() {
     );
 }
 
+#[test]
+fn test_charge_applies_protocol_fee_and_records_net_revenue() {
+    let (env, contract_id, token_addr, user, merchant) = setup();
+    let client = FlowPayClient::new(&env, &contract_id);
+    let token = TokenClient::new(&env, &token_addr);
+    let admin = Address::generate(&env);
+    let collector = Address::generate(&env);
+
+    env.as_contract(&contract_id, || {
+        storage::set_admin(&env, &admin);
+    });
+    client.set_fee(&collector, &500u32); // 5%
+
+    let amount: i128 = 10_0000000;
+    let expected_fee: i128 = 500_0000;
+    let expected_net: i128 = amount - expected_fee;
+    let interval: u64 = 86400;
+
+    client.subscribe(&user, &merchant, &amount, &interval, &token_addr, &None, &None);
+
+    let merchant_before = token.balance(&merchant);
+    let collector_before = token.balance(&collector);
+
+    env.ledger().with_mut(|l| {
+        l.timestamp += interval + 1;
+    });
+    client.charge(&user);
+
+    assert_eq!(token.balance(&merchant) - merchant_before, expected_net);
+    assert_eq!(token.balance(&collector) - collector_before, expected_fee);
+    assert_eq!(client.get_merchant_revenue(&merchant), expected_net);
+}
+
+#[test]
+fn test_charge_with_zero_fee_bps_skips_fee_transfer() {
+    let (env, contract_id, token_addr, user, merchant) = setup();
+    let client = FlowPayClient::new(&env, &contract_id);
+    let token = TokenClient::new(&env, &token_addr);
+    let admin = Address::generate(&env);
+    let collector = Address::generate(&env);
+
+    env.as_contract(&contract_id, || {
+        storage::set_admin(&env, &admin);
+    });
+    client.set_fee(&collector, &0u32);
+
+    let amount: i128 = 5_0000000;
+    let interval: u64 = 86400;
+    client.subscribe(&user, &merchant, &amount, &interval, &token_addr, &None, &None);
+
+    let merchant_before = token.balance(&merchant);
+    let collector_before = token.balance(&collector);
+
+    env.ledger().with_mut(|l| {
+        l.timestamp += interval + 1;
+    });
+    client.charge(&user);
+
+    assert_eq!(token.balance(&merchant) - merchant_before, amount);
+    assert_eq!(token.balance(&collector) - collector_before, 0);
+}
+
 /// subscribe() must store all Subscription fields exactly as provided.
 #[test]
 fn test_subscription_struct_fields_match_input() {
@@ -318,6 +380,58 @@ fn test_pay_per_use() {
 }
 
 #[test]
+fn test_pay_per_use_applies_protocol_fee_and_records_net_revenue() {
+    let (env, contract_id, token_addr, user, merchant) = setup();
+    let client = FlowPayClient::new(&env, &contract_id);
+    let token = TokenClient::new(&env, &token_addr);
+    let admin = Address::generate(&env);
+    let collector = Address::generate(&env);
+
+    env.as_contract(&contract_id, || {
+        storage::set_admin(&env, &admin);
+    });
+    client.set_fee(&collector, &250u32); // 2.5%
+
+    client.subscribe(&user, &merchant, &1_0000000, &86400, &token_addr, &None, &None);
+
+    let amount: i128 = 8_0000000;
+    let expected_fee: i128 = 200_0000;
+    let expected_net: i128 = amount - expected_fee;
+    let merchant_before = token.balance(&merchant);
+    let collector_before = token.balance(&collector);
+
+    client.pay_per_use(&user, &amount);
+
+    assert_eq!(token.balance(&merchant) - merchant_before, expected_net);
+    assert_eq!(token.balance(&collector) - collector_before, expected_fee);
+    assert_eq!(client.get_merchant_revenue(&merchant), expected_net);
+}
+
+#[test]
+fn test_pay_per_use_with_zero_fee_bps_transfers_full_amount() {
+    let (env, contract_id, token_addr, user, merchant) = setup();
+    let client = FlowPayClient::new(&env, &contract_id);
+    let token = TokenClient::new(&env, &token_addr);
+    let admin = Address::generate(&env);
+    let collector = Address::generate(&env);
+
+    env.as_contract(&contract_id, || {
+        storage::set_admin(&env, &admin);
+    });
+    client.set_fee(&collector, &0u32);
+    client.subscribe(&user, &merchant, &1_0000000, &86400, &token_addr, &None, &None);
+
+    let amount: i128 = 3_0000000;
+    let merchant_before = token.balance(&merchant);
+    let collector_before = token.balance(&collector);
+
+    client.pay_per_use(&user, &amount);
+
+    assert_eq!(token.balance(&merchant) - merchant_before, amount);
+    assert_eq!(token.balance(&collector) - collector_before, 0);
+}
+
+#[test]
 #[should_panic]
 fn test_pay_per_use_inactive() {
     let (env, contract_id, token_addr, user, merchant) = setup();
@@ -393,9 +507,10 @@ fn test_pay_per_use_exceeds_cap() {
 fn test_initialize_backward_compat() {
     let (env, contract_id, token_addr, user, merchant) = setup();
     let client = FlowPayClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
 
     // initialize with a default token — should not affect per-sub token
-    client.initialize(&token_addr);
+    client.initialize(&token_addr, &admin);
 
     let token_b = setup_second_token(&env, &contract_id, &user);
     client.subscribe(&user, &merchant, &1_0000000, &86400, &token_b, &None, &None);
@@ -1150,9 +1265,10 @@ fn test_ttl_extension() {
 fn test_double_initialize() {
     let (env, contract_id, token_addr, _user, _merchant) = setup();
     let client = FlowPayClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
 
-    client.initialize(&token_addr); // first call
-    client.initialize(&token_addr); // second call — should panic
+    client.initialize(&token_addr, &admin); // first call
+    client.initialize(&token_addr, &admin); // second call — should panic
 }
 
 // ─────────────────────────────────────────────
@@ -1249,6 +1365,7 @@ fn test_accept_admin_without_proposal_panics() {
 #[test]
 fn test_initialize_without_valid_token() {
     let env = Env::default();
+    env.mock_all_auths();
     let contract_id = env.register_contract(None, FlowPay);
     let client = FlowPayClient::new(&env, &contract_id);
 
@@ -1256,8 +1373,9 @@ fn test_initialize_without_valid_token() {
     // The contract currently does not validate if the address is a valid token contract
     // or even if it's a contract at all.
     let invalid_token = Address::generate(&env);
+    let admin = Address::generate(&env);
     
-    client.initialize(&invalid_token);
+    client.initialize(&invalid_token, &admin);
     
     // Success means it didn't panic, which is the current expected behavior.
 }
@@ -1405,8 +1523,9 @@ fn test_get_token_returns_none_when_not_initialized() {
 fn test_get_token_returns_initialized_token() {
     let (env, contract_id, token_addr, _user, _merchant) = setup();
     let client = FlowPayClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
 
-    client.initialize(&token_addr);
+    client.initialize(&token_addr, &admin);
     assert_eq!(client.get_token(), Some(token_addr));
 }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import { useContractId } from "./hooks/useContractId";
 import { useRpcHealth } from "./hooks/useRpcHealth";
 import { useSubscriberCount } from "./hooks/useSubscriberCount";
 import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
+import { useAnalytics } from "./hooks/useAnalytics";
 import SubscribeForm from "./components/SubscribeForm";
 import Dashboard from "./components/Dashboard";
 import MerchantDashboard from "./components/MerchantDashboard";
@@ -98,6 +99,7 @@ export default function App() {
   const [tab, setTab] = useLocalStorage<"subscribe" | "dashboard" | "merchant">("flowpay_tab", "dashboard");
   const [refresh, setRefresh] = useState(0);
   const [showHelp, setShowHelp] = useState(false);
+  const { isOptedIn: analyticsEnabled, setOptIn: setAnalyticsOptIn, track } = useAnalytics();
   const subscribeErrorBoundaryRef = useRef<ErrorBoundary>(null);
   const dashboardErrorBoundaryRef = useRef<ErrorBoundary>(null);
   const merchantErrorBoundaryRef = useRef<ErrorBoundary>(null);
@@ -146,6 +148,11 @@ export default function App() {
       },
     ],
   });
+
+  async function handleConnectWallet() {
+    await connect();
+    track("wallet_connect");
+  }
 
   return (
     <div className={`app-shell${isMobile ? " app-shell--mobile" : ""}`}>
@@ -291,7 +298,30 @@ export default function App() {
 
       {/* Freighter installed but not connected */}
       {freighterAvailable && !publicKey && (
-        <ConnectWallet onConnect={connect} error={error} loading={connecting} />
+        <>
+          <div className="card connect-wallet">
+            <p className="connect-wallet__hint">
+              Help improve FlowPay with optional anonymous usage analytics.
+            </p>
+            <div style={{ display: "flex", gap: "8px", marginTop: "8px", flexWrap: "wrap" }}>
+              <button
+                className={`btn-secondary${analyticsEnabled ? " active" : ""}`}
+                onClick={() => setAnalyticsOptIn(true)}
+                type="button"
+              >
+                Opt in
+              </button>
+              <button
+                className={`btn-secondary${!analyticsEnabled ? " active" : ""}`}
+                onClick={() => setAnalyticsOptIn(false)}
+                type="button"
+              >
+                Keep disabled
+              </button>
+            </div>
+          </div>
+          <ConnectWallet onConnect={handleConnectWallet} error={error} loading={connecting} />
+        </>
       )}
 
       {/* Connected */}
@@ -321,6 +351,7 @@ export default function App() {
                 <SubscribeForm
                   userKey={publicKey}
                   onSign={signAndSubmit}
+                  onSubscribed={() => track("subscribe")}
                   onSuccess={() => {
                     setTab("dashboard");
                     setRefresh((r) => r + 1);
@@ -359,6 +390,8 @@ export default function App() {
                   onSign={signAndSubmit}
                   refreshTrigger={refresh}
                   announce={announce}
+                  onCancelled={() => track("cancel")}
+                  onPayPerUse={(amount) => track("pay_per_use", { amount: amount.toString() })}
                 />
               </ErrorBoundary>
             )}

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -22,9 +22,11 @@ interface Props {
   onSign: (xdr: string) => Promise<string>;
   refreshTrigger: number;
   announce: (message: string) => void;
+  onCancelled?: () => void;
+  onPayPerUse?: (amount: bigint) => void;
 }
 
-export default function Dashboard({ userKey, onSign, refreshTrigger, announce }: Props) {
+export default function Dashboard({ userKey, onSign, refreshTrigger, announce, onCancelled, onPayPerUse }: Props) {
   const { subscription: sub, loading, refresh } = useSubscription(userKey, refreshTrigger);
   const { toasts, addToast, removeToast } = useToast();
   const { healthy: rpcHealthy, error: rpcError } = useRpcHealth();
@@ -76,6 +78,7 @@ export default function Dashboard({ userKey, onSign, refreshTrigger, announce }:
       });
       addToast("Cancelled.", "success", hash);
       announce("Transaction confirmed");
+      onCancelled?.();
       refresh();
     } catch (e: unknown) {
       const msg = `Error: ${friendlyError(e instanceof Error ? e.message : String(e))}`;
@@ -93,6 +96,7 @@ export default function Dashboard({ userKey, onSign, refreshTrigger, announce }:
       });
       addToast("Paid!", "success", hash);
       announce("Transaction confirmed");
+      onPayPerUse?.(stroops);
     } catch (e: unknown) {
       const msg = `Error: ${friendlyError(e instanceof Error ? e.message : String(e))}`;
       addToast(msg, "error");

--- a/frontend/src/components/SubscribeForm.tsx
+++ b/frontend/src/components/SubscribeForm.tsx
@@ -15,9 +15,10 @@ interface Props {
   onSign: (xdr: string) => Promise<string>;
   onSuccess: () => void;
   announce: (message: string) => void;
+  onSubscribed?: () => void;
 }
 
-export default function SubscribeForm({ userKey, onSign, onSuccess, announce }: Props) {
+export default function SubscribeForm({ userKey, onSign, onSuccess, announce, onSubscribed }: Props) {
   const [merchant, setMerchant] = useState("");
   const [amount, setAmount] = useState("");
   const [interval, setInterval] = useState(BILLING_INTERVALS[2].value);
@@ -47,6 +48,7 @@ export default function SubscribeForm({ userKey, onSign, onSuccess, announce }: 
     if (hash) {
       addToast("Subscribed!", "success", hash);
       announce("Transaction confirmed");
+      onSubscribed?.();
       onSuccess();
     } else if (tx.error) {
       const msg = `Error: ${friendlyError(tx.error)}`;

--- a/frontend/src/hooks/useAnalytics.ts
+++ b/frontend/src/hooks/useAnalytics.ts
@@ -1,0 +1,46 @@
+import { useCallback, useMemo, useState } from "react";
+
+type AnalyticsEvent = "wallet_connect" | "subscribe" | "cancel" | "pay_per_use";
+
+const ANALYTICS_OPT_IN_KEY = "flowpay_analytics_opt_in";
+
+function readOptInPreference(): boolean {
+  if (typeof window === "undefined") return false;
+  return window.localStorage.getItem(ANALYTICS_OPT_IN_KEY) === "true";
+}
+
+export function useAnalytics() {
+  const [isOptedIn, setIsOptedIn] = useState<boolean>(() => readOptInPreference());
+
+  const setOptIn = useCallback((enabled: boolean) => {
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(ANALYTICS_OPT_IN_KEY, String(enabled));
+    }
+    setIsOptedIn(enabled);
+  }, []);
+
+  const track = useCallback(
+    (event: AnalyticsEvent, metadata?: Record<string, string | number | boolean>) => {
+      if (!isOptedIn || typeof window === "undefined") return;
+
+      const payload = {
+        event,
+        metadata: metadata ?? {},
+        timestamp: new Date().toISOString(),
+      };
+
+      // Keep this privacy-first: local event only, no automatic network transport.
+      window.dispatchEvent(new CustomEvent("flowpay-analytics", { detail: payload }));
+    },
+    [isOptedIn]
+  );
+
+  return useMemo(
+    () => ({
+      isOptedIn,
+      setOptIn,
+      track,
+    }),
+    [isOptedIn, setOptIn, track]
+  );
+}


### PR DESCRIPTION
## Summary

closes #171 
closes #187 
closes #188 
closes #189


This PR implements four high-priority tasks across the frontend and Soroban contract:

1. Added an opt-in, privacy-first analytics hook (`useAnalytics`) with localStorage persistence.
2. Enforced protocol fee deduction in `charge()` and recorded merchant revenue as net amount.
3. Applied identical protocol fee behavior in `pay_per_use()` with net revenue accounting.
4. Secured `initialize()` by requiring an explicit admin address and admin auth at initialization.

## Changes

- **Frontend**
  - Created `frontend/src/hooks/useAnalytics.ts`
    - Disabled by default
    - Opt-in preference persisted in localStorage
    - Tracks: wallet connect, subscribe, cancel, pay-per-use
  - Updated `frontend/src/App.tsx`
    - Added analytics opt-in prompt
    - Wired analytics event tracking to user interactions
  - Updated `frontend/src/components/SubscribeForm.tsx`
    - Added `onSubscribed` callback for successful subscription tracking
  - Updated `frontend/src/components/Dashboard.tsx`
    - Added hooks for successful cancel/pay-per-use tracking

- **Contract**
  - Updated `contract/src/fee.rs`
    - Added `get_fee() -> Option<(Address, u32)>`
  - Updated `contract/src/admin.rs`
    - Added `initialize_admin()` with `require_auth()`
  - Updated `contract/src/lib.rs`
    - `initialize(env, token, admin)` now stores admin and enforces admin auth
    - `charge()` now deducts protocol fee when configured and sends net to merchant
    - `pay_per_use()` now deducts protocol fee when configured and sends net to merchant
    - Merchant revenue stats now track net merchant receipts for both flows
  - Updated `contract/src/test.rs`
    - Added fee-behavior tests for `charge()` and `pay_per_use()`
    - Updated initialize callsites to pass admin

## Test plan

- [x] `npm run build` executed (blocked by pre-existing missing type-definition setup)
- [x] `cargo test` executed (blocked by pre-existing compile/test issues already present in repository)
- [x] Confirmed no unrelated cleanup/fixes were introduced outside requested tasks

## Notes

Per request, this PR intentionally avoids fixing unrelated pre-existing repository errors and only focuses on the four requested tasks.