### PR TITLE
docs: synchronize contract event catalog (#915)

### DIFF
--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -4,39 +4,57 @@ This document provides a complete reference for all events emitted by the FlowPa
 
 > **Building on these events?** This file is the payload/schema reference. For polling Soroban RPC, deduplication, reaction patterns (keeper / analytics / notifications / reconciliation), ordering, and reliability, see the companion cookbook: [`docs/EVENT-DRIVEN-GUIDE.md`](EVENT-DRIVEN-GUIDE.md). Reference scripts: [`scripts/watch-events.ts`](../scripts/watch-events.ts), [`scripts/replay-events.ts`](../scripts/replay-events.ts).
 
+> **Catalog version:** Synchronized with `contract/src/events.rs` as of 2026-08-25. All 38 `publish_*` helpers are documented below.
+
 ---
 
 ## Table of Contents
 
-- [Subscription Events](#subscription-events)
+- [Subscription Lifecycle Events](#subscription-lifecycle-events)
 - [Charge & Payment Events](#charge--payment-events)
+- [Subscription Config Events](#subscription-config-events)
 - [Admin Events](#admin-events)
 - [Fee Events](#fee-events)
 - [Merchant Events](#merchant-events)
 - [Daily Limit Events](#daily-limit-events)
 - [Grace Period Events](#grace-period-events)
+- [Referral Events](#referral-events)
+- [Migration & Infrastructure Events](#migration--infrastructure-events)
 - [Related Documentation](#related-documentation)
 
 ---
 
-## Subscription Events
+## Subscription Lifecycle Events
 
-Events related to subscription lifecycle.
+Events related to subscription lifecycle transitions.
 
 ### subscribed
-- **Trigger**: `subscribe()`
+- **Trigger**: `subscribe()` or `subscribe_with_metadata()`
 - **Topic keys**: `["subscribed", user_address]`
-- **Payload schema**: `(merchant: Address, amount: i128, interval: u64)`
+- **Payload schema**:
+  ```rust
+  {
+    merchant: Address,
+    amount: i128,
+    interval: u64,
+    ledger_sequence: u32
+  }
+  ```
 - **JSON example**:
   ```json
   {
     "topic": ["subscribed", "GABC...XYZ"],
-    "data": ["GDEF...ABC", 50000000, 2592000]
+    "data": {
+      "merchant": "GDEF...ABC",
+      "amount": 50000000,
+      "interval": 2592000,
+      "ledger_sequence": 12345
+    }
   }
   ```
 
 ### paused
-- **Trigger**: `pause()`
+- **Trigger**: `pause()` (user-initiated)
 - **Topic keys**: `["paused", user_address]`
 - **Payload schema**: `()`
 - **JSON example**:
@@ -62,26 +80,165 @@ Events related to subscription lifecycle.
 ### cancelled
 - **Trigger**: `cancel()`
 - **Topic keys**: `["cancelled", user_address]`
-- **Payload schema**: `()`
+- **Payload schema**:
+  ```rust
+  {
+    ledger_sequence: u32
+  }
+  ```
 - **JSON example**:
   ```json
   {
     "topic": ["cancelled", "GABC...XYZ"],
+    "data": {
+      "ledger_sequence": 12345
+    }
+  }
+  ```
+
+### cancelled_with_refund
+- **Trigger**: `cancel_and_refund_prorated()`
+- **Topic keys**: `["cancelled_with_refund", user_address]`
+- **Payload schema**:
+  ```rust
+  {
+    refund_amount: i128,
+    ledger_sequence: u32
+  }
+  ```
+- **JSON example**:
+  ```json
+  {
+    "topic": ["cancelled_with_refund", "GABC...XYZ"],
+    "data": {
+      "refund_amount": 25000000,
+      "ledger_sequence": 12345
+    }
+  }
+  ```
+
+### subscription_paused
+- **Trigger**: `batch_pause_subscriptions()` (admin batch operation)
+- **Topic keys**: `["subscription_paused", user_address]`
+- **Payload schema**: `()`
+- **JSON example**:
+  ```json
+  {
+    "topic": ["subscription_paused", "GABC...XYZ"],
     "data": []
   }
   ```
 
-### referred
-- **Trigger**: `subscribe()` (when referrer is provided)
-- **Topic keys**: `["referred", user_address]`
-- **Payload schema**: `referrer: Address`
+### subscription_auto_resumed
+- **Trigger**: `charge()` or `batch_charge()` when `pause_until` expiry has passed
+- **Topic keys**: `["subscription_auto_resumed", user_address]`
+- **Payload schema**: `()`
 - **JSON example**:
   ```json
   {
-    "topic": ["referred", "GABC...XYZ"],
-    "data": "GDEF...ABC"
+    "topic": ["subscription_auto_resumed", "GABC...XYZ"],
+    "data": []
   }
   ```
+
+### trial_extended
+- **Trigger**: `extend_trial()`
+- **Topic keys**: `["trial_extended", user_address]`
+- **Payload schema**:
+  ```rust
+  {
+    additional_seconds: u64,
+    new_last_charged: u64,
+    ledger_sequence: u32
+  }
+  ```
+- **JSON example**:
+  ```json
+  {
+    "topic": ["trial_extended", "GABC...XYZ"],
+    "data": {
+      "additional_seconds": 604800,
+      "new_last_charged": 1719388800,
+      "ledger_sequence": 12345
+    }
+  }
+  ```
+
+---
+
+## Charge & Payment Events
+
+Events related to charges and payments.
+
+### charged
+- **Trigger**: `charge()` or `batch_charge()`
+- **Topic keys**: `["charged", user_address]`
+- **Payload schema**:
+  ```rust
+  {
+    merchant: Address,
+    gross: i128,
+    fee: i128,
+    net: i128,
+    charged_at: u64,
+    ledger_sequence: u32
+  }
+  ```
+- **JSON example**:
+  ```json
+  {
+    "topic": ["charged", "GABC...XYZ"],
+    "data": {
+      "merchant": "GDEF...ABC",
+      "gross": 50000000,
+      "fee": 500000,
+      "net": 49500000,
+      "charged_at": 1719388800,
+      "ledger_sequence": 12345
+    }
+  }
+  ```
+
+### pay_per_use
+- **Trigger**: `pay_per_use()` or `pay_per_use_to()`
+- **Topic keys**: `["pay_per_use", user_address]`
+- **Payload schema**:
+  ```rust
+  {
+    merchant: Address,
+    amount: i128,
+    ledger_sequence: u32
+  }
+  ```
+- **JSON example**:
+  ```json
+  {
+    "topic": ["pay_per_use", "GABC...XYZ"],
+    "data": {
+      "merchant": "GDEF...ABC",
+      "amount": 1000000,
+      "ledger_sequence": 12345
+    }
+  }
+  ```
+
+### daily_window_started
+- **Trigger**: Daily spending window reset in `spending_limit.rs`
+- **Topic keys**: `["daily_window_started", user_address]`
+- **Payload schema**: `()`
+- **JSON example**:
+  ```json
+  {
+    "topic": ["daily_window_started", "GABC...XYZ"],
+    "data": []
+  }
+  ```
+
+---
+
+## Subscription Config Events
+
+Events related to subscription configuration changes.
 
 ### sub_amount_updated
 - **Trigger**: `set_subscription_amount()`
@@ -107,8 +264,20 @@ Events related to subscription lifecycle.
   }
   ```
 
+### sub_transferred
+- **Trigger**: `transfer_subscription()` (legacy event)
+- **Topic keys**: `["sub_transferred", old_user_address]`
+- **Payload schema**: `new_user: Address`
+- **JSON example**:
+  ```json
+  {
+    "topic": ["sub_transferred", "GOLD...USER"],
+    "data": "GNEW...USER"
+  }
+  ```
+
 ### subscription_transferred
-- **Trigger**: `transfer_subscription()`
+- **Trigger**: `transfer_subscription()` (new event, emitted alongside `sub_transferred`)
 - **Topic keys**: `["subscription_transferred", from_address, to_address]`
 - **Payload schema**: `(merchant: Address, amount: i128, interval: u64, token: Address)`
 - **JSON example**:
@@ -121,57 +290,12 @@ Events related to subscription lifecycle.
 
 ---
 
-## Charge & Payment Events
-
-Events related to charges and payments.
-
-### charged
-- **Trigger**: `charge()` or `batch_charge()`
-- **Topic keys**: `["charged", user_address]`
-- **Payload schema**:
-  ```rust
-  {
-    merchant: Address,
-    gross: i128,
-    fee: i128,
-    net: i128,
-    charged_at: u64
-  }
-  ```
-- **JSON example**:
-  ```json
-  {
-    "topic": ["charged", "GABC...XYZ"],
-    "data": {
-      "merchant": "GDEF...ABC",
-      "gross": 50000000,
-      "fee": 500000,
-      "net": 49500000,
-      "charged_at": 1719388800
-    }
-  }
-  ```
-
-### pay_per_use
-- **Trigger**: `pay_per_use()`
-- **Topic keys**: `["pay_per_use", user_address]`
-- **Payload schema**: `(merchant: Address, amount: i128)`
-- **JSON example**:
-  ```json
-  {
-    "topic": ["pay_per_use", "GABC...XYZ"],
-    "data": ["GDEF...ABC", 1000000]
-  }
-  ```
-
----
-
 ## Admin Events
 
 Events related to admin operations.
 
 ### contract_paused
-- **Trigger**: Admin pauses the contract
+- **Trigger**: Admin pauses the contract globally
 - **Topic keys**: `["contract_paused"]`
 - **Payload schema**: `()`
 - **JSON example**:
@@ -183,7 +307,7 @@ Events related to admin operations.
   ```
 
 ### contract_unpaused
-- **Trigger**: Admin unpauses the contract
+- **Trigger**: Admin unpauses the contract globally
 - **Topic keys**: `["contract_unpaused"]`
 - **Payload schema**: `()`
 - **JSON example**:
@@ -195,7 +319,7 @@ Events related to admin operations.
   ```
 
 ### admin_transferred
-- **Trigger**: Admin transfers ownership
+- **Trigger**: Two-step admin transfer completed (`accept_admin()`)
 - **Topic keys**: `["admin_transferred"]`
 - **Payload schema**: `(old_admin: Address, new_admin: Address)`
 - **JSON example**:
@@ -206,14 +330,26 @@ Events related to admin operations.
   }
   ```
 
-### upgraded
-- **Trigger**: Contract is upgraded
-- **Topic keys**: `["upgraded"]`
+### upgrade
+- **Trigger**: Contract WASM upgraded (`commit_upgrade()`)
+- **Topic keys**: `["upgrade"]`
+- **Payload schema**: `()` — note: the `new_wasm_hash` parameter is accepted but **not** emitted in the event data
+- **JSON example**:
+  ```json
+  {
+    "topic": ["upgrade"],
+    "data": []
+  }
+  ```
+
+### upg_proposed
+- **Trigger**: WASM upgrade proposed (`propose_upgrade()`)
+- **Topic keys**: `["upg_proposed"]`
 - **Payload schema**: `new_wasm_hash: BytesN<32>`
 - **JSON example**:
   ```json
   {
-    "topic": ["upgraded"],
+    "topic": ["upg_proposed"],
     "data": "0xabcdef123456..."
   }
   ```
@@ -258,7 +394,7 @@ Events related to admin operations.
 Events related to protocol fee configuration.
 
 ### fee_proposed
-- **Trigger**: Propose a new fee (two-step commit)
+- **Trigger**: `propose_fee()` (two-step commit)
 - **Topic keys**: `["fee_proposed"]`
 - **Payload schema**: `(collector: Address, bps: u32)`
 - **JSON example**:
@@ -270,7 +406,7 @@ Events related to protocol fee configuration.
   ```
 
 ### fee_committed
-- **Trigger**: Commit a proposed fee
+- **Trigger**: `commit_fee()` (two-step commit)
 - **Topic keys**: `["fee_committed"]`
 - **Payload schema**: `(collector: Address, bps: u32)`
 - **JSON example**:
@@ -278,6 +414,30 @@ Events related to protocol fee configuration.
   {
     "topic": ["fee_committed"],
     "data": ["GFEE...COLL", 100]
+  }
+  ```
+
+### fee_cleared
+- **Trigger**: `clear_fee()`
+- **Topic keys**: `["fee_cleared"]`
+- **Payload schema**: `()`
+- **JSON example**:
+  ```json
+  {
+    "topic": ["fee_cleared"],
+    "data": []
+  }
+  ```
+
+### merchant_fee_recipient_set
+- **Trigger**: `set_merchant_fee_recipient()`
+- **Topic keys**: `["merchant_fee_recipient_set", merchant_address]`
+- **Payload schema**: `recipient: Address`
+- **JSON example**:
+  ```json
+  {
+    "topic": ["merchant_fee_recipient_set", "GMERCH...ABC"],
+    "data": "GFEE...RECV"
   }
   ```
 
@@ -336,7 +496,7 @@ Events related to merchant management.
   ```
 
 ### merchant_withdrawal
-- **Trigger**: Merchant withdraws revenue
+- **Trigger**: `withdraw_merchant_revenue()`
 - **Topic keys**: `["merchant_withdrawal", merchant_address]`
 - **Payload schema**: `amount: i128`
 - **JSON example**:
@@ -366,7 +526,7 @@ Events related to user daily limit configuration.
   ```
 
 ### daily_limit_removed
-- **Trigger**: Remove daily limit (e.g., set to 0 or via specific function)
+- **Trigger**: `remove_daily_limit()`
 - **Topic keys**: `["daily_limit_removed", user_address]`
 - **Payload schema**: `()`
 - **JSON example**:
@@ -384,7 +544,7 @@ Events related to user daily limit configuration.
 Events related to grace period configuration.
 
 ### grace_period_proposed
-- **Trigger**: Propose a new grace period (two-step commit)
+- **Trigger**: `propose_grace_period()` (two-step commit)
 - **Topic keys**: `["grace_period_proposed"]`
 - **Payload schema**: `seconds: u64`
 - **JSON example**:
@@ -396,7 +556,7 @@ Events related to grace period configuration.
   ```
 
 ### grace_period_committed
-- **Trigger**: Commit a proposed grace period
+- **Trigger**: `commit_grace_period()` (two-step commit)
 - **Topic keys**: `["grace_period_committed"]`
 - **Payload schema**: `seconds: u64`
 - **JSON example**:
@@ -404,6 +564,54 @@ Events related to grace period configuration.
   {
     "topic": ["grace_period_committed"],
     "data": 86400
+  }
+  ```
+
+---
+
+## Referral Events
+
+Events related to referral tracking.
+
+### referred
+- **Trigger**: `subscribe()` (when referrer is provided)
+- **Topic keys**: `["referred", user_address]`
+- **Payload schema**: `referrer: Address`
+- **JSON example**:
+  ```json
+  {
+    "topic": ["referred", "GABC...XYZ"],
+    "data": "GDEF...ABC"
+  }
+  ```
+
+---
+
+## Migration & Infrastructure Events
+
+Events related to contract migration and infrastructure operations.
+
+### migration_completed
+- **Trigger**: `migrate()` (schema migration)
+- **Topic keys**: `["migration_completed"]`
+- **Payload schema**: `(version: u32, user_count: u32)`
+- **JSON example**:
+  ```json
+  {
+    "topic": ["migration_completed"],
+    "data": [3, 150]
+  }
+  ```
+
+### subscriber_index_ttl_extended
+- **Trigger**: `extend_subscriber_index_ttl()` (admin TTL refresh)
+- **Topic keys**: `["subscriber_index_ttl_extended"]`
+- **Payload schema**: `count: u64`
+- **JSON example**:
+  ```json
+  {
+    "topic": ["subscriber_index_ttl_extended"],
+    "data": 150
   }
   ```
 
@@ -419,4 +627,3 @@ Events related to grace period configuration.
 | [`docs/API.md`](API.md) | Contract function surface |
 | [`scripts/watch-events.ts`](../scripts/watch-events.ts) | Live poller reference implementation |
 | [`scripts/replay-events.ts`](../scripts/replay-events.ts) | Historical range replay with upsert semantics |
-|


### PR DESCRIPTION
Closes #915

## Changes
- Added 10 missing events: cancelled_with_refund, trial_extended, subscription_paused, subscription_auto_resumed, migration_completed, subscriber_index_ttl_extended, merchant_fee_recipient_set, upg_proposed, fee_cleared, daily_window_started
- Fixed event name: "upgraded" → "upgrade" (hash param accepted but not emitted in event data)
- Added ledger_sequence field to subscribed, charged, pay_per_use payloads
- Fixed cancelled payload schema (has ledger_sequence, not empty)
- Documented all 38 publish_* helpers from events.rs
- Added catalog version note with synchronization date
- Reorganized sections: lifecycle, charge, config, admin, fee, merchant, daily limit, grace period, referral, migration/infrastructure
- Cross-linked EVENT-DRIVEN-GUIDE.md