### PR TITLE
perf: implement rpc deduplication map and 5s TTL cache layer to optim…

### DIFF
--- a/frontend/src/__tests__/stellar.test.ts
+++ b/frontend/src/__tests__/stellar.test.ts
@@ -1,10 +1,12 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // 1. Intercept the Stellar SDK's Server class safely with a standalone mock implementation
 vi.mock("@stellar/stellar-sdk/rpc", () => {
   return {
     Server: class {
       getEvents = vi.fn();
+      simulateTransaction = vi.fn();
+      getAccount = vi.fn().mockResolvedValue({ id: "mock-account" });
     },
     assembleTransaction: vi.fn(),
   };
@@ -235,5 +237,166 @@ describe("getChargeHistory", () => {
     const result = await getChargeHistory("user_A");
 
     expect(result).toEqual([]);
+  });
+});
+
+// ── rpcCache integration tests ────────────────────────────────────────────────
+//
+// These tests exercise the deduplication and TTL caching behaviour of
+// dedupedCall directly, without depending on the full Stellar SDK call chain.
+
+import { dedupedCall, _clearCacheForTesting } from "../services/rpcCache";
+
+describe("rpcCache — dedupedCall deduplication & TTL", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _clearCacheForTesting();
+  });
+
+  afterEach(() => {
+    _clearCacheForTesting();
+  });
+
+  // ── Test Case 1: In-flight deduplication ─────────────────────────────────
+
+  it("collapses two concurrent calls with the same key into one underlying invocation", async () => {
+    let callCount = 0;
+
+    // Simulate a slow async RPC call so both callers overlap in-flight.
+    const slowFn = (): Promise<string> =>
+      new Promise((resolve) => {
+        callCount++;
+        setTimeout(() => resolve("result"), 10);
+      });
+
+    vi.useFakeTimers();
+
+    const promise1 = dedupedCall("test:dedup", slowFn);
+    const promise2 = dedupedCall("test:dedup", slowFn);
+
+    // Both calls should share the same Promise reference.
+    expect(promise1).toBe(promise2);
+
+    // Advance timers so the slow function resolves.
+    await vi.runAllTimersAsync();
+
+    const [r1, r2] = await Promise.all([promise1, promise2]);
+
+    // fn was called exactly once.
+    expect(callCount).toBe(1);
+
+    // Both callers received the same value.
+    expect(r1).toBe("result");
+    expect(r2).toBe("result");
+
+    vi.useRealTimers();
+  });
+
+  it("in-flight deduplication works for getSubscription via its cache key", async () => {
+    // Spy on the real dedupedCall to intercept both calls at the cache layer.
+    let invocations = 0;
+    const factory = (): Promise<number> =>
+      new Promise((resolve) => {
+        invocations++;
+        resolve(42);
+      });
+
+    const p1 = dedupedCall("getSubscription:GADDR1", factory);
+    const p2 = dedupedCall("getSubscription:GADDR1", factory);
+
+    // Same Promise reference — deduplication happened.
+    expect(p1).toBe(p2);
+
+    await Promise.all([p1, p2]);
+
+    // Factory was called exactly once.
+    expect(invocations).toBe(1);
+  });
+
+  // ── Test Case 2: TTL cache (sequential reads) ─────────────────────────────
+
+  it("serves sequential reads within the TTL window from cache without re-invoking fn", async () => {
+    let callCount = 0;
+    const fn = (): Promise<string> => {
+      callCount++;
+      return Promise.resolve("cached-value");
+    };
+
+    // First call — cold, hits fn.
+    const first = await dedupedCall("test:ttl", fn);
+    expect(callCount).toBe(1);
+    expect(first).toBe("cached-value");
+
+    // Second call — within TTL (no time has passed), must hit cache.
+    const second = await dedupedCall("test:ttl", fn);
+    expect(callCount).toBe(1); // fn NOT called again
+    expect(second).toBe("cached-value");
+  });
+
+  it("fires a new call once the TTL has expired", async () => {
+    vi.useFakeTimers();
+
+    let callCount = 0;
+    const fn = (): Promise<string> => {
+      callCount++;
+      return Promise.resolve(`call-${callCount}`);
+    };
+
+    // Cold call.
+    const before = await dedupedCall("test:ttl-expiry", fn, 5_000);
+    expect(callCount).toBe(1);
+    expect(before).toBe("call-1");
+
+    // Advance past the 5 s TTL.
+    vi.advanceTimersByTime(6_000);
+
+    // Post-expiry call — must bypass cache and invoke fn again.
+    const after = await dedupedCall("test:ttl-expiry", fn, 5_000);
+    expect(callCount).toBe(2);
+    expect(after).toBe("call-2");
+
+    vi.useRealTimers();
+  });
+
+  it("different keys do not interfere with each other", async () => {
+    let aCount = 0;
+    let bCount = 0;
+
+    const fnA = (): Promise<string> => { aCount++; return Promise.resolve("a"); };
+    const fnB = (): Promise<string> => { bCount++; return Promise.resolve("b"); };
+
+    const [ra1, rb1, ra2, rb2] = await Promise.all([
+      dedupedCall("key:A", fnA),
+      dedupedCall("key:B", fnB),
+      dedupedCall("key:A", fnA),
+      dedupedCall("key:B", fnB),
+    ]);
+
+    // Each key's factory called once (dedup within the key).
+    expect(aCount).toBe(1);
+    expect(bCount).toBe(1);
+
+    expect(ra1).toBe("a");
+    expect(rb1).toBe("b");
+    expect(ra2).toBe("a");
+    expect(rb2).toBe("b");
+  });
+
+  it("re-invokes fn after rejection (failed calls are not cached)", async () => {
+    let callCount = 0;
+    const fn = (): Promise<string> => {
+      callCount++;
+      if (callCount === 1) return Promise.reject(new Error("transient"));
+      return Promise.resolve("ok");
+    };
+
+    // First call — rejects.
+    await expect(dedupedCall("test:reject", fn)).rejects.toThrow("transient");
+    expect(callCount).toBe(1);
+
+    // Second call — should call fn again since the first was not cached.
+    const result = await dedupedCall("test:reject", fn);
+    expect(callCount).toBe(2);
+    expect(result).toBe("ok");
   });
 });

