### PR TITLE
Add validation tests, TTL extension coverage, and subscription limits

### DIFF
--- a/contract/src/errors.rs
+++ b/contract/src/errors.rs
@@ -26,4 +26,8 @@ pub enum ContractError {
     MerchantNotWhitelisted = 10,
     /// Returned when a user attempts to refer themselves
     SelfReferral = 11,
+    /// Returned when a requested subscription interval is shorter than the minimum allowed duration
+    IntervalTooShort = 12,
+    /// Returned when a requested subscription amount exceeds the maximum allowed cap
+    AmountTooLarge = 13,
 }

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -76,6 +76,7 @@ pub enum DataKey {
 
 pub const SUBSCRIPTION_TTL_LEDGERS: u32 = 6307200; // ~1 year (assuming 5s blocks)
 pub const MAX_AMOUNT: i128 = 100_000_000_000;
+pub const MAX_SUBSCRIPTION_AMOUNT: i128 = 1_000_000_0000000;
 
 // ─────────────────────────────────────────────────────────────
 // Data types
@@ -162,7 +163,15 @@ impl FlowPay {
         }
 
         assert!(amount > 0, "amount must be positive");
-        assert!(interval > 0, "interval must be positive");
+        if amount > MAX_SUBSCRIPTION_AMOUNT {
+            env.panic_with_error(ContractError::AmountTooLarge);
+        }
+        if interval == 0 {
+            env.panic_with_error(ContractError::IntervalMustBePositive);
+        }
+        if interval < 60 {
+            env.panic_with_error(ContractError::IntervalTooShort);
+        }
 
         use soroban_sdk::xdr::ToXdr;
         if token.clone().to_xdr(&env).get(7) == Some(0) {

--- a/contract/src/test.rs
+++ b/contract/src/test.rs
@@ -1139,10 +1139,74 @@ fn test_ttl_extension() {
     let client = FlowPayClient::new(&env, &contract_id);
 
     client.subscribe(&user, &merchant, &1_0000000, &86400, &token_addr, &None, &None);
-    
-    // We can't easily assert the exact TTL in the test environment without more complex mock_all_auths 
-    // or internal access, but we can verify the function exists and doesn't panic.
+
+    env.ledger().with_mut(|l| {
+        l.ledger_seq += SUBSCRIPTION_TTL_LEDGERS - 1;
+    });
+
     client.extend_subscription_ttl(&user);
+
+    env.ledger().with_mut(|l| {
+        l.ledger_seq += 2;
+    });
+
+    assert!(client.get_subscription(&user).is_some());
+}
+
+#[test]
+#[should_panic]
+fn test_subscribe_interval_too_short_panics() {
+    let (env, contract_id, token_addr, user, merchant) = setup();
+    let client = FlowPayClient::new(&env, &contract_id);
+
+    client.subscribe(&user, &merchant, &1_0000000, &59, &token_addr, &None, &None);
+}
+
+#[test]
+fn test_subscribe_interval_minimum_succeeds() {
+    let (env, contract_id, token_addr, user, merchant) = setup();
+    let client = FlowPayClient::new(&env, &contract_id);
+
+    client.subscribe(&user, &merchant, &1_0000000, &60, &token_addr, &None, &None);
+
+    let sub = client.get_subscription(&user).unwrap();
+    assert_eq!(sub.interval, 60);
+}
+
+#[test]
+#[should_panic]
+fn test_subscribe_amount_above_cap_panics() {
+    let (env, contract_id, token_addr, user, merchant) = setup();
+    let client = FlowPayClient::new(&env, &contract_id);
+
+    client.subscribe(
+        &user,
+        &merchant,
+        &(MAX_SUBSCRIPTION_AMOUNT + 1),
+        &86400,
+        &token_addr,
+        &None,
+        &None,
+    );
+}
+
+#[test]
+fn test_subscribe_amount_at_cap_succeeds() {
+    let (env, contract_id, token_addr, user, merchant) = setup();
+    let client = FlowPayClient::new(&env, &contract_id);
+
+    client.subscribe(
+        &user,
+        &merchant,
+        &MAX_SUBSCRIPTION_AMOUNT,
+        &86400,
+        &token_addr,
+        &None,
+        &None,
+    );
+
+    let sub = client.get_subscription(&user).unwrap();
+    assert_eq!(sub.amount, MAX_SUBSCRIPTION_AMOUNT);
 }
 
 #[test]

--- a/contract/src/validation.rs
+++ b/contract/src/validation.rs
@@ -13,3 +13,52 @@ pub fn require_active_subscription(active: bool) {
 pub fn require_charge_interval_elapsed(now: u64, last_charged: u64, interval: u64) {
     assert!(now >= last_charged + interval, "interval not elapsed yet");
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_require_positive_amount_accepts_positive() {
+        require_positive_amount(1);
+    }
+
+    #[test]
+    #[should_panic(expected = "amount must be positive")]
+    fn test_require_positive_amount_panics_on_zero() {
+        require_positive_amount(0);
+    }
+
+    #[test]
+    fn test_require_positive_interval_accepts_positive() {
+        require_positive_interval(60);
+    }
+
+    #[test]
+    #[should_panic(expected = "interval must be positive")]
+    fn test_require_positive_interval_panics_on_zero() {
+        require_positive_interval(0);
+    }
+
+    #[test]
+    fn test_require_active_subscription_accepts_true() {
+        require_active_subscription(true);
+    }
+
+    #[test]
+    #[should_panic(expected = "subscription is not active")]
+    fn test_require_active_subscription_panics_on_false() {
+        require_active_subscription(false);
+    }
+
+    #[test]
+    fn test_require_charge_interval_elapsed_accepts_elapsed_interval() {
+        require_charge_interval_elapsed(100, 40, 60);
+    }
+
+    #[test]
+    #[should_panic(expected = "interval not elapsed yet")]
+    fn test_require_charge_interval_elapsed_panics_if_too_early() {
+        require_charge_interval_elapsed(99, 40, 60);
+    }
+}

--- a/contract_validation_tasks.ipynb
+++ b/contract_validation_tasks.ipynb
@@ -1,0 +1,43 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a2b76a23",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "This notebook documents the work for the requested open-source tasks, including test additions and contract validation fixes in the `contract` crate.</VSCode.Cell>\n",
+    "<VSCode.Cell language=\"markdown\">## Repository setup\n",
+    "Clone the PayFlow repository, open the contract crate, and ensure the Rust toolchain is configured for running tests.</VSCode.Cell>\n",
+    "<VSCode.Cell language=\"markdown\">## Add unit tests for `validation.rs`\n",
+    "Identify all public functions in `contract/src/validation.rs` and add positive and negative tests in a `#[cfg(test)]` block to verify helper behavior.</VSCode.Cell>\n",
+    "<VSCode.Cell language=\"markdown\">## Add TTL extension test for storage\n",
+    "Write a new test in `contract/src/test.rs` that calls `extend_subscription_ttl()`, advances ledgers with `env.ledger().with_mut()`, and verifies the subscription still exists after simulated ledger advancement.</VSCode.Cell>\n",
+    "<VSCode.Cell language=\"markdown\">## Enforce interval minimum in `subscribe`\n",
+    "Update `contract/src/lib.rs` to require `interval >= 60`, add `ContractError::IntervalTooShort` in `contract/src/errors.rs`, and add tests for `interval = 59` failing and `interval = 60` succeeding.</VSCode.Cell>\n",
+    "<VSCode.Cell language=\"markdown\">## Add amount maximum cap in `subscribe`\n",
+    "Add a maximum amount cap in `contract/src/lib.rs`, define `ContractError::AmountTooLarge` in `contract/src/errors.rs`, and add a test that an amount above the cap panics.</VSCode.Cell>\n",
+    "<VSCode.Cell language=\"markdown\">## Run cargo tests\n",
+    "Execute `cargo test` to verify all newly added tests and contract validation changes pass."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fd4fc8e2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "os.system('cd /workspaces/PayFlow && cargo test --manifest-path contract/Cargo.toml')\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
closes #217 
closes #218 
cloese #221 
closes #222

## Suggested PR description

- Added direct unit tests for validation.rs helper functions with both positive and negative coverage.
- Added a stronger `extend_subscription_ttl()` regression test that advances ledgers and verifies the subscription is preserved.
- Enforced `subscribe()` interval minimum of 60 seconds and introduced `ContractError::IntervalTooShort`.
- Added a subscription amount cap and `ContractError::AmountTooLarge` to reject oversized subscriptions early.
- Created contract_validation_tasks.ipynb documenting the task changes and test plan.

Made changes.