### PR TITLE
docs: add KEEPER.md and CONTRIBUTING-CONTRACT.md

### DIFF
--- a/docs/CONTRIBUTING-CONTRACT.md
+++ b/docs/CONTRIBUTING-CONTRACT.md
@@ -1,0 +1,350 @@
+# Contributing to the FlowPay Contract
+
+This guide covers everything Rust/Soroban contributors need to know: module layout, adding a new public function, testing conventions, event emission rules, error variant guidelines, and the PR checklist.
+
+For general contribution guidelines (branching, commit style, frontend), see [`CONTRIBUTING.md`](../CONTRIBUTING.md).
+
+---
+
+## Table of Contents
+
+- [Module Layout](#module-layout)
+- [Adding a New Public Function](#adding-a-new-public-function)
+- [Testing Conventions](#testing-conventions)
+- [Benchmarks](#benchmarks)
+- [Event Emission Rules](#event-emission-rules)
+- [Error Variant Guidelines](#error-variant-guidelines)
+- [PR Checklist](#pr-checklist)
+
+---
+
+## Module Layout
+
+```
+contract/src/
+├── lib.rs                    # Contract entry point: DataKey enum, Subscription struct,
+│                             # FlowPay impl block with all public functions
+├── errors.rs                 # ContractError enum (#[contracterror])
+├── events.rs                 # All publish_* helpers
+├── batch.rs                  # batch_charge logic and ChargeResult enum
+├── charge_exec.rs            # Shared charge execution (precheck + execute)
+├── admin.rs                  # Admin / ownership helpers
+├── fee.rs                    # Protocol fee calculation and transfer
+├── grace.rs                  # Grace period get/set
+├── limits.rs                 # Contract-wide amount limits
+├── merchant_stats.rs         # Per-merchant revenue tracking
+├── migration.rs              # Schema versioning and state migration
+├── min_interval.rs           # Minimum subscription interval floor
+├── referral.rs               # Referral tracking
+├── spending_limit.rs         # Per-user daily spending limits (temporary storage)
+├── storage.rs                # Low-level storage helpers and TTL extension
+├── subscription_count.rs     # Active subscription counter
+├── subscription_history.rs   # Per-user charge history
+├── subscription_metadata.rs  # User-assigned subscription labels
+├── token.rs                  # SAC token client helpers
+├── trial.rs                  # Trial period support
+├── upgrade.rs                # Contract upgrade (wasm hash)
+├── validation.rs             # Input validation helpers
+├── whitelist.rs              # Merchant whitelist
+├── bench.rs                  # Benchmark tests (cfg(test) only)
+└── test.rs                   # Unit tests (cfg(test) only)
+```
+
+**Rules:**
+- Business logic belongs in a focused module, not in `lib.rs`.
+- `lib.rs` only wires public contract functions to module helpers — no logic inline.
+- `bench.rs` and `test.rs` are gated with `#[cfg(test)]`.
+
+---
+
+## Adding a New Public Function
+
+Follow these five steps every time.
+
+### 1. Add a storage key (if needed)
+
+In `lib.rs`, add a variant to `DataKey` for any new persistent state:
+
+```rust
+// lib.rs — DataKey enum
+DataKey::UserPreference(Address),
+```
+
+### 2. Implement the logic in a module
+
+Create or extend a module file. Keep functions small and single-purpose:
+
+```rust
+// src/my_feature.rs
+use soroban_sdk::{Address, Env};
+use crate::DataKey;
+
+pub fn get_preference(env: &Env, user: &Address) -> Option<u32> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::UserPreference(user.clone()))
+}
+
+pub fn set_preference(env: &Env, user: &Address, value: u32) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::UserPreference(user.clone()), &value);
+}
+```
+
+### 3. Declare the module in `lib.rs`
+
+```rust
+// lib.rs
+mod my_feature;
+```
+
+### 4. Expose the public contract function in `lib.rs`
+
+```rust
+// lib.rs — FlowPay impl block
+
+/// Returns the caller's preference value, or `None` if unset.
+pub fn get_preference(env: Env, user: Address) -> Option<u32> {
+    my_feature::get_preference(&env, &user)
+}
+
+/// Sets the caller's preference value. Requires caller auth.
+pub fn set_preference(env: Env, user: Address, value: u32) {
+    user.require_auth();
+    my_feature::set_preference(&env, &user, value);
+    events::publish_preference_set(&env, &user, value);
+}
+```
+
+**Auth rule:** any function that mutates user state or moves funds **must** call `user.require_auth()` before doing anything else.
+
+### 5. Add tests and events
+
+See [Testing Conventions](#testing-conventions) and [Event Emission Rules](#event-emission-rules) below.
+
+---
+
+## Testing Conventions
+
+All tests live in `contract/src/test.rs` and are gated with `#![cfg(test)]`.
+
+### Test setup
+
+Use the shared `setup()` helper for a standard environment with one funded user and one merchant:
+
+```rust
+fn setup() -> (Env, Address, Address, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let token_admin = Address::generate(&env);
+    let token_id = env.register_stellar_asset_contract_v2(token_admin.clone());
+    let token_addr = token_id.address();
+
+    let contract_id = env.register_contract(None, FlowPay);
+    let user = Address::generate(&env);
+    let merchant = Address::generate(&env);
+
+    // Mint and approve tokens for the user
+    let sac = StellarAssetClient::new(&env, &token_addr);
+    sac.mint(&user, &10_000_0000000);
+    let token = TokenClient::new(&env, &token_addr);
+    token.approve(&user, &contract_id, &10_000_0000000, &200);
+
+    (env, contract_id, token_addr, user, merchant)
+}
+```
+
+Only deviate from `setup()` when a test requires a genuinely different environment.
+
+### Naming
+
+Name tests after the behaviour being verified, not the function name:
+
+```
+test_daily_limit_blocks_overspend        ✓
+test_set_daily_limit                     ✗ (describes what it calls, not what it checks)
+```
+
+Group related tests using a shared prefix so `cargo test <prefix>` runs the whole suite:
+
+```
+test_daily_limit_allows_spend_within_limit
+test_daily_limit_accumulates_across_calls
+test_daily_limit_blocks_cumulative_overspend
+test_daily_limit_visibility_and_spend_tracking
+test_daily_limit_removed_event_emitted
+```
+
+### What to test
+
+Every new public function needs at minimum:
+
+| Test | What it verifies |
+|------|-----------------|
+| Happy path | Function succeeds under normal conditions |
+| Precondition failure | Correct error when inputs are invalid |
+| Auth enforcement | Panics when called without the required auth |
+| State after | Storage reflects the expected change |
+| Event emitted | The correct event was published (for state-changing functions) |
+
+### Asserting events
+
+Use `env.events().all()` and check the last event:
+
+```rust
+fn assert_last_user_event(env: &Env, topic: &str, user: &Address) {
+    let events = env.events().all();
+    let (_, topics, _) = events.get(events.len() - 1).unwrap();
+    assert_eq!(topics.get(0).unwrap(), Symbol::new(env, topic).into_val(env));
+    assert_eq!(topics.get(1).unwrap(), user.clone().into_val(env));
+}
+```
+
+### Advancing ledger time
+
+Use `env.ledger().set()` to simulate time passing:
+
+```rust
+env.ledger().set(soroban_sdk::testutils::LedgerInfo {
+    timestamp: current + 86_400, // advance by one day
+    ..env.ledger().get()
+});
+```
+
+### Running tests
+
+```bash
+cd contract
+cargo test                       # all tests
+cargo test daily_limit           # tests matching the prefix
+cargo test -- --nocapture        # show println! output (useful for bench)
+```
+
+---
+
+## Benchmarks
+
+Benchmark tests live in `contract/src/bench.rs` and measure CPU instruction counts to detect performance regressions.
+
+### Baselines
+
+| Function | CPU instructions | Memory bytes |
+|----------|-----------------|--------------|
+| `subscribe()` | ~4 200 000 | ~200 000 |
+| `charge()` | ~3 800 000 | ~180 000 |
+| `pay_per_use()` | ~3 600 000 | ~170 000 |
+| `batch_charge()` — 10 users | ~28 000 000 | ~1 200 000 |
+
+Thresholds in `bench.rs` include ~10% headroom. If your change shifts a baseline by more than 5%, update the table and the constant.
+
+### Adding a bench test
+
+```rust
+#[test]
+fn bench_my_feature() {
+    let (env, contract_id, token_addr, user, merchant) = bench_setup();
+    let client = FlowPayClient::new(&env, &contract_id);
+    // ... setup state ...
+
+    let usage = env.budget().cpu_instruction_count();
+    client.my_function(&user);
+    let delta = env.budget().cpu_instruction_count() - usage;
+
+    println!("my_function instructions: {delta}");
+    assert!(delta < MY_FUNCTION_MAX_INSTRUCTIONS);
+}
+```
+
+---
+
+## Event Emission Rules
+
+- **Every state-changing public function must emit an event.** Read-only functions must not.
+- All `publish_*` helpers live in `events.rs`. Add new ones there; never call `env.events().publish()` directly from `lib.rs` or module files.
+- Use a two-element topic tuple `(Symbol, Address)` for user-scoped events, or a single-element `(Symbol,)` for contract-wide events.
+- Topic symbols must be 32 characters or fewer (Soroban `Symbol` limit).
+- Name symbols with snake_case matching the action: `subscribed`, `charged`, `daily_limit_set`, `merchant_frozen`.
+
+**Adding a new event:**
+
+```rust
+// events.rs
+pub fn publish_preference_set(env: &Env, user: &Address, value: u32) {
+    env.events().publish(
+        (Symbol::new(env, "preference_set"), user.clone()),
+        value,
+    );
+}
+```
+
+Then call it from `lib.rs` after the state has been written:
+
+```rust
+my_feature::set_preference(&env, &user, value);
+events::publish_preference_set(&env, &user, value);  // always last
+```
+
+The full event catalogue is documented in [`docs/EVENTS.md`](../docs/EVENTS.md).
+
+---
+
+## Error Variant Guidelines
+
+All contract errors are defined in `errors.rs` as variants of `ContractError` (`#[contracterror]`).
+
+- **One variant per distinct failure reason.** Do not reuse a variant for different conditions.
+- Assign the next sequential `u32` discriminant. Never reuse or reorder existing values.
+- Add a doc comment explaining exactly when the error is returned.
+- Return errors via `Err(ContractError::VariantName)` from internal helpers; `lib.rs` should propagate or `unwrap_or_else` to panic with a clear message only as a last resort.
+
+```rust
+// errors.rs
+/// Returned when a user's daily spending limit would be exceeded by this payment.
+DailyLimitExceeded = 24,
+```
+
+The full error reference is in [`docs/ERROR-CODES.md`](../docs/ERROR-CODES.md).
+
+---
+
+## PR Checklist
+
+Before opening a pull request against `main`:
+
+**Contract**
+- [ ] `cargo test` passes with no failures
+- [ ] `cargo clippy -- -D warnings` passes with no warnings
+- [ ] `cargo check` passes
+- [ ] Every new public function has tests (happy path, auth, error cases, event)
+- [ ] Every new state-changing function emits an event via `events.rs`
+- [ ] New `ContractError` variants have doc comments and sequential discriminants
+- [ ] New `DataKey` variants are documented in a comment explaining the storage type (persistent / temporary / instance) and TTL if relevant
+- [ ] No `unwrap()` on user-controlled input — use `ok_or(ContractError::...)` instead
+- [ ] No floating-point arithmetic — all amounts are in stroops (i128)
+- [ ] `#![no_std]` is preserved — no `std::` imports anywhere
+
+**Benchmarks**
+- [ ] If your change touches `subscribe`, `charge`, `pay_per_use`, or `batch_charge`, run `cargo test bench -- --nocapture` and confirm instruction counts are within the documented baselines
+- [ ] Update `bench.rs` constants and the baselines table if a deliberate change shifts a baseline
+
+**Documentation**
+- [ ] New public functions are added to [`docs/API.md`](API.md)
+- [ ] New events are added to [`docs/EVENTS.md`](EVENTS.md)
+- [ ] New error codes are added to [`docs/ERROR-CODES.md`](ERROR-CODES.md)
+- [ ] PR description explains what changed, why, and links to the relevant issue
+
+**CI**
+- [ ] The `Backend (Rust)` GitHub Actions workflow passes (`cargo build` + `cargo test`)
+
+---
+
+## Related
+
+- General contribution guide: [`CONTRIBUTING.md`](../CONTRIBUTING.md)
+- API reference: [`docs/API.md`](API.md)
+- Event catalogue: [`docs/EVENTS.md`](EVENTS.md)
+- Error codes: [`docs/ERROR-CODES.md`](ERROR-CODES.md)
+- Architecture and storage design: [`docs/ARCHITECTURE.md`](ARCHITECTURE.md)
+- Testing runbook: [`docs/development/testing_runbook.md`](development/testing_runbook.md)

--- a/docs/KEEPER.md
+++ b/docs/KEEPER.md
@@ -1,0 +1,396 @@
+# Keeper Bot Operations Guide
+
+A keeper is an off-chain service that calls `batch_charge()` on the FlowPay contract on a schedule. Because Soroban contracts cannot self-execute, recurring billing only works if a keeper triggers each charge cycle. Without an active keeper, no subscriptions are processed and merchants receive no revenue.
+
+---
+
+## Table of Contents
+
+- [How It Works](#how-it-works)
+- [Running the Reference Keeper](#running-the-reference-keeper)
+- [Configuration](#configuration)
+- [Recommended Cadence](#recommended-cadence)
+- [Monitoring and Alerting](#monitoring-and-alerting)
+- [Handling Failed Charges](#handling-failed-charges)
+- [Deployment Patterns](#deployment-patterns)
+- [Operational Checklist](#operational-checklist)
+
+---
+
+## How It Works
+
+Each subscription stores a `last_charged` timestamp and an `interval` (in seconds). A charge is due when:
+
+```
+current_time >= last_charged + interval
+```
+
+The contract also enforces a configurable grace period. If a charge is attempted after `last_charged + interval + grace_period`, the result is `GracePeriodElapsed` and the subscription is considered lapsed.
+
+`batch_charge(users)` accepts a list of user addresses and processes each one independently — a failure on one address does not abort the rest. Each entry in the returned `Vec<ChargeResult>` is one of:
+
+| Result | Meaning |
+|--------|---------|
+| `Charged` | Funds transferred successfully |
+| `Skipped` | Interval has not elapsed yet |
+| `NoSubscription` | No subscription found for this address |
+| `Inactive` | Subscription is cancelled |
+| `Paused` | Subscription is paused by the user |
+| `GracePeriodElapsed` | Charge window expired; subscription lapsed |
+
+The keeper must page through the full subscriber index using `get_subscriber_index_size()` and `get_subscriber_at(offset)`, then pass slices of addresses to `batch_charge()`.
+
+---
+
+## Running the Reference Keeper
+
+### Prerequisites
+
+- Python 3.9+
+- Soroban RPC endpoint (testnet or mainnet)
+- A funded Stellar keypair for the keeper account (minimum 100 XLM recommended)
+- The deployed contract ID
+
+### Install dependencies
+
+```bash
+pip install stellar-sdk
+```
+
+### Reference implementation
+
+```python
+#!/usr/bin/env python3
+"""FlowPay reference keeper — calls batch_charge() on a schedule."""
+
+import os
+import time
+import logging
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger("keeper")
+
+PAGE_SIZE = int(os.getenv("KEEPER_PAGE_SIZE", "100"))
+INTERVAL_SECONDS = int(os.getenv("KEEPER_INTERVAL", "3600"))
+CONTRACT_ID = os.environ["KEEPER_CONTRACT_ID"]
+RPC_URL = os.environ["KEEPER_RPC_URL"]
+KEEPER_SECRET = os.environ["KEEPER_SECRET_KEY"]
+
+
+def get_client():
+    from stellar_sdk import Keypair, SorobanServer
+    server = SorobanServer(RPC_URL)
+    keypair = Keypair.from_secret(KEEPER_SECRET)
+    return server, keypair
+
+
+def fetch_subscriber_page(server, keypair, offset: int, limit: int) -> list:
+    """Return up to `limit` subscriber addresses starting at `offset`."""
+    # Invoke get_subscriber_at for each position in the page range
+    addresses = []
+    for i in range(offset, offset + limit):
+        result = invoke_read(server, keypair, "get_subscriber_at", {"offset": i})
+        if result is None:
+            break
+        addresses.append(result)
+    return addresses
+
+
+def invoke_read(server, keypair, function_name: str, args: dict):
+    """Read-only contract invocation. Returns None on any error."""
+    try:
+        # Use your preferred Soroban SDK invocation method here
+        pass
+    except Exception as e:
+        logger.warning(f"read {function_name} failed: {e}")
+        return None
+
+
+def run_charge_cycle(server, keypair):
+    """Page through all subscribers and call batch_charge() for each page."""
+    offset = 0
+    total_charged = 0
+
+    while True:
+        addresses = fetch_subscriber_page(server, keypair, offset, PAGE_SIZE)
+        if not addresses:
+            logger.info(f"Cycle complete — {total_charged} charged, {offset} processed")
+            break
+
+        try:
+            results = invoke_batch_charge(server, keypair, addresses)
+            charged = sum(1 for r in results if r == "Charged")
+            total_charged += charged
+            logger.info(f"Page offset={offset} size={len(addresses)}: {charged} charged")
+        except Exception as e:
+            logger.error(f"batch_charge failed at offset={offset}: {e}")
+            alert("batch_charge_failure", {"offset": offset, "error": str(e)})
+
+        offset += PAGE_SIZE
+
+    return total_charged
+
+
+def invoke_batch_charge(server, keypair, addresses: list) -> list:
+    """Call batch_charge(users) and return the list of ChargeResult strings."""
+    # Implement using your Soroban SDK bindings
+    raise NotImplementedError
+
+
+def alert(event: str, context: dict):
+    """Send an alert to your monitoring system."""
+    logger.critical(f"ALERT {event}: {context}")
+
+
+def check_balance(server, keypair) -> float:
+    """Return the keeper account balance in XLM."""
+    # Implement using stellar_sdk account lookup
+    return 0.0
+
+
+def main():
+    server, keypair = get_client()
+
+    while True:
+        balance = check_balance(server, keypair)
+        if balance < 10:
+            alert("keeper_balance_low", {"balance_xlm": balance})
+
+        try:
+            run_charge_cycle(server, keypair)
+        except Exception as e:
+            logger.error(f"Keeper loop error: {e}")
+            alert("keeper_loop_error", {"error": str(e)})
+
+        logger.info(f"Sleeping {INTERVAL_SECONDS}s until next cycle")
+        time.sleep(INTERVAL_SECONDS)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+---
+
+## Configuration
+
+All configuration is read from environment variables. No config file is required.
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `KEEPER_CONTRACT_ID` | Yes | — | Deployed FlowPay contract ID |
+| `KEEPER_RPC_URL` | Yes | — | Soroban RPC endpoint (e.g. `https://soroban-testnet.stellar.org`) |
+| `KEEPER_SECRET_KEY` | Yes | — | Stellar secret key for the keeper account (starts with `S`) |
+| `KEEPER_INTERVAL` | No | `3600` | Seconds between charge cycles |
+| `KEEPER_PAGE_SIZE` | No | `100` | Addresses per `batch_charge()` call (max 100) |
+| `KEEPER_ALERT_WEBHOOK` | No | — | Webhook URL for alert notifications |
+| `KEEPER_MIN_BALANCE_XLM` | No | `10` | Alert threshold for keeper account balance |
+
+Store `KEEPER_SECRET_KEY` in a secrets manager (AWS Secrets Manager, HashiCorp Vault, etc.) — never commit it to source control.
+
+---
+
+## Recommended Cadence
+
+The right interval depends on the shortest subscription interval used in your deployment.
+
+| Shortest subscription interval | Recommended keeper cadence |
+|-------------------------------|---------------------------|
+| 1 day (86 400 s) | Every hour |
+| 1 week | Every 4–6 hours |
+| 1 month | Every 12–24 hours |
+
+Run the keeper more frequently than the shortest subscription interval so that users are charged promptly and the grace period buffer is not consumed by keeper downtime.
+
+For most deployments, **hourly** is the correct default. The full charge cycle for 1 000 subscribers completes in under a minute on a healthy RPC node, so there is no cost to running frequently.
+
+---
+
+## Monitoring and Alerting
+
+### Key metrics to track
+
+| Metric | Warning threshold | Critical threshold | Action |
+|--------|-------------------|--------------------|--------|
+| Keeper account balance | < 50 XLM | < 10 XLM | Top up immediately |
+| Cycle duration | > 2 min | > 5 min | Check RPC health |
+| Failed `batch_charge` calls | > 0 | > 5% of pages | Review error logs |
+| Time since last successful cycle | > 1.5× interval | > 2× interval | Page on-call |
+| `GracePeriodElapsed` results | Any | — | Investigate missed cycles |
+
+### Prometheus / Alertmanager example
+
+```yaml
+# keeper_alerts.yml
+groups:
+  - name: keeper
+    rules:
+      - alert: KeeperBalanceLow
+        expr: keeper_balance_xlm < 10
+        for: 5m
+        annotations:
+          summary: "Keeper account balance below 10 XLM — refund immediately"
+
+      - alert: KeeperCycleMissed
+        expr: time() - keeper_last_successful_cycle_timestamp > 7200
+        for: 5m
+        annotations:
+          summary: "No successful keeper cycle in 2 hours"
+
+      - alert: BatchChargeFailure
+        expr: increase(keeper_batch_charge_errors_total[15m]) > 0
+        annotations:
+          summary: "batch_charge returned an error"
+```
+
+### Health endpoint (recommended)
+
+Expose a `/health` HTTP endpoint that returns:
+
+```json
+{
+  "status": "ok",
+  "last_cycle_at": 1719443400,
+  "last_cycle_charged": 312,
+  "keeper_balance_xlm": 87.4,
+  "cycle_duration_ms": 14200
+}
+```
+
+This allows external uptime monitors (e.g. UptimeRobot, Pingdom) to verify the keeper is alive.
+
+---
+
+## Handling Failed Charges
+
+### Per-address failures
+
+`batch_charge()` returns a `ChargeResult` per address and never reverts the whole batch. Log each non-`Charged` result with the address and result type:
+
+```
+[2026-06-26T10:00:01Z] INFO  GCXXX...=Skipped
+[2026-06-26T10:00:01Z] WARN  GDYYY...=GracePeriodElapsed
+```
+
+`GracePeriodElapsed` results are worth alerting on — they indicate a subscription lapsed because the keeper was late. Investigate the cause (keeper downtime, network congestion).
+
+### Full cycle failures
+
+If `batch_charge()` throws an error (not just returns a bad result), the keeper should:
+
+1. Log the error and page offset
+2. Retry the same page up to 3 times with exponential backoff (1 s, 2 s, 4 s)
+3. If all retries fail, skip that page, continue to the next, and alert
+
+```python
+MAX_RETRIES = 3
+
+def batch_charge_with_retry(server, keypair, addresses):
+    for attempt in range(MAX_RETRIES):
+        try:
+            return invoke_batch_charge(server, keypair, addresses)
+        except Exception as e:
+            if attempt == MAX_RETRIES - 1:
+                raise
+            wait = 2 ** attempt
+            logger.warning(f"Retrying in {wait}s after error: {e}")
+            time.sleep(wait)
+```
+
+### Low keeper balance
+
+If the keeper account has insufficient XLM for transaction fees, all invocations will fail. Set up an automated top-up or a balance alert well above the minimum. The keeper should abort the cycle and alert immediately when balance drops below the configured threshold.
+
+### Contract paused
+
+If the contract admin calls `pause_contract()`, all charges return `ContractPaused` (error code 18). The keeper should detect this, log a clear message, and stop cycling until the contract is unpaused. Do not fill logs with repeated failure attempts.
+
+---
+
+## Deployment Patterns
+
+### Simple cron (non-HA)
+
+Suitable for testnet or low-value deployments:
+
+```bash
+# /etc/cron.d/payflow-keeper
+0 * * * * keeper /opt/keeper/run.py >> /var/log/keeper.log 2>&1
+```
+
+Risks: single point of failure; missed cycles if the host restarts.
+
+### Systemd service (recommended for single-node)
+
+```ini
+# /etc/systemd/system/payflow-keeper.service
+[Unit]
+Description=PayFlow Keeper Bot
+After=network.target
+
+[Service]
+User=keeper
+EnvironmentFile=/etc/payflow/keeper.env
+ExecStart=/opt/keeper/run.py
+Restart=on-failure
+RestartSec=30
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+systemctl enable --now payflow-keeper
+journalctl -u payflow-keeper -f
+```
+
+### High-availability with leader election (production)
+
+Run 2–3 keeper replicas. Only the elected leader executes charge cycles; followers monitor and take over on leader failure. Use Redis `SET NX EX` for a simple distributed lock:
+
+```python
+LEASE_TTL = 300  # seconds
+
+def try_acquire_leader(redis_client, keeper_id: str) -> bool:
+    return redis_client.set("keeper:leader", keeper_id, ex=LEASE_TTL, nx=True)
+```
+
+Renew the lease before it expires. If a leader crashes, the lock expires and a follower acquires it within `LEASE_TTL` seconds.
+
+---
+
+## Operational Checklist
+
+### Before going live
+
+- [ ] Keeper account funded with at least 100 XLM
+- [ ] `KEEPER_CONTRACT_ID`, `KEEPER_RPC_URL`, and `KEEPER_SECRET_KEY` set and verified
+- [ ] Pagination tested against the production subscriber index
+- [ ] Alerting rules deployed and tested with a synthetic low-balance condition
+- [ ] Health endpoint reachable and integrated with an uptime monitor
+- [ ] Restart policy configured (`Restart=on-failure` or equivalent)
+
+### Routine operations
+
+- [ ] Check keeper balance weekly; automate top-up if possible
+- [ ] Review `GracePeriodElapsed` counts after every deploy or maintenance window
+- [ ] Rotate the keeper secret key on a regular schedule; update the secrets manager entry
+- [ ] After a contract upgrade, verify the keeper ABI matches the new contract interface
+
+### Incident response
+
+| Symptom | First check | Resolution |
+|---------|-------------|------------|
+| No cycles for > 2 h | `journalctl -u payflow-keeper` | Restart service; check balance |
+| `GracePeriodElapsed` spikes | Keeper uptime during the window | Manually invoke missed pages; investigate root cause |
+| `batch_charge` throws `InvalidArgument` | Contract upgrade happened | Redeploy keeper with updated ABI |
+| Cycle takes > 5 min | RPC node latency | Switch to a backup RPC endpoint |
+
+---
+
+## Related
+
+- `batch_charge(users)` — contract function reference: [`docs/API.md`](API.md)
+- Full operations runbook (pagination deep-dive, Terraform IaC): [`docs/operations/keeper_runbook.md`](operations/keeper_runbook.md)
+- Architecture and storage layout: [`docs/ARCHITECTURE.md`](ARCHITECTURE.md)
+- Error codes: [`docs/ERROR-CODES.md`](ERROR-CODES.md)


### PR DESCRIPTION
Closes #409 
Closes #410 

## Changes
- **docs/KEEPER.md** — Keeper bot operations guide covering: what a keeper is and why it's needed, reference keeper script, configuration options, recommended cadence, monitoring/alerting (Prometheus rules + health endpoint), handling failed charges, deployment patterns (cron → systemd → HA leader election), and operational checklist.
- **docs/CONTRIBUTING-CONTRACT.md** — Contract contribution guide covering: module layout, how to add a new public function, testing conventions (naming, setup helper, event assertions, time advancement), benchmarks with baselines, event emission rules, error variant guidelines, and the full PR checklist.