### PR TITLE
feat: clippy CI, frontend lint/format CI, daily revenue summary, and alert scripts

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -24,5 +24,9 @@ jobs:
         cache-dependency-path: frontend/package-lock.json
     - name: Install dependencies
       run: npm ci
+    - name: Lint
+      run: npm run lint
+    - name: Format check
+      run: npx prettier --check .
     - name: Build
       run: npm run build

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,6 +20,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - name: Install Rust target
+      run: rustup target add wasm32-unknown-unknown
+    - name: Clippy
+      run: cargo clippy -- -D warnings
+      working-directory: contract
     - name: Build
       run: cargo build --verbose
       working-directory: contract

--- a/scripts/alert-failed-charges.ts
+++ b/scripts/alert-failed-charges.ts
@@ -1,0 +1,135 @@
+#!/usr/bin/env tsx
+/**
+ * alert-failed-charges.ts
+ *
+ * Identifies users whose charge failed from the most recent batch_charge results
+ * and sends a POST webhook notification with the list of failed users.
+ *
+ * Usage:
+ *   WEBHOOK_URL=https://hooks.example.com/payflow tsx scripts/alert-failed-charges.ts [--db <path>] [--since <unix-ts>]
+ *
+ * Environment:
+ *   WEBHOOK_URL   Required. Webhook URL to POST the alert payload to.
+ *   INDEXER_DB    Optional. Path to the indexer SQLite DB (default: indexer.db).
+ *
+ * Expected DB table:
+ *   events(event_name TEXT, data TEXT, timestamp INTEGER)
+ *   - event_name 'charge_failed' with data { user, reason, amount }
+ */
+
+import { DatabaseSync } from "node:sqlite";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+interface FailedChargeData {
+  user?: string;
+  reason?: string;
+  amount?: number | string;
+}
+
+interface FailedChargeEntry {
+  user_address: string;
+  reason: string;
+  subscription_amount: number;
+}
+
+interface AlertPayload {
+  generated_at: string;
+  total_failed: number;
+  failed_charges: FailedChargeEntry[];
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function getArg(flag: string): string | undefined {
+  const idx = process.argv.indexOf(flag);
+  return idx !== -1 ? process.argv[idx + 1] : undefined;
+}
+
+function safeParseData(raw: string): FailedChargeData {
+  try {
+    return JSON.parse(raw) as FailedChargeData;
+  } catch {
+    return {};
+  }
+}
+
+async function sendWebhook(url: string, payload: AlertPayload): Promise<void> {
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    if (!response.ok) {
+      console.error(
+        `Webhook responded with HTTP ${response.status}: ${response.statusText}`
+      );
+    } else {
+      console.error(`Webhook delivered successfully (HTTP ${response.status})`);
+    }
+  } catch (err) {
+    // Log failure but do not crash — callers rely on non-zero exit only for fatal errors
+    console.error(`Webhook delivery failed: ${err}`);
+  }
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const webhookUrl = process.env.WEBHOOK_URL;
+  if (!webhookUrl) {
+    console.error("Error: WEBHOOK_URL environment variable is required.");
+    process.exit(1);
+  }
+
+  const dbPath = getArg("--db") ?? process.env.INDEXER_DB ?? "indexer.db";
+  const sinceArg = getArg("--since");
+  const sinceTs = sinceArg ? parseInt(sinceArg, 10) : 0;
+
+  let db: InstanceType<typeof DatabaseSync>;
+  try {
+    db = new DatabaseSync(dbPath, { open: true });
+  } catch (err) {
+    console.error(`Failed to open database at ${dbPath}: ${err}`);
+    process.exit(1);
+  }
+
+  const query = db.prepare(
+    `SELECT data FROM events
+     WHERE event_name = 'charge_failed'
+       AND timestamp >= ?
+     ORDER BY timestamp DESC`
+  );
+
+  const rows = query.all(sinceTs) as Array<{ data: string }>;
+
+  const failedCharges: FailedChargeEntry[] = rows.map((row) => {
+    const d = safeParseData(row.data);
+    return {
+      user_address: d.user ?? "unknown",
+      reason: d.reason ?? "unknown",
+      subscription_amount: Number(d.amount ?? 0),
+    };
+  });
+
+  const payload: AlertPayload = {
+    generated_at: new Date().toISOString(),
+    total_failed: failedCharges.length,
+    failed_charges: failedCharges,
+  };
+
+  if (failedCharges.length === 0) {
+    console.error("No failed charges found. No webhook sent.");
+    console.log(JSON.stringify(payload, null, 2));
+    return;
+  }
+
+  console.log(JSON.stringify(payload, null, 2));
+  await sendWebhook(webhookUrl, payload);
+}
+
+main().catch((err) => {
+  console.error(`Fatal error: ${err}`);
+  process.exit(1);
+});