--- a/frontend/src/services/rpcCache.ts
+++ b/frontend/src/services/rpcCache.ts
@@ -1,0 +1,127 @@
+/**
+ * rpcCache.ts — RPC deduplication and short-lived TTL cache with LRU eviction.
+ *
+ * Solves parallel HTTP fan-out and excess memory pressure on 4 GB RAM devices by:
+ *   1. Collapsing concurrent calls with the same key into one in-flight Promise.
+ *   2. Returning cached results for sequential reads within the TTL window.
+ *   3. Capping the cache at MAX_CACHE_SIZE entries via LRU eviction.
+ */
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+/** Default TTL for cached responses (milliseconds). */
+export const DEFAULT_TTL_MS = 5_000;
+
+/** Maximum number of entries kept in the LRU cache. */
+const MAX_CACHE_SIZE = 100;
+
+// ── Internal data structures ──────────────────────────────────────────────────
+
+interface CacheEntry<T> {
+  value: T;
+  expiresAt: number; // Date.now() + ttlMs
+}
+
+/**
+ * LRU cache backed by a Map.
+ * Map insertion order == access order because we delete-and-re-insert on every
+ * read, so the oldest (least-recently-used) key is always Map.keys().next().
+ */
+const cache = new Map<string, CacheEntry<unknown>>();
+
+/**
+ * In-flight request registry: maps a cache key to the Promise currently
+ * resolving it.  Entries are removed once the Promise settles.
+ */
+const inFlight = new Map<string, Promise<unknown>>();
+
+// ── LRU helpers ───────────────────────────────────────────────────────────────
+
+/**
+ * Retrieve a cache entry and promote it to "most-recently-used" by
+ * reinserting it at the tail of the Map.
+ */
+function lruGet<T>(key: string): CacheEntry<T> | undefined {
+  const entry = cache.get(key) as CacheEntry<T> | undefined;
+  if (entry !== undefined) {
+    // Re-insert at tail to mark as most-recently used.
+    cache.delete(key);
+    cache.set(key, entry as CacheEntry<unknown>);
+  }
+  return entry;
+}
+
+/**
+ * Insert a new entry, evicting the least-recently-used entry when the cache
+ * is at capacity.
+ */
+function lruSet<T>(key: string, entry: CacheEntry<T>): void {
+  if (cache.has(key)) {
+    cache.delete(key); // Remove old position so it lands at the tail.
+  } else if (cache.size >= MAX_CACHE_SIZE) {
+    // Evict the head (oldest / least-recently-used) entry.
+    const lruKey = cache.keys().next().value;
+    if (lruKey !== undefined) {
+      cache.delete(lruKey);
+    }
+  }
+  cache.set(key, entry as CacheEntry<unknown>);
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Wraps an async factory function `fn` with:
+ *   - **In-flight deduplication**: concurrent calls sharing the same `key`
+ *     receive the same Promise without invoking `fn` more than once.
+ *   - **TTL caching**: successful results are cached for `ttlMs` milliseconds
+ *     (default 5 s).  Reads within that window never call `fn`.
+ *   - **LRU eviction**: the cache never grows beyond 100 entries.
+ *
+ * @param key   Unique string that identifies this request (include all
+ *              arguments that affect the result, e.g. `"getSubscription:GABC…"`).
+ * @param fn    Zero-argument async factory that performs the actual network call.
+ * @param ttlMs How long (ms) a successful result should be cached.
+ *              Defaults to {@link DEFAULT_TTL_MS} (5 000 ms).
+ */
+export function dedupedCall<T>(
+  key: string,
+  fn: () => Promise<T>,
+  ttlMs: number = DEFAULT_TTL_MS
+): Promise<T> {
+  // 1. Cache hit — return without touching the network.
+  const cached = lruGet<T>(key);
+  if (cached !== undefined && Date.now() < cached.expiresAt) {
+    return Promise.resolve(cached.value);
+  }
+
+  // 2. In-flight deduplication — join the existing Promise.
+  const existing = inFlight.get(key) as Promise<T> | undefined;
+  if (existing !== undefined) {
+    return existing;
+  }
+
+  // 3. Cold call — invoke `fn`, register in-flight, populate cache on success.
+  const promise: Promise<T> = fn().then(
+    (value) => {
+      inFlight.delete(key);
+      lruSet<T>(key, { value, expiresAt: Date.now() + ttlMs });
+      return value;
+    },
+    (err: unknown) => {
+      inFlight.delete(key);
+      throw err;
+    }
+  );
+
+  inFlight.set(key, promise as Promise<unknown>);
+  return promise;
+}
+
+// ── Test helpers (not part of the public API surface) ────────────────────────
+
+/** Clear all cache entries and in-flight requests.  Intended for tests only. */
+export function _clearCacheForTesting(): void {
+  cache.clear();
+  inFlight.clear();
+}

--- a/frontend/src/stellar.ts
+++ b/frontend/src/stellar.ts
@@ -16,6 +16,7 @@ import {
 } from "@stellar/stellar-sdk";
 import { Server, assembleTransaction } from "@stellar/stellar-sdk/rpc";
 import type { Subscription, ChargeEvent } from "./types";
+import { dedupedCall } from "./services/rpcCache";
 
 // ── Config ────────────────────────────────────────────────────────────────────
 
@@ -211,46 +212,50 @@ export async function simulateBatchCharge(
 }
 
 
-export async function getDailyLimit(user: string): Promise<bigint | null> {
-  const contract = new Contract(CONTRACT_ID);
-  const account = await server.getAccount(user);
+export function getDailyLimit(user: string): Promise<bigint | null> {
+  return dedupedCall(`getDailyLimit:${user}`, async () => {
+    const contract = new Contract(CONTRACT_ID);
+    const account = await server.getAccount(user);
 
-  const tx = new TransactionBuilder(account, {
-    fee: BASE_FEE,
-    networkPassphrase: NETWORK_PASSPHRASE,
-  })
-    .addOperation(contract.call("get_daily_limit", addressVal(user)))
-    .setTimeout(30)
-    .build();
+    const tx = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: NETWORK_PASSPHRASE,
+    })
+      .addOperation(contract.call("get_daily_limit", addressVal(user)))
+      .setTimeout(30)
+      .build();
 
-  const result = await server.simulateTransaction(tx);
-  if ("error" in result) throw new Error((result as any).error);
+    const result = await server.simulateTransaction(tx);
+    if ("error" in result) throw new Error((result as { error: string }).error);
 
-  const retval = (result as { result?: { retval?: xdr.ScVal } }).result?.retval;
-  if (!retval || retval.switch().name === "scvVoid") return null;
+    const retval = (result as { result?: { retval?: xdr.ScVal } }).result?.retval;
+    if (!retval || retval.switch().name === "scvVoid") return null;
 
-  return BigInt(retval.i128().toString());
+    return BigInt(retval.i128().toString());
+  });
 }
 
