### PR TITLE
docs: add local development network matrix (#918)

### DIFF
--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -171,6 +171,8 @@ npm run dev
 
 You'll need a `VITE_CONTRACT_ID` in `.env.local` pointing at a deployed testnet contract to interact with real data — see [`docs/DEPLOYMENT.md`](DEPLOYMENT.md) if you want to deploy your own testnet instance. For contract-only or frontend-UI-only contributions, you generally don't need this step.
 
+For a complete reference of all environment variables and how RPC, passphrase, and contract ID must align across frontend, scripts, and contract tests, see [`docs/development/network-matrix.md`](development/network-matrix.md).
+
 ---
 
 ## 3. Choosing an Issue
@@ -286,12 +288,14 @@ Before opening, run through [`CONTRIBUTING.md`](../CONTRIBUTING.md#pull-request-
 
 ## 6. Troubleshooting
 
+For environment variable alignment issues (RPC URL, network passphrase, contract ID mismatch between frontend/scripts), see the [network matrix](development/network-matrix.md).
+
 | Problem                                                                              | Likely cause                                                                                                        | Fix                                                                                                                                                                       |
 | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `error[E0463]: can't find crate for 'core'` (or similar) when building the contract  | Missing the `wasm32-unknown-unknown` target                                                                         | `rustup target add wasm32-unknown-unknown`                                                                                                                                |
 | `cargo test` fails with `unresolved import` or dependency errors right after cloning | Stale/partial `Cargo.lock` or first-time dependency download interrupted                                            | `cd contract && cargo clean && cargo test`                                                                                                                                |
 | `npm run test` / `npm run build` fails immediately with module-not-found errors      | `npm install` wasn't run, or was run in the wrong directory                                                         | Make sure you're in `frontend/` (not repo root) before running `npm install`                                                                                              |
 | `cargo clippy -- -D warnings` fails on code you didn't touch                         | You're on a stale `master` that predates a clippy/toolchain update                                                  | `git fetch origin && git rebase origin/master`                                                                                                                            |
-| Frontend dev server starts but the UI shows contract errors / can't fetch data       | `VITE_CONTRACT_ID` not set (or points at a contract that isn't deployed on the network your `VITE_RPC_URL` targets) | Follow [`docs/DEPLOYMENT.md`](DEPLOYMENT.md) to deploy a testnet contract, then set `.env.local` accordingly — or skip running the live UI if your change doesn't need it |
+| Frontend dev server starts but the UI shows contract errors / can't fetch data       | `VITE_CONTRACT_ID` not set (or points at a contract that isn't deployed on the network your `VITE_RPC_URL` targets) | Follow [`docs/DEPLOYMENT.md`](DEPLOYMENT.md) to deploy a testnet contract, then set `.env.local` accordingly — or skip running the live UI if your change doesn't need it. Also check the [network matrix](development/network-matrix.md) for alignment rules. |
 
 If you hit something not covered here, open a GitHub Discussion or comment on your issue — see [Questions](../CONTRIBUTING.md#questions) in `CONTRIBUTING.md`.

--- a/docs/development/network-matrix.md
+++ b/docs/development/network-matrix.md
@@ -1,0 +1,105 @@
+# Local Development Network Matrix
+
+This matrix documents every environment variable that controls network/RPC/contract alignment across the three packages: frontend, scripts, and contract tests. Use it to ensure all packages target the same network and contract.
+
+---
+
+## Environment Variable Matrix
+
+| Variable | Package | Testnet example | Mainnet caution |
+|----------|---------|----------------|----------------|
+| `VITE_CONTRACT_ID` | frontend | `C...` (56 chars) | Must match mainnet-deployed contract |
+| `VITE_RPC_URL` | frontend | `https://soroban-testnet.stellar.org` | Use `https://soroban-mainnet.stellar.org` or your own node |
+| `VITE_NETWORK_PASSPHRASE` | frontend | `Test SDF Network ; September 2015` | `Public Global Stellar Network ; September 2015` |
+| `VITE_TOKEN_CONTRACT_ID` | frontend | (token address) | Must match mainnet token contract |
+| `VITE_DEFAULT_TOKEN` | frontend | XLM SAC address (default) | — |
+| `VITE_ANALYTICS_URL` | frontend | (unset) | — |
+| `CONTRACT_ID` | scripts | `C...` (56 chars) | Must match mainnet-deployed contract |
+| `KEEPER_SECRET` | scripts | `S...` (56 chars) | **Never commit real keys** |
+| `RPC_URL` | scripts | `https://soroban-testnet.stellar.org` | Use `https://soroban-mainnet.stellar.org` |
+| `NETWORK_PASSPHRASE` | scripts | `Test SDF Network ; September 2015` | `Public Global Stellar Network ; September 2015` |
+| `CHARGE_INTERVAL_MS` | scripts | `3600000` (1 hour) | — |
+| `PAGE_SIZE` | scripts | `100` | — |
+| `MAX_RETRIES` | scripts | `3` | — |
+| `LOG_LEVEL` | scripts | `debug` (local) / `info` (production) | Use `info` or `warn` |
+
+**Contract tests** require no environment variables. They run entirely in-memory using `Env::default()` with mock authentication and an in-memory token.
+
+---
+
+## Alignment Rules
+
+All three packages must agree on:
+
+1. **RPC URL** — `VITE_RPC_URL` (frontend) and `RPC_URL` (scripts) must point at the same Soroban RPC node.
+2. **Network passphrase** — `VITE_NETWORK_PASSPHRASE` (frontend) and `NETWORK_PASSPHRASE` (scripts) must be identical. A mismatch causes transaction submission failures.
+3. **Contract ID** — `VITE_CONTRACT_ID` (frontend) and `CONTRACT_ID` (scripts) must reference the same deployed contract. Using different contract IDs means the frontend and keeper operate on different subscription sets.
+4. **Token contract** — If the contract was initialized with a specific token (not the default XLM SAC), `VITE_TOKEN_CONTRACT_ID` must match.
+
+---
+
+## Freighter Network Matching
+
+The frontend's `useNetworkCheck` hook (in `frontend/src/hooks/useNetworkCheck.ts`) compares the Freighter wallet's `networkPassphrase` against the app's `NETWORK_PASSPHRASE`. If they differ, the UI displays a warning.
+
+**To avoid warnings:** Ensure Freighter is set to the same network as `VITE_NETWORK_PASSPHRASE`:
+- **Testnet:** Freighter → Stellar Testnet
+- **Mainnet:** Freighter → Stellar Public Network
+
+The `NetworkBadge` component (`frontend/src/components/NetworkBadge.tsx`) derives the displayed network name from `NETWORK_PASSPHRASE`:
+- Passphrase contains `"Public Global"` → badge shows "Mainnet"
+- Otherwise → badge shows "Testnet"
+
+---
+
+## Verification Commands
+
+### Health check (scripts)
+
+```bash
+cd scripts
+npm install
+npx tsx health-check.ts
+```
+
+Verifies RPC connectivity and contract initialization status.
+
+### Frontend network badge
+
+Start the frontend dev server and confirm the `NetworkBadge` in the top-right corner shows the expected network:
+
+```bash
+cd frontend
+cp .env.example .env.local
+# Edit .env.local with your VITE_CONTRACT_ID and VITE_NETWORK_PASSPHRASE
+npm install
+npm run dev
+```
+
+### Contract tests (no network required)
+
+```bash
+cd contract
+cargo test
+```
+
+Contract tests are fully offline and deterministic — no RPC, passphrase, or contract ID needed.
+
+---
+
+## Common Mistakes
+
+| Mistake | Symptom | Fix |
+|---------|---------|-----|
+| Frontend targets testnet, scripts target mainnet (or vice versa) | Transaction simulation succeeds but submission fails with `NOT_FOUND` or `PASSPHRASE_MISMATCH` | Set `VITE_NETWORK_PASSPHRASE` and `NETWORK_PASSPHRASE` to the same value |
+| Contract ID differs between frontend and scripts | Frontend shows no subscriptions; keeper charges nothing | Set `VITE_CONTRACT_ID` and `CONTRACT_ID` to the same value |
+| Freighter wallet set to wrong network | `useNetworkCheck` shows a network mismatch warning | Switch Freighter to match `VITE_NETWORK_PASSPHRASE` |
+| RPC URL is unreachable or wrong network | `useRpcHealth` reports unhealthy; scripts fail to connect | Verify the RPC URL returns a valid Soroban response: `curl <RPC_URL>` |
+
+---
+
+## See Also
+
+- [DEPLOYMENT.md](../DEPLOYMENT.md) — testnet and mainnet deployment guides
+- [scripts/README.md](../../scripts/README.md) — scripts package documentation
+- [ONBOARDING.md](../ONBOARDING.md) — contributor onboarding walkthrough


### PR DESCRIPTION
Closes #918

## Changes
- Created `docs/development/network-matrix.md` with full environment variable matrix
- Covers frontend VITE_* variables, scripts env vars, and contract test expectations
- Documented alignment rules for RPC URL, network passphrase, and contract ID
- Documented Freighter network matching via useNetworkCheck hook
- Added verification commands: health-check, NetworkBadge, cargo test
- Added common mistakes table with symptoms and fixes
- Cross-linked from ONBOARDING.md troubleshooting and first-run sections
- Cross-linked DEPLOYMENT.md and scripts/README.md