### PR TITLE
two operator automation script

### DIFF
--- a/deployments/config.json
+++ b/deployments/config.json
@@ -1,0 +1,11 @@
+{
+  "network": "testnet",
+  "networkPassphrase": "Test SDF Network ; September 2015",
+  "rpcUrl": "https://soroban-testnet.stellar.org",
+  "tokenAddress": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+  "adminAddress": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+  "feeBps": 0,
+  "feeCollector": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+  "initialMerchants": [],
+  "wasmPath": "contract/target/wasm32-unknown-unknown/release/flow_pay.wasm"
+}

--- a/deployments/manifest.json
+++ b/deployments/manifest.json
@@ -1,0 +1,14 @@
+{
+  "contractId": null,
+  "deployedAt": null,
+  "network": "testnet",
+  "deployer": null,
+  "steps": {
+    "build": false,
+    "deploy": false,
+    "initialize": false,
+    "fee": false,
+    "merchants": false
+  },
+  "lastUpdatedAt": "1970-01-01T00:00:00.000Z"
+}

--- a/scripts/deploy-pipeline.ts
+++ b/scripts/deploy-pipeline.ts
@@ -1,0 +1,346 @@
+#!/usr/bin/env tsx
+/**
+ * deploy-pipeline.ts — Reproducible FlowPay deployment pipeline.
+ *
+ * Usage:
+ *   npx tsx scripts/deploy-pipeline.ts [--dry-run]
+ *
+ * Config:
+ *   deployments/config.json
+ *
+ * Environment:
+ *   DEPLOYER_SECRET_KEY                       Required for live deployment.
+ *   ADMIN_SECRET_KEY                          Required for admin-signed post-deploy steps.
+ *   RPC_URL / VITE_RPC_URL                    Optional override.
+ *   NETWORK_PASSPHRASE / VITE_NETWORK_PASSPHRASE
+ *                                            Optional override.
+ */
+
+import { isAbsolute, resolve } from "node:path";
+import {
+  addressToScVal,
+  createServer,
+  invokeContract,
+  isValidStellarAddress,
+  loadSorobanConfig,
+  nativeToScVal,
+  projectPath,
+  readContractValue,
+  readJsonFile,
+  retry,
+  runCommand,
+  scValToNative,
+  vecAddressToScVal,
+  writeJsonFile,
+} from "./soroban-admin.js";
+
+interface DeploymentConfig {
+  network: string;
+  networkPassphrase: string;
+  rpcUrl: string;
+  tokenAddress: string;
+  adminAddress: string;
+  feeBps: number;
+  feeCollector: string;
+  initialMerchants: string[];
+  wasmPath?: string;
+}
+
+interface DeploymentManifest {
+  contractId: string | null;
+  deployedAt: string | null;
+  network: string;
+  deployer: string | null;
+  steps: {
+    build: boolean;
+    deploy: boolean;
+    initialize: boolean;
+    fee: boolean;
+    merchants: boolean;
+  };
+  lastUpdatedAt: string;
+}
+
+const CONFIG_PATH = projectPath("deployments", "config.json");
+const MANIFEST_PATH = projectPath("deployments", "manifest.json");
+
+function parseArgs(argv: string[]): { dryRun: boolean } {
+  return { dryRun: argv.includes("--dry-run") };
+}
+
+function validateConfig(config: DeploymentConfig): void {
+  if (!config.networkPassphrase) {
+    throw new Error("deployments/config.json must define networkPassphrase.");
+  }
+  if (!isValidStellarAddress(config.tokenAddress)) {
+    throw new Error("tokenAddress must be a valid Stellar address.");
+  }
+  if (!isValidStellarAddress(config.adminAddress)) {
+    throw new Error("adminAddress must be a valid Stellar address.");
+  }
+  if (!isValidStellarAddress(config.feeCollector)) {
+    throw new Error("feeCollector must be a valid Stellar address.");
+  }
+  for (const merchant of config.initialMerchants) {
+    if (!isValidStellarAddress(merchant)) {
+      throw new Error(`Invalid initial merchant address: ${merchant}`);
+    }
+  }
+}
+
+function defaultManifest(config: DeploymentConfig): DeploymentManifest {
+  return {
+    contractId: null,
+    deployedAt: null,
+    network: config.network,
+    deployer: null,
+    steps: {
+      build: false,
+      deploy: false,
+      initialize: false,
+      fee: false,
+      merchants: false,
+    },
+    lastUpdatedAt: new Date().toISOString(),
+  };
+}
+
+async function saveManifest(manifest: DeploymentManifest): Promise<void> {
+  manifest.lastUpdatedAt = new Date().toISOString();
+  await writeJsonFile(MANIFEST_PATH, manifest);
+}
+
+async function loadConfig(): Promise<DeploymentConfig> {
+  const config = await readJsonFile<DeploymentConfig | null>(CONFIG_PATH, null);
+  if (!config) {
+    throw new Error(`Missing deployment config at ${CONFIG_PATH}`);
+  }
+  validateConfig(config);
+  return config;
+}
+
+async function buildWasm(dryRun: boolean): Promise<void> {
+  if (dryRun) {
+    console.log("[dry-run] Would build contract WASM.");
+    return;
+  }
+  await runCommand("cargo", ["build", "--release", "--target", "wasm32-unknown-unknown"], projectPath("contract"));
+}
+
+async function deployContract(config: DeploymentConfig, dryRun: boolean): Promise<string> {
+  if (dryRun) {
+    console.log("[dry-run] Would deploy contract.");
+    return "DRY_RUN_CONTRACT_ID";
+  }
+
+  const deployerSecretKey = process.env.DEPLOYER_SECRET_KEY ?? "";
+  if (!deployerSecretKey) {
+    throw new Error("DEPLOYER_SECRET_KEY is required for live deployment.");
+  }
+
+  const configuredWasmPath =
+    config.wasmPath ?? projectPath("contract", "target", "wasm32-unknown-unknown", "release", "flow_pay.wasm");
+  const wasmPath = isAbsolute(configuredWasmPath) ? configuredWasmPath : resolve(process.cwd(), configuredWasmPath);
+  const output = await retry(
+    3,
+    () =>
+      runCommand(
+        "stellar",
+        [
+          "contract",
+          "deploy",
+          "--wasm",
+          wasmPath,
+          "--source",
+          deployerSecretKey,
+          "--rpc-url",
+          config.rpcUrl,
+          "--network-passphrase",
+          config.networkPassphrase,
+        ],
+        process.cwd()
+      ),
+    "deploy contract"
+  );
+
+  const contractId = output.split(/\s+/).find((token) => token.startsWith("C"));
+  if (!contractId) {
+    throw new Error(`Could not parse contract ID from deploy output: ${output}`);
+  }
+
+  return contractId;
+}
+
+async function verifyInitialized(contractId: string, config: DeploymentConfig): Promise<boolean> {
+  const sorobanConfig = loadSorobanConfig({
+    contractId,
+    rpcUrl: config.rpcUrl,
+    networkPassphrase: config.networkPassphrase,
+  });
+  const server = createServer(sorobanConfig);
+
+  const retval = await readContractValue<Record<string, unknown>>(
+    sorobanConfig,
+    server,
+    "contract_health_check",
+    [],
+    (value) => (value ? (scValToNative(value) as Record<string, unknown>) : {})
+  );
+
+  return retval.admin_configured === true && retval.token_configured === true;
+}
+
+async function initializeContract(contractId: string, config: DeploymentConfig, dryRun: boolean): Promise<void> {
+  if (dryRun) {
+    console.log("[dry-run] Would initialize contract.");
+    return;
+  }
+
+  const sorobanConfig = loadSorobanConfig({
+    contractId,
+    rpcUrl: config.rpcUrl,
+    networkPassphrase: config.networkPassphrase,
+  });
+  const server = createServer(sorobanConfig);
+  const alreadyInitialized = await verifyInitialized(contractId, config);
+  if (alreadyInitialized) {
+    return;
+  }
+  await invokeContract(sorobanConfig, server, "initialize", [
+    addressToScVal(config.tokenAddress),
+    addressToScVal(config.adminAddress),
+  ]);
+}
+
+async function configureFee(contractId: string, config: DeploymentConfig, dryRun: boolean): Promise<void> {
+  if (dryRun) {
+    console.log("[dry-run] Would propose and commit fee.");
+    return;
+  }
+
+  const sorobanConfig = loadSorobanConfig({
+    contractId,
+    rpcUrl: config.rpcUrl,
+    networkPassphrase: config.networkPassphrase,
+  });
+  const server = createServer(sorobanConfig);
+
+  const existing = await readContractValue<[string, number] | null>(
+    sorobanConfig,
+    server,
+    "get_fee",
+    [],
+    (value) => (value ? (scValToNative(value) as [string, number]) : null)
+  );
+
+  if (existing && existing[0] === config.feeCollector && Number(existing[1]) === config.feeBps) {
+    return;
+  }
+
+  await invokeContract(sorobanConfig, server, "propose_fee", [
+    addressToScVal(config.feeCollector),
+    nativeToScVal(config.feeBps, { type: "u32" }),
+  ]);
+  await invokeContract(sorobanConfig, server, "commit_fee", []);
+}
+
+async function whitelistInitialMerchants(contractId: string, config: DeploymentConfig, dryRun: boolean): Promise<void> {
+  if (config.initialMerchants.length === 0) {
+    return;
+  }
+  if (dryRun) {
+    console.log(`[dry-run] Would whitelist ${config.initialMerchants.length} merchant(s).`);
+    return;
+  }
+
+  const sorobanConfig = loadSorobanConfig({
+    contractId,
+    rpcUrl: config.rpcUrl,
+    networkPassphrase: config.networkPassphrase,
+  });
+  const server = createServer(sorobanConfig);
+  const missing: string[] = [];
+
+  for (const merchant of config.initialMerchants) {
+    const whitelisted = await readContractValue<boolean>(
+      sorobanConfig,
+      server,
+      "is_merchant_whitelisted",
+      [addressToScVal(merchant)],
+      (value) => Boolean(value?.b())
+    );
+    if (!whitelisted) {
+      missing.push(merchant);
+    }
+  }
+
+  if (missing.length === 0) {
+    return;
+  }
+
+  await invokeContract(sorobanConfig, server, "whitelist_batch_add", [vecAddressToScVal(missing)]);
+}
+
+async function main(): Promise<void> {
+  const { dryRun } = parseArgs(process.argv);
+  const config = await loadConfig();
+
+  const envPassphrase = process.env.NETWORK_PASSPHRASE ?? process.env.VITE_NETWORK_PASSPHRASE;
+  if (envPassphrase && envPassphrase !== config.networkPassphrase) {
+    throw new Error("NETWORK_PASSPHRASE does not match deployments/config.json.");
+  }
+
+  const manifest = await readJsonFile<DeploymentManifest>(MANIFEST_PATH, defaultManifest(config));
+
+  if (!manifest.steps.build) {
+    await buildWasm(dryRun);
+    manifest.steps.build = true;
+    await saveManifest(manifest);
+  }
+
+  if (!manifest.steps.deploy) {
+    manifest.contractId = await deployContract(config, dryRun);
+    manifest.deployedAt = new Date().toISOString();
+    manifest.deployer = dryRun ? "DRY_RUN" : "DEPLOYER_SECRET_KEY";
+    manifest.steps.deploy = true;
+    await saveManifest(manifest);
+  }
+
+  if (!manifest.contractId) {
+    throw new Error("Manifest does not contain a contractId after deploy step.");
+  }
+
+  if (!manifest.steps.initialize) {
+    await initializeContract(manifest.contractId, config, dryRun);
+    if (!dryRun) {
+      const healthy = await verifyInitialized(manifest.contractId, config);
+      if (!healthy) {
+        throw new Error("Initialization verification failed.");
+      }
+    }
+    manifest.steps.initialize = true;
+    await saveManifest(manifest);
+  }
+
+  if (!manifest.steps.fee) {
+    await configureFee(manifest.contractId, config, dryRun);
+    manifest.steps.fee = true;
+    await saveManifest(manifest);
+  }
+
+  if (!manifest.steps.merchants) {
+    await whitelistInitialMerchants(manifest.contractId, config, dryRun);
+    manifest.steps.merchants = true;
+    await saveManifest(manifest);
+  }
+
+  console.log(`Deployment pipeline complete. Manifest: ${MANIFEST_PATH}`);
+  if (!dryRun) {
+    console.log(`Contract ID: ${manifest.contractId}`);
+  }
+}
+
+main().catch((error) => {
+  console.error("deploy-pipeline failed:", error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/scripts/onboard-merchant.ts
+++ b/scripts/onboard-merchant.ts
@@ -1,0 +1,212 @@
+#!/usr/bin/env tsx
+/**
+ * onboard-merchant.ts — Admin merchant onboarding automation for FlowPay.
+ *
+ * Usage:
+ *   npx tsx scripts/onboard-merchant.ts G...
+ *   npx tsx scripts/onboard-merchant.ts --batch merchants.csv
+ *
+ * Environment:
+ *   CONTRACT_ID or VITE_CONTRACT_ID          Required. FlowPay contract ID.
+ *   ADMIN_SECRET_KEY                         Required. Admin secret for signed whitelist txs.
+ *   RPC_URL or VITE_RPC_URL                  Optional. Soroban RPC URL.
+ *   NETWORK_PASSPHRASE or VITE_NETWORK_PASSPHRASE
+ *                                            Optional. Stellar network passphrase.
+ *   MERCHANT_ONBOARD_WEBHOOK_URL             Optional. Webhook to notify after onboarding.
+ */
+
+import { readFile } from "node:fs/promises";
+import {
+  appendJsonLine,
+  addressToScVal,
+  createServer,
+  invokeContract,
+  isValidStellarAddress,
+  loadSorobanConfig,
+  projectPath,
+  readContractValue,
+  vecAddressToScVal,
+} from "./soroban-admin.js";
+
+interface CliArgs {
+  address?: string;
+  batchFile?: string;
+}
+
+interface MerchantOutcome {
+  address: string;
+  status: "onboarded" | "already_whitelisted" | "frozen" | "invalid";
+  txHash: string | null;
+  message: string;
+}
+
+const LOG_PATH = projectPath("data", "merchants.jsonl");
+
+const config = loadSorobanConfig();
+const server = createServer(config);
+
+function parseArgs(argv: string[]): CliArgs {
+  let address: string | undefined;
+  let batchFile: string | undefined;
+
+  for (let i = 2; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--batch") {
+      batchFile = argv[++i];
+    } else if (!address) {
+      address = arg;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!address && !batchFile) {
+    throw new Error("Provide a merchant address or --batch merchants.csv.");
+  }
+
+  return { address, batchFile };
+}
+
+async function loadBatchAddresses(csvPath: string): Promise<string[]> {
+  const content = await readFile(csvPath, "utf-8");
+  return content
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .map((line) => {
+      const [firstCell] = line.split(",");
+      return firstCell.trim();
+    })
+    .filter((value) => value.toLowerCase() !== "address");
+}
+
+async function isMerchantFrozen(address: string): Promise<boolean> {
+  return readContractValue<boolean>(
+    config,
+    server,
+    "is_merchant_frozen",
+    [addressToScVal(address)],
+    (value) => (value ? Boolean(value.b()) : false)
+  );
+}
+
+async function isMerchantWhitelisted(address: string): Promise<boolean> {
+  return readContractValue<boolean>(
+    config,
+    server,
+    "is_merchant_whitelisted",
+    [addressToScVal(address)],
+    (value) => (value ? Boolean(value.b()) : false)
+  );
+}
+
+async function notifyWebhook(address: string, txHash: string | null, status: MerchantOutcome["status"]): Promise<void> {
+  const url = process.env.MERCHANT_ONBOARD_WEBHOOK_URL;
+  if (!url) {
+    return;
+  }
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      address,
+      tx_hash: txHash,
+      status,
+      onboarded_at: new Date().toISOString(),
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Webhook returned HTTP ${response.status}`);
+  }
+}
+
+async function logMerchant(address: string, txHash: string | null): Promise<void> {
+  await appendJsonLine(LOG_PATH, {
+    address,
+    onboarded_at: new Date().toISOString(),
+    tx_hash: txHash,
+  });
+}
+
+async function onboardMerchant(address: string): Promise<MerchantOutcome> {
+  if (!isValidStellarAddress(address)) {
+    return {
+      address,
+      status: "invalid",
+      txHash: null,
+      message: "Invalid Stellar address; skipped.",
+    };
+  }
+
+  const frozen = await isMerchantFrozen(address);
+  if (frozen) {
+    return {
+      address,
+      status: "frozen",
+      txHash: null,
+      message: "Merchant is frozen; onboarding blocked.",
+    };
+  }
+
+  const alreadyWhitelisted = await isMerchantWhitelisted(address);
+  if (alreadyWhitelisted) {
+    await logMerchant(address, null);
+    await notifyWebhook(address, null, "already_whitelisted");
+    return {
+      address,
+      status: "already_whitelisted",
+      txHash: null,
+      message: "Merchant already whitelisted; no transaction sent.",
+    };
+  }
+
+  const tx = await invokeContract(config, server, "whitelist_batch_add", [vecAddressToScVal([address])]);
+  const verified = await isMerchantWhitelisted(address);
+  if (!verified) {
+    throw new Error(`Whitelist verification failed after tx ${tx.hash}`);
+  }
+
+  await logMerchant(address, tx.hash);
+  await notifyWebhook(address, tx.hash, "onboarded");
+
+  return {
+    address,
+    status: "onboarded",
+    txHash: tx.hash,
+    message: `Merchant whitelisted successfully in tx ${tx.hash}.`,
+  };
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv);
+  const addresses = args.batchFile ? await loadBatchAddresses(args.batchFile) : [args.address as string];
+  const outcomes: MerchantOutcome[] = [];
+  let hadExecutionError = false;
+
+  for (const address of addresses) {
+    try {
+      const outcome = await onboardMerchant(address);
+      outcomes.push(outcome);
+      console.log(`${address}: ${outcome.message}`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      hadExecutionError = true;
+      console.error(`${address}: ${message}`);
+    }
+  }
+
+  const failures = outcomes.filter((outcome) => outcome.status === "invalid" || outcome.status === "frozen");
+  if (failures.length > 0) {
+    console.error(`Completed with ${failures.length} blocked or invalid merchant(s).`);
+  }
+  if (hadExecutionError) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error("onboard-merchant failed:", error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/scripts/soroban-admin.ts
+++ b/scripts/soroban-admin.ts
@@ -1,0 +1,261 @@
+import { appendFile, mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import {
+  Account,
+  Address,
+  BASE_FEE,
+  Contract,
+  Keypair,
+  Networks,
+  TransactionBuilder,
+  nativeToScVal,
+  scValToNative,
+  xdr,
+} from "@stellar/stellar-sdk";
+import { Server } from "@stellar/stellar-sdk/rpc";
+
+const execFileAsync = promisify(execFile);
+
+const DEFAULT_RPC_URL = "https://soroban-testnet.stellar.org";
+const SIMULATION_SOURCE = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+
+export interface SorobanConfig {
+  contractId: string;
+  rpcUrl: string;
+  networkPassphrase: string;
+  adminSecretKey: string;
+}
+
+export interface TxResult {
+  hash: string;
+  status: string;
+}
+
+export function getNetworkPassphrase(
+  networkPassphrase = process.env.NETWORK_PASSPHRASE ?? process.env.VITE_NETWORK_PASSPHRASE
+): string {
+  return networkPassphrase ?? Networks.TESTNET;
+}
+
+export function loadSorobanConfig(overrides: Partial<SorobanConfig> = {}): SorobanConfig {
+  const contractId = overrides.contractId ?? process.env.CONTRACT_ID ?? process.env.VITE_CONTRACT_ID ?? "";
+  const rpcUrl = overrides.rpcUrl ?? process.env.RPC_URL ?? process.env.VITE_RPC_URL ?? DEFAULT_RPC_URL;
+  const networkPassphrase = overrides.networkPassphrase ?? getNetworkPassphrase();
+  const adminSecretKey = overrides.adminSecretKey ?? process.env.ADMIN_SECRET_KEY ?? "";
+
+  if (!contractId) {
+    throw new Error("CONTRACT_ID or VITE_CONTRACT_ID is required.");
+  }
+  if (!adminSecretKey) {
+    throw new Error("ADMIN_SECRET_KEY is required for admin-signed operations.");
+  }
+
+  return { contractId, rpcUrl, networkPassphrase, adminSecretKey };
+}
+
+export function createServer(config: Pick<SorobanConfig, "rpcUrl">): Server {
+  return new Server(config.rpcUrl);
+}
+
+export function parseStellarAddress(address: string): Address {
+  return Address.fromString(address);
+}
+
+export function isValidStellarAddress(address: string): boolean {
+  try {
+    parseStellarAddress(address);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function addressToScVal(address: string): xdr.ScVal {
+  return nativeToScVal(parseStellarAddress(address), { type: "address" });
+}
+
+export function vecAddressToScVal(addresses: string[]): xdr.ScVal {
+  return nativeToScVal(
+    addresses.map((address) => parseStellarAddress(address)),
+    { type: "vec" }
+  );
+}
+
+async function loadSimulationAccount(server: Server): Promise<Account> {
+  try {
+    return await server.getAccount(SIMULATION_SOURCE);
+  } catch {
+    return new Account(SIMULATION_SOURCE, "0");
+  }
+}
+
+export async function simulateRead(
+  config: Pick<SorobanConfig, "contractId" | "networkPassphrase">,
+  server: Server,
+  method: string,
+  args: xdr.ScVal[] = []
+): Promise<xdr.ScVal | null> {
+  const account = await loadSimulationAccount(server);
+  const contract = new Contract(config.contractId);
+
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: config.networkPassphrase,
+  })
+    .addOperation(contract.call(method, ...args))
+    .setTimeout(30)
+    .build();
+
+  const result = await server.simulateTransaction(tx);
+  if ("error" in result) {
+    throw new Error(`Simulation failed for ${method}: ${result.error}`);
+  }
+
+  return (result as { result?: { retval?: xdr.ScVal } }).result?.retval ?? null;
+}
+
+export async function readContractValue<T>(
+  config: Pick<SorobanConfig, "contractId" | "networkPassphrase">,
+  server: Server,
+  method: string,
+  args: xdr.ScVal[] = [],
+  decode?: (value: xdr.ScVal | null) => T
+): Promise<T> {
+  const retval = await simulateRead(config, server, method, args);
+  if (decode) {
+    return decode(retval);
+  }
+
+  if (!retval) {
+    return null as T;
+  }
+
+  return scValToNative(retval) as T;
+}
+
+export async function invokeContract(
+  config: SorobanConfig,
+  server: Server,
+  method: string,
+  args: xdr.ScVal[] = []
+): Promise<TxResult> {
+  const keypair = Keypair.fromSecret(config.adminSecretKey);
+  const sourceAccount = await server.getAccount(keypair.publicKey());
+  const contract = new Contract(config.contractId);
+
+  let tx = new TransactionBuilder(sourceAccount, {
+    fee: BASE_FEE,
+    networkPassphrase: config.networkPassphrase,
+  })
+    .addOperation(contract.call(method, ...args))
+    .setTimeout(60)
+    .build();
+
+  tx = await server.prepareTransaction(tx);
+  tx.sign(keypair);
+
+  const sendResult = await server.sendTransaction(tx);
+  if (sendResult.errorResult) {
+    throw new Error(`Transaction submission failed for ${method}: ${sendResult.errorResult.toString()}`);
+  }
+
+  const hash = sendResult.hash;
+  const finalResult = await waitForTransaction(server, hash);
+  if (finalResult.status !== "SUCCESS") {
+    throw new Error(`Transaction ${hash} finished with status ${finalResult.status}`);
+  }
+
+  return {
+    hash,
+    status: finalResult.status,
+  };
+}
+
+export async function waitForTransaction(server: Server, hash: string): Promise<{ status: string }> {
+  const startedAt = Date.now();
+
+  while (Date.now() - startedAt < 120_000) {
+    const response = await server.getTransaction(hash).catch(() => null);
+    if (response && response.status !== "NOT_FOUND") {
+      return { status: response.status };
+    }
+    await sleep(2_000);
+  }
+
+  throw new Error(`Timed out waiting for transaction ${hash}`);
+}
+
+export async function retry<T>(attempts: number, action: () => Promise<T>, label: string): Promise<T> {
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      return await action();
+    } catch (error) {
+      lastError = error;
+      if (attempt < attempts) {
+        console.warn(`${label} failed (attempt ${attempt}/${attempts}); retrying...`);
+        await sleep(1_500 * attempt);
+      }
+    }
+  }
+
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function runCommand(command: string, args: string[], cwd: string): Promise<string> {
+  const { stdout, stderr } = await execFileAsync(command, args, {
+    cwd,
+    env: process.env,
+  });
+
+  if (stderr.trim()) {
+    console.error(stderr.trim());
+  }
+
+  return stdout.trim();
+}
+
+export async function ensureDir(path: string): Promise<void> {
+  await mkdir(path, { recursive: true });
+}
+
+export async function fileExists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function readJsonFile<T>(path: string, fallback: T): Promise<T> {
+  if (!(await fileExists(path))) {
+    return fallback;
+  }
+
+  const content = await readFile(path, "utf-8");
+  return JSON.parse(content) as T;
+}
+
+export async function writeJsonFile(path: string, value: unknown): Promise<void> {
+  await ensureDir(dirname(path));
+  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`, "utf-8");
+}
+
+export async function appendJsonLine(path: string, value: unknown): Promise<void> {
+  await ensureDir(dirname(path));
+  await appendFile(path, `${JSON.stringify(value)}\n`, "utf-8");
+}
+
+export function projectPath(...segments: string[]): string {
+  return resolve(process.cwd(), ...segments);
+}
+
+export { nativeToScVal, scValToNative };


### PR DESCRIPTION
## Summary

Adds two operator automation scripts for FlowPay:

- `scripts/onboard-merchant.ts` for merchant onboarding
- `scripts/deploy-pipeline.ts` for reproducible contract deployment

This reduces manual admin work and adds verification/logging around high-risk operational flows.

Closes #595
Closes #592

## What Changed

- Added `scripts/onboard-merchant.ts`
- Added `scripts/deploy-pipeline.ts`
- Added shared helper `scripts/soroban-admin.ts`
- Added `deployments/config.json`
- Added `deployments/manifest.json`

## Merchant Onboarding

- Validates merchant Stellar addresses before any transaction
- Checks `is_merchant_frozen` and blocks onboarding with a clear message
- Treats already-whitelisted merchants idempotently
- Calls `whitelist_batch_add([address])` for new merchants
- Verifies onboarding with `is_merchant_whitelisted`
- Sends optional webhook notifications via `MERCHANT_ONBOARD_WEBHOOK_URL`
- Appends `{ address, onboarded_at, tx_hash }` to `data/merchants.jsonl`
- Supports batch CSV mode with `--batch merchants.csv`

## Deployment Pipeline

- Reads deployment settings from `deployments/config.json`
- Orchestrates build -> deploy -> initialize -> fee config -> merchant whitelist
- Supports `--dry-run`
- Persists deployment state in `deployments/manifest.json`
- Skips completed steps on rerun
- Verifies initialization using `contract_health_check`
- Retries deployment up to 3 times for transient failures
- Validates `NETWORK_PASSPHRASE` against config before proceeding

## Notes

- Both scripts are environment-driven and include inline usage docs
- Live validation against testnet is still needed after installing the `scripts` dependencies locally