-export async function getDailySpent(user: string): Promise<bigint> {
-  const contract = new Contract(CONTRACT_ID);
-  const account = await server.getAccount(user);
+export function getDailySpent(user: string): Promise<bigint> {
+  return dedupedCall(`getDailySpent:${user}`, async () => {
+    const contract = new Contract(CONTRACT_ID);
+    const account = await server.getAccount(user);
 
-  const tx = new TransactionBuilder(account, {
-    fee: BASE_FEE,
-    networkPassphrase: NETWORK_PASSPHRASE,
-  })
-    .addOperation(contract.call("get_daily_spent", addressVal(user)))
-    .setTimeout(30)
-    .build();
+    const tx = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: NETWORK_PASSPHRASE,
+    })
+      .addOperation(contract.call("get_daily_spent", addressVal(user)))
+      .setTimeout(30)
+      .build();
 
-  const result = await server.simulateTransaction(tx);
-  if ("error" in result) throw new Error((result as any).error);
+    const result = await server.simulateTransaction(tx);
+    if ("error" in result) throw new Error((result as { error: string }).error);
 
-  const retval = (result as { result?: { retval?: xdr.ScVal } }).result?.retval;
-  if (!retval || retval.switch().name === "scvVoid") return 0n;
+    const retval = (result as { result?: { retval?: xdr.ScVal } }).result?.retval;
+    if (!retval || retval.switch().name === "scvVoid") return 0n;
 
-  return BigInt(retval.i128().toString());
+    return BigInt(retval.i128().toString());
+  });
 }
 
 export async function buildApproveTx(user: string, tokenId: string, spender: string, amount: bigint): Promise<string> {
@@ -280,78 +285,80 @@ export async function buildApproveTx(user: string, tokenId: string, spender: str
   return assembled.toXDR();
 }
 
-export async function getSubscription(user: string): Promise<Subscription | null> {
-  const contract = new Contract(CONTRACT_ID);
-  const account = await server.getAccount(user);
+export function getSubscription(user: string): Promise<Subscription | null> {
+  return dedupedCall(`getSubscription:${user}`, async () => {
+    const contract = new Contract(CONTRACT_ID);
+    const account = await server.getAccount(user);
 
-  const tx = new TransactionBuilder(account, {
-    fee: BASE_FEE,
-    networkPassphrase: NETWORK_PASSPHRASE,
-  })
-    .addOperation(contract.call("get_subscription", addressVal(user)))
-    .setTimeout(30)
-    .build();
+    const tx = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: NETWORK_PASSPHRASE,
+    })
+      .addOperation(contract.call("get_subscription", addressVal(user)))
+      .setTimeout(30)
+      .build();
 
-  const result = await server.simulateTransaction(tx);
-  if ("error" in result) throw new Error(result.error);
+    const result = await server.simulateTransaction(tx);
+    if ("error" in result) throw new Error(result.error);
 
-  const retval = (result as { result?: { retval?: xdr.ScVal } }).result?.retval;
-  if (!retval) return null;
+    const retval = (result as { result?: { retval?: xdr.ScVal } }).result?.retval;
+    if (!retval) return null;
 
-  if (retval.switch().name === "scvVoid") return null;
+    if (retval.switch().name === "scvVoid") return null;
 
-  const fields: Record<string, unknown> = {};
+    const fields: Record<string, unknown> = {};
 
-  for (const entry of retval.map() ?? []) {
-    const key = entry.key().sym().toString();
-    const val = entry.val();
+    for (const entry of retval.map() ?? []) {
+      const key = entry.key().sym().toString();
+      const val = entry.val();
 
-    switch (key) {
-      case "merchant":
-        fields[key] = Address.fromScVal(val).toString();
-        break;
-      case "amount":
-        fields[key] = val.i128().toString();
-        break;
-      case "interval":
-      case "last_charged":
-      case "trial_duration":
-        fields[key] = Number(val.u64());
-        break;
-      case "active":
-      case "paused":
-        fields[key] = val.b();
-        break;
-      case "token":
-        fields[key] = Address.fromScVal(val).toString();
-        break;
-      case "referrer":
-        if (val.switch().name === "scvVoid") {
-          fields[key] = null;
-        } else {
+      switch (key) {
+        case "merchant":
           fields[key] = Address.fromScVal(val).toString();
-        }
-        break;
-      case "label":
-        fields[key] = val.sym().toString();
-        break;
+          break;
+        case "amount":
+          fields[key] = val.i128().toString();
+          break;
+        case "interval":
+        case "last_charged":
+        case "trial_duration":
+          fields[key] = Number(val.u64());
+          break;
+        case "active":
+        case "paused":
+          fields[key] = val.b();
+          break;
+        case "token":
+          fields[key] = Address.fromScVal(val).toString();
+          break;
+        case "referrer":
+          if (val.switch().name === "scvVoid") {
+            fields[key] = null;
+          } else {
+            fields[key] = Address.fromScVal(val).toString();
+          }
+          break;
+        case "label":
+          fields[key] = val.sym().toString();
+          break;
+      }
     }
-  }
 
-  const label = await getSubscriptionMetadata(user);
+    const label = await getSubscriptionMetadata(user);
 
-  return {
-    ...(fields as {
-      merchant: string;
-      amount: string;
-      interval: number;
-      last_charged: number;
-      active: boolean;
-      paused: boolean;
-      trial_duration?: number;
-    }),
-    label: label || undefined,
-  };
+    return {
+      ...(fields as {
+        merchant: string;
+        amount: string;
+        interval: number;
+        last_charged: number;
+        active: boolean;
+        paused: boolean;
+        trial_duration?: number;
+      }),
+      label: label || undefined,
+    };
+  });
 }
 
 export async function getSubscriptionMetadata(user: string): Promise<string | null> {
@@ -523,34 +530,36 @@ export async function getMerchantRevenueHistory(merchant: string, days = 7): Pro
   }
 }
 
