### PR TITLE
feat: extend keyboard shortcuts with n, r, 1/2/3 keys

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -167,6 +167,21 @@ export default function App() {
   // Global keyboard shortcuts
   useRegisterShortcuts([
     {
+      key: "1",
+      description: "Switch to Subscriber tab",
+      action: () => setTab("dashboard"),
+    },
+    {
+      key: "2",
+      description: "Switch to Merchant tab",
+      action: () => setTab("merchant"),
+    },
+    {
+      key: "3",
+      description: "Switch to Admin tab",
+      action: () => setTab("admin"),
+    },
+    {
       key: "d",
       description: "Switch to Dashboard",
       action: () => setTab("dashboard"),
@@ -185,6 +200,18 @@ export default function App() {
       key: "a",
       description: "Switch to Admin",
       action: () => setTab("admin"),
+    },
+    {
+      key: "n",
+      description: "New Subscription form",
+      action: () => {
+        if (!showHelp) setTab("subscribe");
+      },
+    },
+    {
+      key: "r",
+      description: "Refresh current tab",
+      action: () => setRefresh((r) => r + 1),
     },
     {
       key: "?",

--- a/frontend/src/__tests__/useKeyboardShortcuts.test.tsx
+++ b/frontend/src/__tests__/useKeyboardShortcuts.test.tsx
@@ -1,0 +1,132 @@
+import { fireEvent, renderHook, render, screen } from "@testing-library/react";
+import React from "react";
+import { vi, describe, it, expect } from "vitest";
+import { useKeyboardShortcuts } from "../hooks/useKeyboardShortcuts";
+
+// ── useKeyboardShortcuts ──────────────────────────────────────────────────────
+
+describe("useKeyboardShortcuts", () => {
+  it("calls the registered action when the matching key is pressed", () => {
+    const action = vi.fn();
+    renderHook(() =>
+      useKeyboardShortcuts({ shortcuts: [{ key: "k", description: "Test action", action }] })
+    );
+    fireEvent.keyDown(window, { key: "k" });
+    expect(action).toHaveBeenCalledTimes(1);
+  });
+
+  it("does nothing when an unregistered key is pressed", () => {
+    const action = vi.fn();
+    renderHook(() =>
+      useKeyboardShortcuts({ shortcuts: [{ key: "k", description: "Test action", action }] })
+    );
+    fireEvent.keyDown(window, { key: "x" });
+    expect(action).not.toHaveBeenCalled();
+  });
+
+  it("does not trigger shortcuts when enabled is false", () => {
+    const action = vi.fn();
+    renderHook(() =>
+      useKeyboardShortcuts({
+        enabled: false,
+        shortcuts: [{ key: "k", description: "Test action", action }],
+      })
+    );
+    fireEvent.keyDown(window, { key: "k" });
+    expect(action).not.toHaveBeenCalled();
+  });
+
+  it("cleans up the global key listener on unmount", () => {
+    const action = vi.fn();
+    const { unmount } = renderHook(() =>
+      useKeyboardShortcuts({ shortcuts: [{ key: "k", description: "Test action", action }] })
+    );
+    unmount();
+    fireEvent.keyDown(window, { key: "k" });
+    expect(action).not.toHaveBeenCalled();
+  });
+
+  // ── Disabled in input / textarea / contentEditable ───────────────────────
+
+  it("does not fire shortcut when target is an INPUT element", () => {
+    const action = vi.fn();
+    renderHook(() =>
+      useKeyboardShortcuts({ shortcuts: [{ key: "n", description: "New", action }] })
+    );
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.focus();
+    fireEvent.keyDown(input, { key: "n" });
+    document.body.removeChild(input);
+    expect(action).not.toHaveBeenCalled();
+  });
+
+  it("does not fire shortcut when target is a TEXTAREA element", () => {
+    const action = vi.fn();
+    renderHook(() =>
+      useKeyboardShortcuts({ shortcuts: [{ key: "r", description: "Refresh", action }] })
+    );
+    const ta = document.createElement("textarea");
+    document.body.appendChild(ta);
+    ta.focus();
+    fireEvent.keyDown(ta, { key: "r" });
+    document.body.removeChild(ta);
+    expect(action).not.toHaveBeenCalled();
+  });
+
+  // ── Each key fires its action ─────────────────────────────────────────────
+
+  it("fires ? shortcut action", () => {
+    const action = vi.fn();
+    renderHook(() =>
+      useKeyboardShortcuts({ shortcuts: [{ key: "?", description: "Help", action }] })
+    );
+    fireEvent.keyDown(window, { key: "?" });
+    expect(action).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires n shortcut action", () => {
+    const action = vi.fn();
+    renderHook(() =>
+      useKeyboardShortcuts({ shortcuts: [{ key: "n", description: "New Subscription", action }] })
+    );
+    fireEvent.keyDown(window, { key: "n" });
+    expect(action).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires r shortcut action", () => {
+    const action = vi.fn();
+    renderHook(() =>
+      useKeyboardShortcuts({ shortcuts: [{ key: "r", description: "Refresh", action }] })
+    );
+    fireEvent.keyDown(window, { key: "r" });
+    expect(action).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires 1 shortcut action (Subscriber tab)", () => {
+    const action = vi.fn();
+    renderHook(() =>
+      useKeyboardShortcuts({ shortcuts: [{ key: "1", description: "Subscriber tab", action }] })
+    );
+    fireEvent.keyDown(window, { key: "1" });
+    expect(action).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires 2 shortcut action (Merchant tab)", () => {
+    const action = vi.fn();
+    renderHook(() =>
+      useKeyboardShortcuts({ shortcuts: [{ key: "2", description: "Merchant tab", action }] })
+    );
+    fireEvent.keyDown(window, { key: "2" });
+    expect(action).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires 3 shortcut action (Admin tab)", () => {
+    const action = vi.fn();
+    renderHook(() =>
+      useKeyboardShortcuts({ shortcuts: [{ key: "3", description: "Admin tab", action }] })
+    );
+    fireEvent.keyDown(window, { key: "3" });
+    expect(action).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
- n: navigate to New Subscription form (subscribe tab)
- r: trigger data refresh on current tab
- 1: switch to Subscriber (dashboard) tab
- 2: switch to Merchant tab
- 3: switch to Admin tab
- All shortcuts remain disabled when input/textarea is focused
- ShortcutHelpOverlay displays all registered shortcuts
- Tests cover each shortcut key fires its action, disabled in INPUT/TEXTAREA focus

Closes #671
Closes #670 