--- a/scripts/daily-revenue-summary.ts
+++ b/scripts/daily-revenue-summary.ts
@@ -1,0 +1,148 @@
+#!/usr/bin/env tsx
+/**
+ * daily-revenue-summary.ts
+ *
+ * Queries the indexer DB for the previous calendar day's (UTC) events and
+ * outputs a structured JSON revenue summary to stdout.
+ *
+ * Usage:
+ *   tsx scripts/daily-revenue-summary.ts [--date YYYY-MM-DD] [--db <path>]
+ *
+ * Expected DB tables:
+ *   events(event_name TEXT, data TEXT, timestamp INTEGER)
+ *   - event_name 'charged'      → data includes { amount, merchant, user }
+ *   - event_name 'subscribed'   → new subscriber
+ *   - event_name 'cancelled'    → cancellation
+ *   - event_name 'fee_collected'→ data includes { amount }
+ */
+
+import { DatabaseSync } from "node:sqlite";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+interface ChargeData {
+  amount?: number | string;
+  fee?: number | string;
+  merchant?: string;
+  user?: string;
+}
+
+interface DailyRevenueSummary {
+  date: string;
+  generated_at: string;
+  total_charges: number;
+  total_amount: number;
+  total_fees_collected: number;
+  new_subscriptions: number;
+  cancellations: number;
+  net_merchant_revenue: number;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function getArg(flag: string): string | undefined {
+  const idx = process.argv.indexOf(flag);
+  return idx !== -1 ? process.argv[idx + 1] : undefined;
+}
+
+function utcDayBounds(dateStr: string): { startMs: number; endMs: number } {
+  const startMs = new Date(`${dateStr}T00:00:00Z`).getTime();
+  const endMs = startMs + 86_400_000;
+  return { startMs, endMs };
+}
+
+function previousUtcDay(): string {
+  const now = new Date();
+  const yesterday = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - 1)
+  );
+  return yesterday.toISOString().slice(0, 10);
+}
+
+function safeParseData(raw: string): ChargeData {
+  try {
+    return JSON.parse(raw) as ChargeData;
+  } catch {
+    return {};
+  }
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+function main(): void {
+  const dbPath = getArg("--db") ?? process.env.INDEXER_DB ?? "indexer.db";
+  const dateArg = getArg("--date");
+  const targetDate = dateArg ?? previousUtcDay();
+
+  // Validate date format
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(targetDate)) {
+    console.error(`Invalid date format: ${targetDate}. Expected YYYY-MM-DD.`);
+    process.exit(1);
+  }
+
+  const { startMs, endMs } = utcDayBounds(targetDate);
+  const startSec = Math.floor(startMs / 1000);
+  const endSec = Math.floor(endMs / 1000);
+
+  let db: InstanceType<typeof DatabaseSync>;
+  try {
+    db = new DatabaseSync(dbPath, { open: true });
+  } catch (err) {
+    console.error(`Failed to open database at ${dbPath}: ${err}`);
+    process.exit(1);
+  }
+
+  const query = db.prepare(
+    `SELECT event_name, data FROM events
+     WHERE timestamp >= ? AND timestamp < ?`
+  );
+
+  const rows = query.all(startSec, endSec) as Array<{
+    event_name: string;
+    data: string;
+  }>;
+
+  let totalCharges = 0;
+  let totalAmount = 0;
+  let totalFees = 0;
+  let newSubscriptions = 0;
+  let cancellations = 0;
+
+  for (const row of rows) {
+    switch (row.event_name) {
+      case "charged": {
+        const d = safeParseData(row.data);
+        totalCharges += 1;
+        totalAmount += Number(d.amount ?? 0);
+        totalFees += Number(d.fee ?? 0);
+        break;
+      }
+      case "fee_collected": {
+        const d = safeParseData(row.data);
+        totalFees += Number(d.amount ?? 0);
+        break;
+      }
+      case "subscribed":
+        newSubscriptions += 1;
+        break;
+      case "cancelled":
+        cancellations += 1;
+        break;
+    }
+  }
+
+  const summary: DailyRevenueSummary = {
+    date: targetDate,
+    generated_at: new Date().toISOString(),
+    total_charges: totalCharges,
+    total_amount: totalAmount,
+    total_fees_collected: totalFees,
+    new_subscriptions: newSubscriptions,
+    cancellations: cancellations,
+    net_merchant_revenue: totalAmount - totalFees,
+  };
+
+  console.log(JSON.stringify(summary, null, 2));
+}
+
+main();


### PR DESCRIPTION
## Summary

- **#403** — Added `npm run lint` and `npx prettier --check .` steps to `.github/workflows/frontend.yml` after dependency install. CI now fails on lint errors or formatting violations.
- **#404** — Added `cargo clippy -- -D warnings` step to `.github/workflows/rust.yml` after checkout (before build). Warnings are treated as errors.
- **#405** — Added `scripts/alert-failed-charges.ts`: queries `charge_failed` events from the indexer SQLite DB, builds a structured payload, and POSTs to a configurable `WEBHOOK_URL`. Gracefully handles webhook failures (logs, does not crash). Accepts `--since <unix-ts>` and `--db <path>`.
- **#406** — Added `scripts/daily-revenue-summary.ts`: queries the indexer DB for the previous calendar day (UTC) and outputs a JSON summary with `total_charges`, `total_amount`, `total_fees_collected`, `new_subscriptions`, `cancellations`, and `net_merchant_revenue`. Accepts `--date YYYY-MM-DD` for historical reports.

## Closes

Closes #403
Closes #404
Closes #405
Closes #406

## Test plan
- [ ] `cargo clippy -- -D warnings` passes on current contract codebase
- [ ] `npm run lint` and `npx prettier --check .` pass on current frontend
- [ ] `tsx scripts/daily-revenue-summary.ts --db test.db --date 2026-06-27` outputs valid JSON
- [ ] `WEBHOOK_URL=... tsx scripts/alert-failed-charges.ts --db test.db` POSTs payload and logs delivery

🤖 Generated with [Claude Code](https://claude.com/claude-code)