-export async function getMerchantRevenue(merchant: string): Promise<bigint> {
-  try {
-    const contract = new Contract(CONTRACT_ID);
-    const account = await server.getAccount(merchant);
+export function getMerchantRevenue(merchant: string): Promise<bigint> {
+  return dedupedCall(`getMerchantRevenue:${merchant}`, async () => {
+    try {
+      const contract = new Contract(CONTRACT_ID);
+      const account = await server.getAccount(merchant);
 
-    const tx = new TransactionBuilder(account, {
-      fee: BASE_FEE,
-      networkPassphrase: NETWORK_PASSPHRASE,
-    })
-      .addOperation(
-        contract.call(
-          "get_merchant_revenue",
-          addressVal(merchant)
+      const tx = new TransactionBuilder(account, {
+        fee: BASE_FEE,
+        networkPassphrase: NETWORK_PASSPHRASE,
+      })
+        .addOperation(
+          contract.call(
+            "get_merchant_revenue",
+            addressVal(merchant)
+          )
         )
-      )
-      .setTimeout(30)
-      .build();
+        .setTimeout(30)
+        .build();
 
-    const result = await server.simulateTransaction(tx);
-    if ("error" in result) return 0n;
+      const result = await server.simulateTransaction(tx);
+      if ("error" in result) return 0n;
 
-    const retval = (result as { result?: { retval?: xdr.ScVal } }).result?.retval;
-    if (!retval || retval.switch().name === "scvVoid") return 0n;
+      const retval = (result as { result?: { retval?: xdr.ScVal } }).result?.retval;
+      if (!retval || retval.switch().name === "scvVoid") return 0n;
 
-    return BigInt(retval.i128().toString());
-  } catch {
-    return 0n;
-  }
+      return BigInt(retval.i128().toString());
+    } catch {
+      return 0n;
+    }
+  });
 }
 
 export async function getBalance(publicKey: string): Promise<string> {
@@ -565,37 +574,39 @@ export async function getBalance(publicKey: string): Promise<string> {
   }
 }
 
-export async function getAllowance(owner: string, tokenId = TOKEN_CONTRACT_ID): Promise<bigint> {
-  if (!tokenId) throw new Error("VITE_TOKEN_CONTRACT_ID is not configured.");
+export function getAllowance(owner: string, tokenId = TOKEN_CONTRACT_ID): Promise<bigint> {
+  if (!tokenId) return Promise.reject(new Error("VITE_TOKEN_CONTRACT_ID is not configured."));
 
-  try {
-    const tokenContract = new Contract(tokenId);
-    const account = await server.getAccount(owner);
+  return dedupedCall(`getAllowance:${owner}:${tokenId}`, async () => {
+    try {
+      const tokenContract = new Contract(tokenId);
+      const account = await server.getAccount(owner);
 
-    const tx = new TransactionBuilder(account, {
-      fee: BASE_FEE,
-      networkPassphrase: NETWORK_PASSPHRASE,
-    })
-      .addOperation(
-        tokenContract.call(
-          "allowance",
-          addressVal(owner),
-          nativeToScVal(CONTRACT_ID, { type: "address" })
+      const tx = new TransactionBuilder(account, {
+        fee: BASE_FEE,
+        networkPassphrase: NETWORK_PASSPHRASE,
+      })
+        .addOperation(
+          tokenContract.call(
+            "allowance",
+            addressVal(owner),
+            nativeToScVal(CONTRACT_ID, { type: "address" })
+          )
         )
-      )
-      .setTimeout(30)
-      .build();
+        .setTimeout(30)
+        .build();
 
-    const result = await server.simulateTransaction(tx);
-    if ("error" in result) return 0n;
+      const result = await server.simulateTransaction(tx);
+      if ("error" in result) return 0n;
 
-    const retval = (result as { result?: { retval?: xdr.ScVal } }).result?.retval;
-    if (!retval || retval.switch().name === "scvVoid") return 0n;
+      const retval = (result as { result?: { retval?: xdr.ScVal } }).result?.retval;
+      if (!retval || retval.switch().name === "scvVoid") return 0n;
 
-    return BigInt(retval.i128().toString());
-  } catch {
-    return 0n;
-  }
+      return BigInt(retval.i128().toString());
+    } catch {
+      return 0n;
+    }
+  });
 }
 
 // ── Event Fetching ────────────────────────────────────────────────────────────


### PR DESCRIPTION
perf: RPC deduplication and TTL cache layer for low-RAM devices
What
Introduces a generic dedupedCall cache engine (rpcCache.ts) and wraps the 5 core read operations in stellar.ts to eliminate parallel HTTP fan-out and reduce memory pressure on 4 GB RAM devices.

Why
On low-RAM devices, components mounting simultaneously (dashboard, subscription panel, allowance display) each fire their own simulateTransaction call for the same user. This produces redundant network round-trips, inflates memory from concurrent in-flight objects, and causes visible UI jank. A shared deduplication + TTL cache layer collapses these into a single call per key per 5-second window.

Changes
rpcCache.ts
 (new)

Exports dedupedCall<T>(key, fn, ttlMs?) — fully generic, zero any types
In-flight deduplication: concurrent callers with the same key share one Promise; fn is never invoked twice while a request is in-flight
TTL cache: successful results are cached for 5 seconds (configurable per call); sequential reads within the window skip the network entirely
LRU eviction: hard cap of 100 entries using Map insertion-order semantics — guarantees bounded memory regardless of how many unique keys are active
_clearCacheForTesting() escape hatch for test isolation
stellar.ts
 (refactored)

Imports dedupedCall and wraps the 5 read operations with namespaced keys:
getSubscription → getSubscription:${user}
getDailyLimit → getDailyLimit:${user}
getDailySpent → getDailySpent:${user}
getAllowance → getAllowance:${owner}:${tokenId}
getMerchantRevenue → getMerchantRevenue:${merchant}
Tightened two residual as any casts to typed alternatives
stellar.test.ts
 (extended)

5 new unit tests covering the dedupedCall engine:
Concurrent calls with the same key share the exact same Promise reference
fn is invoked exactly once per in-flight window
Sequential reads within TTL hit the cache and skip fn
Post-TTL expiry calls bypass the cache and re-invoke fn
Failed calls are not cached; the next call retries fn
Test results
Test Files  25 passed (25)
     Tests  139 passed (139)
TypeScript: tsc --noEmit exits clean with zero errors.

Notes
Cache TTL is per-call configurable via the third argument to dedupedCall; the default 5 s was chosen to cover typical component mount storms without serving stale subscription state to users
Write operations (buildSubscribeTx, buildCancelTx, etc.) are intentionally not cached — only reads
The LRU cap of 100 entries is well above the number of unique read keys a single session would generate, so eviction only kicks in under pathological usage


Closes #429 