### PR TITLE
Sundayjob996

### DIFF
--- a/contract/src/errors.rs
+++ b/contract/src/errors.rs
@@ -64,4 +64,8 @@ pub enum ContractError {
     ContractPausedError = 30,
     /// Returned when a provided recipient address is invalid (e.g., contract address)
     InvalidRecipient = 32,
+    /// Returned when a configured global volume cap is not positive
+    InvalidVolumeCap = 33,
+    /// Returned when configured fee bounds are inconsistent (min > max, or max > 10000)
+    InvalidFeeBounds = 34,
 }

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -1588,6 +1588,39 @@ impl FlowPay {
         let sub: Subscription = env.storage().persistent().get(&DataKey::Subscription(user))?;
         Some(sub.merchant)
     }
+
+    /// Returns a page of subscriber addresses starting at `offset`, capped
+    /// at 50 per call, filtered to only those whose subscription is
+    /// currently active. Avoids forcing callers to over-fetch via
+    /// `get_subscriber_page` and filter client-side.
+    pub fn get_active_subscriber_page(env: Env, offset: u64, limit: u32) -> Vec<Address> {
+        let count = subscription_count::get_subscriber_index_size(&env);
+        let cap: u32 = if limit > 50 { 50 } else { limit };
+        let mut result = Vec::new(&env);
+        if offset >= count || cap == 0 {
+            return result;
+        }
+        let mut i = offset;
+        while i < count && result.len() < cap {
+            if let Some(addr) = env
+                .storage()
+                .persistent()
+                .get::<DataKey, Address>(&DataKey::SubscriberIndex(i))
+            {
+                if let Some(sub) = env
+                    .storage()
+                    .persistent()
+                    .get::<DataKey, Subscription>(&DataKey::Subscription(addr.clone()))
+                {
+                    if sub.active {
+                        result.push_back(addr);
+                    }
+                }
+            }
+            i += 1;
+        }
+        result
+    }
 }
 
 /// Refreshes the contract instance's TTL. Instance storage holds shared

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -1543,6 +1543,38 @@ impl FlowPay {
             .instance()
             .set(&DataKey::GlobalVolumeCapOverride, &new_cap);
     }
+
+    // ─────────────────────────────────────────────────────────────
+    // Configurable fee bounds (governance guardrails)
+    // ─────────────────────────────────────────────────────────────
+
+    /// Admin-only: configures the allowed [min_bps, max_bps] range for
+    /// future fee proposals, guarding against accidental fee misconfiguration
+    /// (e.g. an operator typo setting bps close to 10000).
+    pub fn set_fee_bounds(env: Env, min_bps: u32, max_bps: u32) {
+        admin::require_admin(&env);
+        if min_bps > max_bps || max_bps > 10_000 {
+            env.panic_with_error(ContractError::InvalidFeeBounds);
+        }
+        env.storage().instance().set(&DataKey::MinFeeBps, &min_bps);
+        env.storage().instance().set(&DataKey::MaxFeeBps, &max_bps);
+    }
+
+    /// Returns the configured (min_bps, max_bps) fee bounds, defaulting to
+    /// (0, 10000) when governance has not configured explicit bounds.
+    pub fn get_fee_bounds(env: Env) -> (u32, u32) {
+        let min_bps = env
+            .storage()
+            .instance()
+            .get(&DataKey::MinFeeBps)
+            .unwrap_or(0u32);
+        let max_bps = env
+            .storage()
+            .instance()
+            .get(&DataKey::MaxFeeBps)
+            .unwrap_or(10_000u32);
+        (min_bps, max_bps)
+    }
 }
 
 /// Refreshes the contract instance's TTL. Instance storage holds shared

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -1575,6 +1575,19 @@ impl FlowPay {
             .unwrap_or(10_000u32);
         (min_bps, max_bps)
     }
+
+    // ─────────────────────────────────────────────────────────────
+    // Lightweight subscription reads
+    // ─────────────────────────────────────────────────────────────
+
+    /// Returns just the merchant address for a user's subscription, without
+    /// decoding the full `Subscription` struct. Lighter-weight than
+    /// `get_subscription` for callers that only need to know which merchant
+    /// a user subscribes to.
+    pub fn get_subscriber_merchant(env: Env, user: Address) -> Option<Address> {
+        let sub: Subscription = env.storage().persistent().get(&DataKey::Subscription(user))?;
+        Some(sub.merchant)
+    }
 }
 
 /// Refreshes the contract instance's TTL. Instance storage holds shared

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -97,6 +97,11 @@ pub enum DataKey {
     PendingUpgrade,
     // Feature: pause expiry (bounded pause with auto-resume)
     PauseExpiry(Address),
+    // Feature: configurable global hourly volume cap override
+    GlobalVolumeCapOverride,
+    // Feature: configurable min/max fee bps bounds
+    MinFeeBps,
+    MaxFeeBps,
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -1511,6 +1516,32 @@ impl FlowPay {
         extend_subscription_ttl(&env, &new_user);
 
         events::publish_subscription_transferred(&env, &user, &new_user);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Configurable global hourly volume cap
+    // ─────────────────────────────────────────────────────────────
+
+    /// Returns the currently effective global hourly volume cap (stroops).
+    /// Falls back to the compile-time `GLOBAL_MAX_VOLUME_PER_HOUR` default
+    /// when no operator override has been configured.
+    pub fn get_global_volume_cap(env: Env) -> i128 {
+        env.storage()
+            .instance()
+            .get(&DataKey::GlobalVolumeCapOverride)
+            .unwrap_or(GLOBAL_MAX_VOLUME_PER_HOUR)
+    }
+
+    /// Admin-only: overrides the global hourly volume cap without requiring
+    /// a contract upgrade. `new_cap` must be strictly positive.
+    pub fn set_global_volume_cap(env: Env, new_cap: i128) {
+        admin::require_admin(&env);
+        if new_cap <= 0 {
+            env.panic_with_error(ContractError::InvalidVolumeCap);
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::GlobalVolumeCapOverride, &new_cap);
     }
 }
 


### PR DESCRIPTION
closes #622
closes #632
closes #639
closes #631

GLOBAL_MAX_VOLUME_PER_HOUR is hardcoded as a constant at 50_000_000_000_000 stroops. As the protocol scales or moves to mainnet, operators need to adjust this cap without redeploying the contract.

Problem
The global hourly volume cap is a compile-time constant and cannot be changed without a contract upgrade. This is inflexible for production operations where the cap may need tuning based on observed usage patterns or token price changes.

set_fee validates that bps <= 10000 (100%) but has no minimum validation. An admin could set bps = 9999 (99.99% fee), which while technically valid is likely an operator error. Bounds checking at initialization time and a configurable max bps would prevent accidental fee misconfiguration.

Problem
Fee bps has only an upper bound (10000) and no minimum, and there is no way for governance to enforce a maximum allowed fee below 10000. A misconfigured fee could effectively confiscate subscriber payments.


get_subscription returns the full Subscription struct. For use cases that only need the merchant address (e.g., checking which merchant a user subscribes to), this is wasteful. A dedicated read function improves RPC efficiency.

Problem
There is no lightweight get_subscriber_merchant(user) -> Option function. Callers must decode the full subscription struct when they only need the merchant address, increasing RPC response sizes and client-side parsing complexity.

