### PR TITLE
perf: virtualize MerchantDashboard subscriber list

### DIFF
--- a/frontend/src/__tests__/MerchantDashboard.test.tsx
+++ b/frontend/src/__tests__/MerchantDashboard.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../stellar");
 vi.mock("../hooks/usePolling", () => ({ usePolling: () => {} }));
@@ -68,6 +68,24 @@ describe("MerchantDashboard", () => {
     render(<MerchantDashboard merchantKey="GMERCHANT" onSign={onSign} refreshTrigger={0} />);
 
     await waitFor(() => expect(screen.getByText(/No active subscribers found/)).toBeTruthy());
+  });
+
+  it("renders a virtualized window for large subscriber lists", async () => {
+    const manySubscribers = Array.from({ length: 200 }, (_, index) => ({
+      ...SAMPLE_SUBSCRIBER,
+      subscriber: `GUSER${String(index).padStart(51, "0")}`,
+    }));
+    vi.mocked(stellar.getMerchantSubscribers).mockResolvedValue(manySubscribers);
+    const onSign = vi.fn();
+
+    const { container } = render(
+      <MerchantDashboard merchantKey="GMERCHANT" onSign={onSign} refreshTrigger={0} />
+    );
+
+    await waitFor(() => expect(screen.getByText("200 total")).toBeTruthy());
+
+    const renderedRows = container.querySelectorAll(".merchant-subscriber-row");
+    expect(renderedRows.length).toBeLessThanOrEqual(20);
   });
 
   it("enables the batch charge button when subscribers are due", async () => {

--- a/frontend/src/components/MerchantDashboard.tsx
+++ b/frontend/src/components/MerchantDashboard.tsx
@@ -3,8 +3,12 @@ import { getMerchantSubscribers, type MerchantSubscriber, buildBatchChargeTx, si
 import { formatAddress, formatXlm } from "../utils/format";
 import { usePolling } from "../hooks/usePolling";
 import { useTransaction } from "../hooks/useTransaction";
+import { useVirtualList } from "../hooks/useVirtualList";
 import CopyButton from "./CopyButton";
 import RevenueSparkline from "./RevenueSparkline";
+
+const SUBSCRIBER_ROW_HEIGHT = 72;
+const SUBSCRIBER_LIST_HEIGHT = 400;
 
 interface Props {
   merchantKey: string;
@@ -33,6 +37,11 @@ export default function MerchantDashboard({
 
   const dueSubscribers = subscribers.filter(
     (s) => s.nextChargeAt <= Math.floor(Date.now() / 1000)
+  );
+  const virtualSubscribers = useVirtualList(
+    subscribers,
+    SUBSCRIBER_ROW_HEIGHT,
+    SUBSCRIBER_LIST_HEIGHT
   );
 
   const refresh = useCallback(async () => {
@@ -85,7 +94,7 @@ export default function MerchantDashboard({
       });
 
       // 3. Success — refresh list to show updated next charge times
-      setTimeout(refresh, 2000);
+      window.setTimeout(refresh, 2000);
     } catch (e) {
       console.error("Batch charge failed:", e);
     }
@@ -98,8 +107,6 @@ export default function MerchantDashboard({
       </div>
     );
   }
-
-  const maxRevenue = revenueHistory.reduce((a, b) => (a > b ? a : b), 1n);
 
   return (
     <div className="dashboard">
@@ -183,32 +190,51 @@ export default function MerchantDashboard({
             </div>
           )}
 
-          <div className="subscription-rows merchant-subscriber-list">
-            {subscribers.map((entry) => (
-              <div className="subscription-row merchant-subscriber-row" key={entry.subscriber}>
-                <div className="merchant-row">
-                  <span className="merchant-row__address">
-                    {formatAddress(entry.subscriber)}
-                  </span>
-                  <CopyButton text={entry.subscriber} />
-                </div>
-                <div className="merchant-subscriber-value">
-                  <span className="subscription-row__value">
-                    {formatXlm(entry.amount)}
-                  </span>
-                  <div className="flex flex-col items-end gap-1">
-                    <span className="subscription-row__label">
-                      Next charge {formatNextCharge(entry.nextChargeAt)}
-                    </span>
-                    {outcomes[entry.subscriber] && (
-                      <span className={`badge badge-${outcomes[entry.subscriber].toLowerCase()}`}>
-                        {outcomes[entry.subscriber]}
+          <div
+            className="subscription-rows merchant-subscriber-list"
+            onScroll={virtualSubscribers.onScroll}
+            style={{ height: SUBSCRIBER_LIST_HEIGHT }}
+          >
+            <div
+              className="merchant-subscriber-list__spacer"
+              style={{ height: virtualSubscribers.totalHeight }}
+            >
+              <div
+                className="merchant-subscriber-list__window"
+                style={{ transform: `translateY(${virtualSubscribers.offsetY}px)` }}
+              >
+                {virtualSubscribers.visibleItems.map(({ item: entry, index }) => (
+                  <div
+                    className={`subscription-row merchant-subscriber-row${
+                      index === subscribers.length - 1 ? " merchant-subscriber-row--last" : ""
+                    }`}
+                    key={entry.subscriber}
+                  >
+                    <div className="merchant-row">
+                      <span className="merchant-row__address">
+                        {formatAddress(entry.subscriber)}
                       </span>
-                    )}
+                      <CopyButton text={entry.subscriber} />
+                    </div>
+                    <div className="merchant-subscriber-value">
+                      <span className="subscription-row__value">
+                        {formatXlm(entry.amount)}
+                      </span>
+                      <div className="flex flex-col items-end gap-1">
+                        <span className="subscription-row__label">
+                          Next charge {formatNextCharge(entry.nextChargeAt)}
+                        </span>
+                        {outcomes[entry.subscriber] && (
+                          <span className={`badge badge-${outcomes[entry.subscriber].toLowerCase()}`}>
+                            {outcomes[entry.subscriber]}
+                          </span>
+                        )}
+                      </div>
+                    </div>
                   </div>
-                </div>
+                ))}
               </div>
-            ))}
+            </div>
           </div>
         </div>
       )}

--- a/frontend/src/hooks/useVirtualList.ts
+++ b/frontend/src/hooks/useVirtualList.ts
@@ -1,0 +1,62 @@
+import { useCallback, useMemo, useState, type UIEvent } from "react";
+
+const OVERSCAN_ROWS = 3;
+
+export interface VirtualListItem<T> {
+  item: T;
+  index: number;
+}
+
+interface VirtualListResult<T> {
+  visibleItems: VirtualListItem<T>[];
+  totalHeight: number;
+  offsetY: number;
+  onScroll: (event: UIEvent) => void;
+}
+
+export function useVirtualList<T>(
+  items: T[],
+  itemHeight: number,
+  containerHeight: number
+): VirtualListResult<T> {
+  const [scrollTop, setScrollTop] = useState(0);
+
+  const onScroll = useCallback((event: UIEvent) => {
+    setScrollTop((event.currentTarget as { scrollTop: number }).scrollTop);
+  }, []);
+
+  return useMemo(() => {
+    const totalHeight = items.length * itemHeight;
+
+    if (items.length === 0 || itemHeight <= 0 || containerHeight <= 0) {
+      return {
+        visibleItems: [],
+        totalHeight,
+        offsetY: 0,
+        onScroll,
+      };
+    }
+
+    const maxFirstVisibleIndex = Math.max(items.length - 1, 0);
+    const firstVisibleIndex = Math.min(
+      Math.floor(scrollTop / itemHeight),
+      maxFirstVisibleIndex
+    );
+    const visibleCount = Math.ceil(containerHeight / itemHeight);
+    const startIndex = Math.max(firstVisibleIndex - OVERSCAN_ROWS, 0);
+    const endIndex = Math.min(
+      firstVisibleIndex + visibleCount + OVERSCAN_ROWS,
+      items.length
+    );
+    const visibleItems = items
+      .slice(startIndex, endIndex)
+      .map((item, offset) => ({ item, index: startIndex + offset }));
+
+    return {
+      visibleItems,
+      totalHeight,
+      offsetY: startIndex * itemHeight,
+      onScroll,
+    };
+  }, [containerHeight, itemHeight, items, onScroll, scrollTop]);
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -615,16 +615,32 @@ input::placeholder {
 }
 
 .merchant-subscriber-list {
-  gap: var(--space-3);
+  display: block;
+  overflow-y: auto;
+  position: relative;
+}
+
+.merchant-subscriber-list__spacer {
+  position: relative;
+  width: 100%;
+}
+
+.merchant-subscriber-list__window {
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
 }
 
 .merchant-subscriber-row {
+  box-sizing: border-box;
+  height: 72px;
   padding: var(--space-4) 0;
   border-bottom: 1px solid var(--color-border);
   align-items: flex-start;
 }
 
-.merchant-subscriber-row:last-child {
+.merchant-subscriber-row--last {
   border-bottom: none;
 }
 


### PR DESCRIPTION
## Summary

Fixes #431.

This adds a custom generic `useVirtualList<T>` hook and uses it to window the Merchant Dashboard subscriber list so large merchant subscriber sets no longer render every row at once.

## Problem

`MerchantDashboard.tsx` rendered the full `getMerchantSubscribers()` result directly. For 200+ subscribers, that creates hundreds of row trees and makes the 30-second polling refresh more expensive than necessary.

## Fix

- Add `frontend/src/hooks/useVirtualList.ts` with fixed-height virtual scrolling and 3-row overscan above/below the visible range.
- Render subscribers in a 400px native-scroll viewport with a total-height spacer and translated visible rows.
- Keep existing subscriber actions, labels, copy buttons, due-state handling, and batch-charge flow intact.
- Add a regression test that builds a 200-subscriber list and verifies the initial DOM row count stays at or below 20.

No new dependencies were added, and `package.json` / lockfiles are unchanged.

## Validation

QA-approved branch evidence:

- `cd frontend && npm test -- MerchantDashboard.test.tsx` passed (`5/5`).
- `cd frontend && ./node_modules/.bin/eslint src/hooks/useVirtualList.ts src/components/MerchantDashboard.tsx src/__tests__/MerchantDashboard.test.tsx` passed.
- `npm run typecheck` passed from the repository root.
- `cd frontend && npm run build` passed; Vite still reports the existing `src/stellar.ts` dynamic/static import chunk warning.
- `git diff --check HEAD^..HEAD` passed.

## Risk notes

- The virtualization uses a fixed `72px` row height and `400px` viewport to keep the scroll math stable.
- Full project `npm test` and full `npm run lint` still have unrelated pre-existing failures documented during QA; the touched-file lint, targeted regression test, typecheck, and frontend build passed for this change.
