### PR TITLE
docs: update deployment, operations, API, and referral guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ Stellar's Soroban platform uses state archiving — persistent storage entries h
 - `pay_per_use(user, amount)` — the function this limit applies to
 - Full API reference: [`docs/API.md`](docs/API.md)
 - Architecture overview: [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)
+- Referral system (canonical): [`docs/REFERRALS.md`](docs/REFERRALS.md)
 - Developer Integration Guide: [`docs/INTEGRATION-GUIDE.md`](docs/INTEGRATION-GUIDE.md)
 - Mainnet deployment checklist: [`docs/MAINNET-DEPLOYMENT.md`](docs/MAINNET-DEPLOYMENT.md)
 - Merchant Integration Cookbook: [`docs/MERCHANT-INTEGRATION.md`](docs/MERCHANT-INTEGRATION.md)

--- a/docs/API.md
+++ b/docs/API.md
@@ -6,9 +6,11 @@ This document tracks the current public contract surface in [contract/src/lib.rs
 
 ## Table of Contents
 
+- [Bounded API delta (Issue 110)](#bounded-api-delta-issue-110)
 - [Data Types](#data-types)
   - [Subscription](#subscription)
   - [ChargeResult](#chargeresult)
+  - [ChargeSimResult](#chargesimresult)
   - [ProtocolStats](#protocolstats)
   - [HealthReport](#healthreport)
   - [DataKey](#datakey)
@@ -17,10 +19,12 @@ This document tracks the current public contract surface in [contract/src/lib.rs
   - [subscribe](#subscribe)
   - [subscribe\_with\_metadata](#subscribe_with_metadata)
   - [charge](#charge)
+  - [simulate\_charge](#simulate_charge)
   - [extend\_subscription\_ttl](#extend_subscription_ttl)
   - [pay\_per\_use](#pay_per_use)
   - [cancel](#cancel)
   - [pause](#pause)
+  - [pause\_until](#pause_until)
   - [resume](#resume)
   - [transfer\_admin](#transfer_admin)
   - [accept\_admin](#accept_admin)
@@ -57,11 +61,15 @@ This document tracks the current public contract surface in [contract/src/lib.rs
   - [get\_fee](#get_fee)
   - [propose\_fee](#propose_fee)
   - [commit\_fee](#commit_fee)
+  - [set\_fee\_bounds](#set_fee_bounds)
+  - [get\_fee\_bounds](#get_fee_bounds)
   - [batch\_charge](#batch_charge)
+  - [get\_batch\_charge\_estimate](#get_batch_charge_estimate)
   - [get\_active\_count](#get_active_count)
   - [get\_subscriber\_count](#get_subscriber_count)
   - [get\_subscriber\_at](#get_subscriber_at)
   - [get\_subscriber\_page](#get_subscriber_page)
+  - [get\_active\_subscriber\_page](#get_active_subscriber_page)
   - [get\_merchant\_revenue](#get_merchant_revenue)
   - [get\_merchant\_revenue\_history](#get_merchant_revenue_history)
   - [clear\_merchant\_revenue\_history](#clear_merchant_revenue_history)
@@ -96,6 +104,26 @@ This document tracks the current public contract surface in [contract/src/lib.rs
 
 ---
 
+## Bounded API delta (Issue 110)
+
+This revision documents only the following symbols against `contract/src/lib.rs`, `contract/src/charge_exec.rs`, `contract/src/batch.rs`, `contract/src/fee.rs`, `contract/src/errors.rs`, and `contract/src/storage.rs`. It is **not** a full API audit.
+
+- [x] `contract_health_check`
+- [x] `HealthReport`
+- [x] `simulate_charge`
+- [x] `get_batch_charge_estimate`
+- [x] `ChargeResult`
+- [x] `ChargeSimResult`
+- [x] `set_fee_bounds`
+- [x] `get_fee_bounds`
+- [x] `pause_until`
+- [x] pause-expiry getter — **not exposed** (internal `storage::get_pause_expiry` only; no public contract method)
+- [x] `get_active_subscriber_page`
+
+Related ops: [`EVENTS.md`](./EVENTS.md) (`paused`, `subscription_auto_resumed`, `charged`), [`KEEPER.md`](./KEEPER.md) (`batch_charge`), [`MAINNET-DEPLOYMENT.md`](./MAINNET-DEPLOYMENT.md) (fee bounds / health gates).
+
+---
+
 ## Data Types
 
 ### `Subscription`
@@ -117,16 +145,57 @@ pub struct Subscription {
 
 ### `ChargeResult`
 
+Returned by live `batch_charge` and by `get_batch_charge_estimate`. Defined in `contract/src/batch.rs` (re-exported from `lib.rs`).
+
 ```rust
 pub enum ChargeResult {
-  Charged,
-  Skipped,
-  NoSubscription,
-  Inactive,
-  Paused,
-  GracePeriodElapsed,
+  Charged,            // live: funds transferred; estimate: would charge (see caveats)
+  Skipped,            // interval has not elapsed
+  NoSubscription,     // no subscription record
+  Inactive,           // cancelled / inactive
+  Paused,             // still paused
+  GracePeriodElapsed, // past the grace window
 }
 ```
+
+| Variant | Meaning on `batch_charge` | Meaning on `get_batch_charge_estimate` |
+| --- | --- | --- |
+| `Charged` | Transfer succeeded | Precheck passed (or auto-resume short-circuit; **no transfer**) |
+| `Skipped` | Interval not elapsed | Same (via `precheck_charge`) |
+| `NoSubscription` | No record | Same |
+| `Inactive` | Cancelled / inactive | Same |
+| `Paused` | Still paused | Same |
+| `GracePeriodElapsed` | Past grace window | Same |
+
+This type is **not** the dry-run enum. Single-user simulation uses [`ChargeSimResult`](#chargesimresult).
+
+### `ChargeSimResult`
+
+Returned only by `simulate_charge`. Defined in `contract/src/charge_exec.rs`.
+
+```rust
+pub enum ChargeSimResult {
+  WouldSucceed,
+  NotDue,
+  Inactive,
+  InsufficientAllowance,
+  GracePeriodElapsed,
+  ContractPaused,
+  SubscriptionPaused,
+}
+```
+
+| Variant | Meaning |
+| --- | --- |
+| `WouldSucceed` | Prechecks including SAC allowance would pass |
+| `NotDue` | Ledger time is before next charge |
+| `Inactive` | Missing subscription **or** inactive (no separate `NoSubscription`) |
+| `InsufficientAllowance` | `allowance(user, contract) < amount` |
+| `GracePeriodElapsed` | Past grace window |
+| `ContractPaused` | Protocol paused (`storage::is_contract_paused`) |
+| `SubscriptionPaused` | User pause, including unexpired `pause_until` |
+
+`simulate_charge` never panics with a `ContractError` for these outcomes; they are return values.
 
 ### `ProtocolStats`
 
@@ -144,6 +213,8 @@ pub struct ProtocolStats {
 
 ### `HealthReport`
 
+Returned by [`contract_health_check`](#contract_health_check). There is no separate health-status enum: interpret `is_healthy` plus the component flags.
+
 ```rust
 pub struct HealthReport {
   pub is_healthy: bool,
@@ -153,8 +224,26 @@ pub struct HealthReport {
   pub instance_ttl_ledgers: u32,
   pub active_subscription_count: u64,
   pub schema_version: u32,
+  pub fee_collector_set: bool,
+  pub global_volume_utilization_pct: u32,
+  pub pending_merchant_rev_count: u32,
 }
 ```
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `is_healthy` | `bool` | `!contract_paused && token_configured && admin_configured && instance_ttl_ledgers > 17_280` |
+| `contract_paused` | `bool` | Protocol pause flag |
+| `token_configured` | `bool` | Instance token is set |
+| `admin_configured` | `bool` | Admin is set |
+| `instance_ttl_ledgers` | `u32` | **On-chain:** hardcoded `100_000` (Soroban does not expose `get_ttl()` outside tests). **Test/testutils:** real instance TTL. Do not treat the on-chain value as precise remaining TTL. |
+| `active_subscription_count` | `u64` | Active subscription counter |
+| `schema_version` | `u32` | Migration schema version |
+| `fee_collector_set` | `bool` | Protocol fee collector is set |
+| `global_volume_utilization_pct` | `u32` | `(accumulated * 100) / cap`, clamped to ≤ 100; `0` if cap is 0. Cap is `GlobalVolumeCapOverride` or `GLOBAL_MAX_VOLUME_PER_HOUR`. |
+| `pending_merchant_rev_count` | `u32` | Merchants in `MerchantIndex` with unwithdrawn revenue `> 0` |
+
+**How to interpret:** treat `is_healthy == false` as “do not send production traffic” until pause, token, admin, or TTL flags are understood. `fee_collector_set` and volume utilization are informational and do **not** enter the `is_healthy` formula. `global_volume_utilization_pct` uses the stored cap override when present; charge-time enforcement still uses the compile-time constant (see [`MAINNET-DEPLOYMENT.md`](./MAINNET-DEPLOYMENT.md#2-volume-cap)).
 
 ### `DataKey`
 
@@ -297,6 +386,44 @@ CLI example:
 soroban contract invoke --id <CONTRACT_ID> --source <KEEPER_KEY> --network testnet -- charge --user <USER_ADDRESS>
 ```
 
+### `simulate_charge`
+
+Dry-run of a single `charge()` for `user`. **No storage writes** and **no token transfer**. Outcomes are [`ChargeSimResult`](#chargesimresult) variants, not panics.
+
+```
+simulate_charge(env: Env, user: Address) -> ChargeSimResult
+```
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `user` | `Address` | Subscriber to simulate. |
+
+**Auth:** none.
+
+**Returns:** `ChargeSimResult`.
+
+**Success behavior:** evaluates contract pause, subscription presence, `pause_until` expiry (in memory only — does not persist auto-resume), due time, grace window, then SAC `allowance(user, contract)` vs `amount`. Returns `WouldSucceed` if all pass.
+
+**Error conditions:** none as `ContractError` panics. Failure reasons are enum variants (`ContractPaused`, `Inactive`, `SubscriptionPaused`, `NotDue`, `GracePeriodElapsed`, `InsufficientAllowance`).
+
+**Distinguish from live charge and batch estimate:**
+
+| | `charge` / `batch_charge` | `simulate_charge` | `get_batch_charge_estimate` |
+| --- | --- | --- | --- |
+| Transfers | Yes | No | No |
+| Storage writes | Yes on success / auto-resume | No (auto-resume is memory-only) | **Yes** if `try_auto_resume` fires |
+| Contract pause | Enforced (panic / skip) | `ContractPaused` | **Ignored** |
+| Allowance | Required for success | Checked | **Not checked** |
+| Return | void / `ChargeResult` | `ChargeSimResult` | `Vec<ChargeResult>` |
+
+Keeper ops still use live `batch_charge`; see [`KEEPER.md`](./KEEPER.md). Events for a real charge are in [`EVENTS.md`](./EVENTS.md).
+
+CLI example:
+
+```bash
+soroban contract invoke --id <CONTRACT_ID> --network testnet -- simulate_charge --user <USER_ADDRESS>
+```
+
 ### `extend_subscription_ttl`
 
 ```
@@ -384,6 +511,41 @@ CLI example:
 
 ```bash
 soroban contract invoke --id <CONTRACT_ID> --source <USER_KEY> --network testnet -- pause --user <USER_ADDRESS>
+```
+
+### `pause_until`
+
+Bounded user pause. The subscription auto-resumes on a later `charge` or `batch_charge` when ledger time `>= expiry`. Unlike indefinite [`pause`](#pause), this path sets `paused = true` **and** `active = false`.
+
+```
+pause_until(env: Env, user: Address, expiry: u64)
+```
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `user` | `Address` | Subscriber and signer. |
+| `expiry` | `u64` | Unix ledger timestamp; must be **strictly greater than** current ledger time. |
+
+**Auth:** `user.require_auth()`.
+
+**Returns:** `()`.
+
+**Success behavior:** writes the subscription, stores pause expiry internally, emits `paused` (`("paused", user)`). See [`EVENTS.md`](./EVENTS.md).
+
+**Errors:**
+
+| Condition | Code | Symbol |
+| --- | --- | --- |
+| `expiry <= now` | 27 | `InvalidPauseExpiry` |
+| No subscription | 4 | `NoSubscriptionFound` |
+| `!sub.active` | 16 | `SubscriptionNotActive` |
+
+**Pause-expiry read API:** there is **no** public `get_pause_expiry`, `get_pause`, or `paused_until` contract method. Expiry is stored via internal `storage::set_pause_expiry` / `storage::get_pause_expiry` only.
+
+CLI example:
+
+```bash
+soroban contract invoke --id <CONTRACT_ID> --source <USER_KEY> --network testnet -- pause_until --user <USER_ADDRESS> --expiry <UNIX_TIMESTAMP>
 ```
 
 ### `resume`
@@ -1099,13 +1261,60 @@ Auth: admin only.
 
 Returns: `()`.
 
-Errors: `ContractError::NoPendingProposal`.
+Errors: `ContractError::NoPendingProposal` (23), `ContractError::FeeOutOfBoundsAtCommit` (35) if pending bps is outside [`get_fee_bounds`](#get_fee_bounds).
 
 CLI example:
 
 ```bash
 soroban contract invoke --id <CONTRACT_ID> --source <ADMIN_KEY> --network testnet -- commit_fee
 ```
+
+### `set_fee_bounds`
+
+Admin-only guardrails for **future** fee commits. Stored on instance as `DataKey::MinFeeBps` / `DataKey::MaxFeeBps`.
+
+```
+set_fee_bounds(env: Env, min_bps: u32, max_bps: u32)
+```
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `min_bps` | `u32` | Inclusive minimum bps for a pending fee at commit. |
+| `max_bps` | `u32` | Inclusive maximum bps; must be `<= 10_000`. |
+
+**Auth:** admin (`admin::require_admin`).
+
+**Returns:** `()`.
+
+**Bounds semantics:** `propose_fee` does **not** apply these bounds (it only rejects `bps > 10_000` and an invalid collector). `commit_fee` rejects pending bps outside `[min_bps, max_bps]` with `FeeOutOfBoundsAtCommit` (35).
+
+**Errors:** `ContractError::InvalidFeeBounds` (34) if `min_bps > max_bps` or `max_bps > 10_000`. Unauthorized callers fail admin auth.
+
+CLI example:
+
+```bash
+soroban contract invoke --id <CONTRACT_ID> --source <ADMIN_KEY> --network testnet -- set_fee_bounds --min_bps 0 --max_bps 500
+```
+
+### `get_fee_bounds`
+
+```
+get_fee_bounds(env: Env) -> (u32, u32)
+```
+
+**Auth:** none.
+
+**Returns:** `(min_bps, max_bps)`. Defaults to `(0, 10000)` when governance has not set explicit bounds.
+
+**Errors:** none.
+
+CLI example:
+
+```bash
+soroban contract invoke --id <CONTRACT_ID> --network testnet -- get_fee_bounds
+```
+
+Operational gate: [`MAINNET-DEPLOYMENT.md`](./MAINNET-DEPLOYMENT.md#1-fee-bounds).
 
 ### `batch_charge`
 
@@ -1123,6 +1332,41 @@ CLI example:
 
 ```bash
 soroban contract invoke --id <CONTRACT_ID> --source <KEEPER_KEY> --network testnet -- batch_charge --users '["<USER_A>","<USER_B>"]'
+```
+
+### `get_batch_charge_estimate`
+
+Batch **estimate** (not a transfer). Returns `Vec<ChargeResult>` — the live batch enum — **not** [`ChargeSimResult`](#chargesimresult).
+
+```
+get_batch_charge_estimate(env: Env, users: Vec<Address>) -> Vec<ChargeResult>
+```
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `users` | `Vec<Address>` | Addresses to estimate. |
+
+**Auth:** none.
+
+**Returns:** one `ChargeResult` per input address, in order.
+
+**Success behavior:** for each user, missing sub → `NoSubscription`. If paused and `try_auto_resume` returns true → **`Charged` immediately** (skips `precheck_charge`). Otherwise maps `precheck_charge` to `Charged` / skip variants.
+
+**Errors:** `ContractError::BatchTooLarge` (20) if `users.len() > 200` (hardcoded; not `get_max_batch_size`). Ordinary per-user outcomes are enum values, not panics.
+
+**Operational caveats (from `lib.rs`):**
+
+1. Calls real `try_auto_resume`, which **writes** the subscription, clears pause expiry, and emits `subscription_auto_resumed` — **not a pure view**.
+2. Does **not** check contract pause or token allowance (unlike `simulate_charge`).
+3. Auto-resume short-circuit to `Charged` can disagree with live `batch_charge`, which still runs `precheck_charge` after resume (estimate may say `Charged` when live would `Skipped`).
+4. Cap 200 vs live batch max (default 50 via `MaxBatchSize`).
+
+Use `simulate_charge` for a no-write, allowance-aware single-user dry-run. Keepers that charge should still call `batch_charge` ([`KEEPER.md`](./KEEPER.md)). Auto-resume event: [`EVENTS.md`](./EVENTS.md).
+
+CLI example:
+
+```bash
+soroban contract invoke --id <CONTRACT_ID> --network testnet -- get_batch_charge_estimate --users '["<USER_A>","<USER_B>"]'
 ```
 
 ### `get_active_count`
@@ -1187,6 +1431,35 @@ CLI example:
 
 ```bash
 soroban contract invoke --id <CONTRACT_ID> --network testnet -- get_subscriber_page --offset 0 --limit 10
+```
+
+### `get_active_subscriber_page`
+
+View of **active** subscriber addresses from the append-only `SubscriberIndex`. Sibling [`get_subscriber_page`](#get_subscriber_page) does not filter on `sub.active`.
+
+```
+get_active_subscriber_page(env: Env, offset: u64, limit: u32) -> Vec<Address>
+```
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `offset` | `u64` | **Index-slot** cursor into `SubscriberIndex`, not “Nth active subscriber”. |
+| `limit` | `u32` | Requested page size. Silently clamped to **50**. `0` returns empty. |
+
+**Auth:** none.
+
+**Returns:** `Vec<Address>`. Empty when `offset >= index_size` or `cap == 0`. Length may be **less than** `limit` when many slots are missing or inactive; the scan continues until `result.len() == cap` or the index ends.
+
+**Pagination:** increment `offset` by the number of **index slots consumed**, not by `result.len()`, if you need to walk the whole index. The implementation walks `i` from `offset` upward and pushes only addresses whose `Subscription` exists and `sub.active` is true.
+
+**Errors:** none.
+
+**Related:** `ChargeResult` / keeper paging still typically use `batch_charge` with an operator-supplied address list ([`KEEPER.md`](./KEEPER.md)).
+
+CLI example:
+
+```bash
+soroban contract invoke --id <CONTRACT_ID> --network testnet -- get_active_subscriber_page --offset 0 --limit 50
 ```
 
 ### `get_merchant_revenue`
@@ -1554,13 +1827,21 @@ soroban contract invoke --id <CONTRACT_ID> --network testnet -- set_initial_admi
 
 ### `contract_health_check`
 
+Read-only snapshot of protocol health. Safe at any time: **no auth, no storage writes**. There is no `health_check` or `get_health` export.
+
 ```
 contract_health_check(env: Env) -> HealthReport
 ```
 
-Auth: none.
+**Auth:** none.
 
-Returns: `HealthReport`.
+**Returns:** [`HealthReport`](#healthreport).
+
+**Success behavior:** builds the struct; does not panic on the normal path. `is_healthy` is true only when the contract is not paused, token and admin are set, and `instance_ttl_ledgers > 17_280`.
+
+**Errors:** none defined.
+
+**Operational notes:** on-chain `instance_ttl_ledgers` is a hardcoded `100_000`. Off-chain `scripts/health-check.ts` is a **shallow** RPC simulation of `get_schema_version` and `get_active_count` only — it does not call this method. See [`MAINNET-DEPLOYMENT.md`](./MAINNET-DEPLOYMENT.md#3-health).
 
 CLI example:
 
@@ -2662,3 +2943,6 @@ All error conditions are returned as `ContractError` values. Client SDKs can dec
 | 10 | `MerchantNotWhitelisted` | The merchant is not on the whitelist (when whitelist is enabled). |
 | 11 | `ContractPaused` | The contract is paused; all user-facing write operations are blocked. |
 | 24 | `DailyLimitExceeded` | A `pay_per_use()` call would exceed the user's configured daily spending limit. |
+| 33 | `InvalidVolumeCap` | `set_global_volume_cap` was called with a non-positive cap. |
+| 34 | `InvalidFeeBounds` | `set_fee_bounds` min/max is inconsistent or `max_bps > 10000`. |
+| 35 | `FeeOutOfBoundsAtCommit` | `commit_fee` pending bps is outside current fee bounds. |

--- a/docs/ERROR-CODES.md
+++ b/docs/ERROR-CODES.md
@@ -45,6 +45,9 @@ Use the [quick-reference table](#quick-reference-table) for lookups, then jump t
 | 29   | `InvalidBatchSize`          | Validation   | Configured batch limit invalid     |
 | 30   | `ContractPausedError`       | State        | Subscribe while paused             |
 | 32   | `InvalidRecipient`          | Validation   | Recipient address invalid          |
+| 33   | `InvalidVolumeCap`          | Validation   | Volume cap override not positive   |
+| 34   | `InvalidFeeBounds`          | Validation   | Fee bounds min/max invalid         |
+| 35   | `FeeOutOfBoundsAtCommit`    | Validation   | Pending fee outside bounds         |
 
 > **Note:** Code `31` is intentionally unused. Source of truth: [`contract/src/errors.rs`](../contract/src/errors.rs).
 
@@ -570,13 +573,61 @@ Use the [quick-reference table](#quick-reference-table) for lookups, then jump t
 
 ---
 
+### 33 — `InvalidVolumeCap`
+
+| Field               | Detail                                                         |
+| ------------------- | -------------------------------------------------------------- |
+| **When it occurs**  | Admin `set_global_volume_cap` with `new_cap <= 0`              |
+| **Immediate cause** | Configured hourly volume cap must be strictly positive         |
+
+**Recovery steps**
+
+1. Choose a positive cap in stroops.
+2. Retry `set_global_volume_cap` as admin.
+
+**Prevention:** Validate `new_cap > 0` in admin tooling. See [`MAINNET-DEPLOYMENT.md`](./MAINNET-DEPLOYMENT.md#2-volume-cap).
+
+---
+
+### 34 — `InvalidFeeBounds`
+
+| Field               | Detail                                                                      |
+| ------------------- | --------------------------------------------------------------------------- |
+| **When it occurs**  | Admin `set_fee_bounds` with `min_bps > max_bps` or `max_bps > 10_000`      |
+| **Immediate cause** | Fee bound range is empty or exceeds 100% (10_000 bps)                       |
+
+**Recovery steps**
+
+1. Choose `min_bps <= max_bps` with `max_bps <= 10000`.
+2. Retry `set_fee_bounds` as admin.
+
+**Prevention:** Validate bounds in admin UI before signing. See [`API.md`](./API.md#set_fee_bounds).
+
+---
+
+### 35 — `FeeOutOfBoundsAtCommit`
+
+| Field               | Detail                                                                                 |
+| ------------------- | -------------------------------------------------------------------------------------- |
+| **When it occurs**  | `commit_fee` when pending bps is outside current `[MinFeeBps, MaxFeeBps]`              |
+| **Immediate cause** | Bounds were tightened (or never matched) between `propose_fee` and `commit_fee`        |
+
+**Recovery steps**
+
+1. Call `get_fee_bounds` and `get_fee` / inspect pending proposal.
+2. Either `set_fee_bounds` to include the pending bps, or `propose_fee` again with in-range bps, then `commit_fee`.
+
+**Prevention:** Set bounds before proposing; do not tighten bounds under an in-flight proposal unless that is intended.
+
+---
+
 ## Error Categories
 
 | Category       | Codes                                    | Typical owners                |
 | -------------- | ---------------------------------------- | ----------------------------- |
 | Auth / access  | 8, 10, 22                                | User + admin                  |
 | State          | 1, 4, 5, 7, 16, 17, 18, 21, 23, 24, 30   | Deployer, user, admin, keeper |
-| Validation     | 2, 3, 11, 12, 13, 14, 19, 26, 27, 29, 32 | Client / admin tooling        |
+| Validation     | 2, 3, 11, 12, 13, 14, 19, 26, 27, 29, 32, 33, 34, 35 | Client / admin tooling        |
 | Limit / timing | 6, 9, 15, 20, 25, 28                     | Keeper + user                 |
 
 ---

--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -585,6 +585,8 @@ Events related to referral tracking.
   }
   ```
 
+See the canonical referral guide: [`REFERRALS.md`](./REFERRALS.md#referred-event).
+
 ---
 
 ## Migration & Infrastructure Events

--- a/docs/MAINNET-DEPLOYMENT.md
+++ b/docs/MAINNET-DEPLOYMENT.md
@@ -2,24 +2,208 @@
 
 FlowPay is **currently deployed on Testnet only**. Use this checklist when the protocol is ready for Public Global Stellar Network (Mainnet) after a formal security audit.
 
-For day-to-day Testnet steps, see [`DEPLOYMENT.md`](DEPLOYMENT.md). For audit gates, see [`security/audit-preparation.md`](security/audit-preparation.md) and [`SECURITY.md`](SECURITY.md).
+For day-to-day Testnet steps, see [`DEPLOYMENT.md`](DEPLOYMENT.md). For audit gates, see [`security/audit-preparation.md`](security/audit-preparation.md), [`SECURITY.md`](SECURITY.md), and the repository [`SECURITY.md`](../SECURITY.md).
+
+This document does **not** authorize a Mainnet deployment. Do not deploy or deposit real funds until every gate below is complete.
 
 ---
 
-## Phase 0 — Security gates (do not skip)
+## Audit gate (mandatory — do not skip)
+
+The repository security policy is explicit:
+
+> PayFlow is currently deployed on Testnet only and has not been formally audited.
+>
+> Do not use on Mainnet with real funds until an independent security audit is completed.
+>
+> — [`SECURITY.md`](../SECURITY.md)
+
+[`docs/SECURITY.md`](SECURITY.md) repeats that FlowPay has not been formally audited and requires remediating findings, re-testing, and publishing the report (or summary) **before Mainnet**.
+
+**Do not deploy a Mainnet instance, and do not deposit or route real funds, until:**
+
+- [ ] An independent Soroban-focused security audit is complete
+- [ ] Findings remediations are merged
+- [ ] The report (or summary) is published or accepted by maintainers
+- [ ] The audited WASM hash matches the release artifact
+
+There is no in-repo override that weakens this requirement.
+
+---
+
+## Phase 0 — Security gates
 
 > Real funds must not flow through an unaudited Mainnet deployment.
 
-- [ ] **Independent security audit complete** — findings remediations merged; report (or summary) published or accepted by maintainers. _Why:_ Mainnet holds user allowances and merchant revenue.
-- [ ] **Audit WASM hash matches release artifact** — SHA256 of `flow_pay.wasm` recorded in release notes. _Why:_ prevents deploying an unaudited binary.
+- [ ] **Independent security audit complete** — see [Audit gate](#audit-gate-mandatory--do-not-skip). _Why:_ Mainnet holds user allowances and merchant revenue.
+- [ ] **Audit WASM hash matches release artifact** — SHA256 of the release WASM (`flow_pay.wasm` per [`deployments/config.json`](../deployments/config.json)) recorded in release notes. _Why:_ prevents deploying an unaudited binary.
 - [ ] **Key management plan approved**
   - [ ] Admin key on a **hardware wallet** (or equivalent HSM)
   - [ ] Prefer **multisig / multi-party** admin (Stellar multisig thresholds) over a single hot key
   - [ ] Deployer key separate from long-term admin key where possible
-  - [ ] Keeper keys are hot keys with **limited XLM** and no admin rights  
-        _Why:_ admin compromise can pause, freeze merchants, or change fees.
-- [ ] **Emergency runbook rehearsed** — who can call `pause_contract()`, who to page, how to unpause. _Why:_ reduces incident MTTR.
-- [ ] **Fee governance configured** — intended `bps` and fee collector (not the contract address). Two-step propose/commit understood. _Why:_ fee mistakes are costly on Mainnet.
+  - [ ] Keeper keys are hot keys with **limited XLM** and no admin rights
+        _Why:_ admin compromise can pause, freeze merchants, change fees, or commit an upgrade.
+- [ ] **Emergency runbook rehearsed** — who can call `pause_contract()`, who to page, how to unpause. _Why:_ reduces incident MTTR. There is **no automatic rollback**.
+- [ ] **Fee governance configured** — intended `bps` and fee collector (not the contract address). Two-step `propose_fee` / `commit_fee` understood. Fee **bounds** configured and verified (see [Fee bounds](#1-fee-bounds)).
+- [ ] **Volume cap verified** — see [Volume cap](#2-volume-cap).
+- [ ] **Health gates understood** — on-chain `contract_health_check` plus the shallow `scripts/health-check.ts` script (see [Health](#3-health)).
+
+---
+
+## 1. Fee bounds
+
+Configured fee bounds are admin-set guardrails on future protocol-fee commits. They must be verified **before any Mainnet funds** (user allowances or merchant revenue) are allowed into the contract.
+
+| Method | Auth | Role |
+| --- | --- | --- |
+| `set_fee_bounds(min_bps: u32, max_bps: u32)` | admin (`require_admin`) | Writes instance keys `MinFeeBps` / `MaxFeeBps` |
+| `get_fee_bounds() -> (u32, u32)` | none | Returns configured bounds; defaults to `(0, 10000)` if unset |
+
+**Semantics (from `contract/src/lib.rs` and `contract/src/fee.rs`):**
+
+- `set_fee_bounds` panics with `InvalidFeeBounds` (34) if `min_bps > max_bps` or `max_bps > 10_000`.
+- `propose_fee` does **not** check these bounds; it only rejects `bps > 10_000` (`InvalidFeeBps`, 13) and an invalid collector (`InvalidFeeCollector`, 26).
+- `commit_fee` re-validates the pending bps against `[min_bps, max_bps]` and panics with `FeeOutOfBoundsAtCommit` (35) if the pending value is outside the range.
+
+**Pre-deposit checks:**
+
+```bash
+soroban contract invoke --id <CONTRACT_ID> --network mainnet -- get_fee_bounds
+soroban contract invoke --id <CONTRACT_ID> --network mainnet -- get_fee
+```
+
+- [ ] `get_fee_bounds` returns the intended `(min_bps, max_bps)` for Mainnet (not an accidental default of `0`–`10000` unless that is the approved policy)
+- [ ] Current `get_fee` collector and bps sit inside those bounds
+- [ ] Operators understand that tightening bounds after `propose_fee` will block `commit_fee`
+
+API reference: [`API.md` — `set_fee_bounds` / `get_fee_bounds`](API.md#set_fee_bounds).
+
+---
+
+## 2. Volume cap
+
+The protocol enforces a **global hourly volume cap** so a burst of charges cannot move unbounded value in a single window. The compile-time default is:
+
+```text
+GLOBAL_MAX_VOLUME_PER_HOUR = 50_000_000_000_000  // 50 trillion stroops
+HOUR_IN_SECONDS            = 3600
+```
+
+| Method | Auth | Role |
+| --- | --- | --- |
+| `get_global_volume_cap() -> i128` | none | Effective cap: instance override `GlobalVolumeCapOverride`, or the compile-time default |
+| `get_global_volume_window() -> (i128, u64)` | none | `(accumulated_volume, window_start_timestamp)`; `(0, 0)` if no window yet |
+| `set_global_volume_cap(new_cap: i128)` | admin | Stores a positive override; panics `InvalidVolumeCap` (33) if `new_cap <= 0` |
+
+**Operational purpose:** limit protocol-wide transfer volume per rolling hour. Exceeding the cap during charge accounting panics with `GlobalVolumeExceeded` (28).
+
+**Enforcement note (do not assume the override is live in the charge path):** `check_and_update_global_volume` currently compares accumulated volume against the compile-time `GLOBAL_MAX_VOLUME_PER_HOUR` constant, not against `get_global_volume_cap()`. `get_contract_config` also reports the constant. Treat `set_global_volume_cap` as stored operator intent and a health-report input (`HealthReport.global_volume_utilization_pct` uses the override when present). The charge-time ceiling that actually panics is still `GLOBAL_MAX_VOLUME_PER_HOUR` until that path is wired to the override.
+
+**Pre-deposit checks:**
+
+```bash
+soroban contract invoke --id <CONTRACT_ID> --network mainnet -- get_global_volume_cap
+soroban contract invoke --id <CONTRACT_ID> --network mainnet -- get_global_volume_window
+```
+
+- [ ] Recorded cap matches the approved Mainnet risk limit
+- [ ] Window accumulation is as expected for a fresh or recently migrated instance
+- [ ] Operators know `GlobalVolumeExceeded` is a protocol-wide halt on further charges in that hour
+
+---
+
+## 3. Health
+
+A Mainnet deployment is **healthy** only when both the on-chain snapshot and the off-chain responsiveness check succeed.
+
+### On-chain: `contract_health_check` → `HealthReport`
+
+There is **no** exported `health_check` or `get_health` method. The public ABI name is `contract_health_check`. Auth: none. No storage writes.
+
+`is_healthy` is true when **all** of the following hold (`contract/src/lib.rs`):
+
+- `contract_paused` is false
+- `token_configured` is true
+- `admin_configured` is true
+- `instance_ttl_ledgers > 17_280` (~1 day at ~5 s/ledger)
+
+On-chain, `instance_ttl_ledgers` is a **hardcoded 100_000** estimate (`get_ttl()` is not available outside test builds). Do not treat it as a precise remaining-TTL reading.
+
+```bash
+soroban contract invoke --id <CONTRACT_ID> --network mainnet -- contract_health_check
+```
+
+Also confirm:
+
+```bash
+soroban contract invoke --id <CONTRACT_ID> --network mainnet -- get_protocol_stats
+soroban contract invoke --id <CONTRACT_ID> --network mainnet -- get_schema_version
+soroban contract invoke --id <CONTRACT_ID> --network mainnet -- is_contract_paused
+```
+
+Fields and interpretation: [`API.md` — `HealthReport`](API.md#healthreport).
+
+### Off-chain: `scripts/health-check.ts` (shallow)
+
+This script simulates `get_schema_version` and `get_active_count`. It does **not** call `contract_health_check` and has **no** `--deep` mode.
+
+```bash
+cd scripts
+CONTRACT_ID=<CONTRACT_ID> npx tsx health-check.ts
+# exit 0 = both calls returned valid responses; exit 1 = unhealthy
+```
+
+Env: `CONTRACT_ID` (required; `VITE_CONTRACT_ID` accepted), `RPC_URL` / `VITE_RPC_URL`, `NETWORK=mainnet` to select `Networks.PUBLIC`.
+
+- [ ] `contract_health_check` reports `is_healthy: true`, token + admin configured, not paused
+- [ ] `scripts/health-check.ts` exits 0 against the Mainnet contract ID and Mainnet RPC
+- [ ] Schema version matches the release notes / [`DEPLOYMENT.md` migration history](DEPLOYMENT.md#migration-history)
+
+---
+
+## 4. Pre-upgrade controls
+
+Run these **before** proposing a WASM swap on Mainnet. They are separate scripts; they are not wired together automatically.
+
+### `scripts/pre-upgrade-check.ts`
+
+```bash
+CONTRACT_ID=<CONTRACT_ID> npx tsx scripts/pre-upgrade-check.ts
+CONTRACT_ID=<CONTRACT_ID> npx tsx scripts/pre-upgrade-check.ts --wasm ./contract/target/wasm32-unknown-unknown/release/flow_pay.wasm
+CONTRACT_ID=<CONTRACT_ID> npx tsx scripts/pre-upgrade-check.ts --skip-key-check --upgrade-config ./upgrade-config.json
+```
+
+From `scripts/`: `npm run pre-upgrade-check` → `tsx pre-upgrade-check.ts`.
+
+Checks include: `get_schema_version`, optional expected schema from upgrade-config, optional WASM magic/size/hash prefix, `get_admin` plus optional `ADMIN_SECRET_KEY` sign test, `get_active_count` (warns if > 0), `get_fee`, and a dry-run simulate of `migrate`. Exit 1 on blocking failures.
+
+Env: `CONTRACT_ID`, `RPC_URL`, `NETWORK_PASSPHRASE`, `ADMIN_SECRET_KEY`, `UPGRADE_CONFIG_PATH`.
+
+### Snapshot then diff
+
+```bash
+CONTRACT_ID=<CONTRACT_ID> npx tsx scripts/subscription-snapshot.ts --file addresses.txt --out before.json
+# … upgrade or config change …
+CONTRACT_ID=<CONTRACT_ID> npx tsx scripts/subscription-snapshot.ts --file addresses.txt --out after.json
+npx tsx scripts/snapshot-diff.ts before.json after.json
+# exit 0 = no differences; exit 1 = differences; exit 2 = usage/file errors
+```
+
+`snapshot-diff.ts` compares `active`, `paused`, `amount`, `interval`, `merchant`, `token`. There is no npm script alias for snapshot-diff.
+
+- [ ] `pre-upgrade-check` exits 0 on the candidate WASM
+- [ ] Before/after snapshots retained; `snapshot-diff` reviewed if an upgrade is in the same change window
+
+### `ALLOW_MAINNET` and network authorization
+
+**This repository does not implement an `ALLOW_MAINNET` environment variable or deploy-time guard.** Network selection is a manual operator control:
+
+- Soroban CLI `--network mainnet`
+- `scripts/health-check.ts`: `NETWORK=mainnet` selects `Networks.PUBLIC`
+- `deployments/config.json` `network` / `networkPassphrase` / `rpcUrl` (the checked-in example is **testnet**)
+- `NETWORK_PASSPHRASE` / `VITE_NETWORK_PASSPHRASE` for scripts and frontend
+
+Absence of a flag is **not** authorization to use real funds. Confirm passphrase, RPC, SAC, and contract ID are Mainnet **before** any signed invoke.
 
 ---
 
@@ -33,26 +217,27 @@ cd contract
 cargo build --release --target wasm32-unknown-unknown
 ```
 
-Expected artifact:
+Expected artifact path used by [`deployments/config.json`](../deployments/config.json) and `scripts/deploy-pipeline.ts`:
 
 ```text
-target/wasm32-unknown-unknown/release/flow_pay.wasm
+contract/target/wasm32-unknown-unknown/release/flow_pay.wasm
 ```
 
 - [ ] **Record WASM hash**
 
 ```bash
-sha256sum target/wasm32-unknown-unknown/release/flow_pay.wasm
+sha256sum contract/target/wasm32-unknown-unknown/release/flow_pay.wasm
 # Windows PowerShell:
-Get-FileHash target\wasm32-unknown-unknown\release\flow_pay.wasm -Algorithm SHA256
+Get-FileHash contract\target\wasm32-unknown-unknown\release\flow_pay.wasm -Algorithm SHA256
 ```
 
-- [ ] **Schema version check** — confirm `get_schema_version` expectations match docs migration table in [`DEPLOYMENT.md`](DEPLOYMENT.md#migration-history).
+- [ ] **Schema version check** — confirm `get_schema_version` expectations match [`DEPLOYMENT.md`](DEPLOYMENT.md#migration-history).
 - [ ] **Testnet smoke test on the same commit**
   - [ ] Deploy/upgrade testnet with this WASM
   - [ ] `subscribe` → wait/advance interval → `charge` / keeper `batch_charge`
-  - [ ] `pause` / `resume`, merchant withdraw (if applicable)
-  - [ ] `scripts/verify-contract.sh --network testnet --id <TESTNET_CONTRACT_ID>` passes
+  - [ ] `pause` / `pause_until` / `resume`, merchant withdraw (if applicable)
+  - [ ] `CONTRACT_ID=<TESTNET_CONTRACT_ID> npx tsx scripts/health-check.ts` exits 0
+  - [ ] `soroban contract invoke ... -- contract_health_check` is healthy
 - [ ] **Mainnet SAC address confirmed** — use the Mainnet Stellar Asset Contract for the chosen asset (not Testnet SAC).
 - [ ] **RPC / horizon endpoints selected** — primary + backup Mainnet Soroban RPC.
 - [ ] **Funding** — deployer and keeper accounts funded with Mainnet XLM for fees.
@@ -61,13 +246,20 @@ Get-FileHash target\wasm32-unknown-unknown\release\flow_pay.wasm -Algorithm SHA2
 
 ## Phase 2 — Deploy
 
-> Prefer `scripts/deploy.sh` when available; otherwise use Soroban CLI equivalents below.
+> Prefer `scripts/deploy-pipeline.ts` when you intend a scripted deploy. There is **no** `scripts/deploy.sh` in this repository. The pipeline reads [`deployments/config.json`](../deployments/config.json); the checked-in file is **testnet**. Do not point it at Mainnet until the [audit gate](#audit-gate-mandatory--do-not-skip) is complete.
 
-### Option A — Script
+### Option A — Deploy pipeline
 
 ```bash
-bash scripts/deploy.sh --network mainnet --source <DEPLOYER_KEYPAIR> --token <MAINNET_SAC_ADDRESS>
+# Dry-run first (no live deploy)
+npx tsx scripts/deploy-pipeline.ts --dry-run
+
+# Live deploy requires DEPLOYER_SECRET_KEY and ADMIN_SECRET_KEY.
+# Use a Mainnet-specific deployments/config.json (network, passphrase, RPC, SAC, wasmPath).
+npx tsx scripts/deploy-pipeline.ts
 ```
+
+The pipeline builds WASM, runs `stellar contract deploy`, `initialize`, verifies via `contract_health_check` (`admin_configured` + `token_configured`), then `propose_fee` / `commit_fee` and `whitelist_batch_add` when configured. It does **not** set fee bounds or volume cap, and it has **no** `ALLOW_MAINNET` gate.
 
 Save the printed **contract ID**.
 
@@ -78,7 +270,7 @@ Save the printed **contract ID**.
 soroban contract upload \
   --source <DEPLOYER> \
   --network mainnet \
-  --wasm target/wasm32-unknown-unknown/release/flow_pay.wasm
+  --wasm contract/target/wasm32-unknown-unknown/release/flow_pay.wasm
 # Expected: prints WASM hash (hex)
 
 # 2) Deploy instance
@@ -103,6 +295,8 @@ soroban contract invoke \
 - [ ] Contract ID recorded in password manager / ops vault
 - [ ] `initialize` succeeded exactly once
 - [ ] Admin address is the intended hardware/multisig account
+- [ ] `set_fee_bounds` applied with the approved range
+- [ ] Volume cap recorded (`get_global_volume_cap`); `set_global_volume_cap` only if policy requires an override
 
 ### Optional: migrate
 
@@ -120,33 +314,30 @@ soroban contract invoke \
 
 ## Phase 3 — Post-deploy verification
 
-```bash
-bash scripts/verify-contract.sh --network mainnet --id <CONTRACT_ID>
-```
-
-Manual checks:
+There is **no** `scripts/verify-contract.sh`. Verify with the health APIs and admin reads:
 
 ```bash
-soroban contract invoke --id <CONTRACT_ID> --network mainnet -- health_check
-# Expected: healthy / is_healthy true (per contract ABI)
-
+soroban contract invoke --id <CONTRACT_ID> --network mainnet -- contract_health_check
 soroban contract invoke --id <CONTRACT_ID> --network mainnet -- get_protocol_stats
-# Expected: readable stats; no panic
-
 soroban contract invoke --id <CONTRACT_ID> --network mainnet -- get_schema_version
-# Expected: version matching release notes
+soroban contract invoke --id <CONTRACT_ID> --network mainnet -- get_fee_bounds
+soroban contract invoke --id <CONTRACT_ID> --network mainnet -- get_global_volume_cap
+
+cd scripts
+CONTRACT_ID=<CONTRACT_ID> NETWORK=mainnet npx tsx health-check.ts
 ```
 
-- [ ] Health check passes
+- [ ] Health check passes (`is_healthy` true; script exit 0)
 - [ ] Token and admin configured (non-empty)
 - [ ] Schema version matches release
-- [ ] **First-subscriber smoke test** (small amount)
+- [ ] Fee bounds and volume cap match the approved policy
+- [ ] **First-subscriber smoke test** (small amount, still after audit approval)
   1. Approve SAC allowance to the contract
   2. `subscribe` with a short-but-valid interval
   3. Trigger `charge` after interval (or keeper page)
   4. Confirm token balances / events
 - [ ] **Monitoring live**
-  - [ ] Keeper metrics + balance alerts ([`KEEPER.md`](KEEPER.md))
+  - [ ] Keeper + indexer + metrics readiness ([`scripts/README.md`](../scripts/README.md), [`KEEPER.md`](KEEPER.md))
   - [ ] RPC error-rate alerts
   - [ ] Pause / anomaly alerts for ops
 
@@ -156,7 +347,7 @@ soroban contract invoke --id <CONTRACT_ID> --network mainnet -- get_schema_versi
 
 ### Frontend / clients
 
-Update production env (example):
+Update production env (example — placeholders only):
 
 ```bash
 VITE_CONTRACT_ID=<MAINNET_CONTRACT_ID>
@@ -185,13 +376,53 @@ VITE_NETWORK_PASSPHRASE=Public Global Stellar Network ; September 2015
 
 ---
 
-## Rollback (emergency)
+## Rollback / upgrade
 
-FlowPay does not auto-rollback. If a critical issue appears:
+FlowPay does **not** auto-rollback. Production WASM replacement is the two-step admin flow in [`contract/src/upgrade.rs`](../contract/src/upgrade.rs):
+
+1. `propose_upgrade(new_wasm_hash)` — admin; stores `PendingUpgrade` in temporary storage (TTL 17,280 ledgers).
+2. Independently verify the pending hash (`get_pending_upgrade`) against a reproducible build.
+3. `commit_upgrade()` — admin; calls `update_current_contract_wasm`. Panics `NoPendingProposal` (23) if nothing is pending.
+4. Optional: `cancel_pending_upgrade()` — admin; drops the pending hash without swapping WASM.
+
+CLI (also in [`architecture/two-step-auth.md`](architecture/two-step-auth.md)):
+
+```bash
+soroban contract invoke --id <CONTRACT_ID> --source <ADMIN_KEY> --network mainnet -- \
+  propose_upgrade --new_wasm_hash <WASM_HASH>
+
+soroban contract invoke --id <CONTRACT_ID> --source <ADMIN_KEY> --network mainnet -- \
+  get_pending_upgrade
+
+soroban contract invoke --id <CONTRACT_ID> --source <ADMIN_KEY> --network mainnet -- \
+  commit_upgrade
+```
+
+The single-step `upgrade` entrypoint exists **only under `#[cfg(test)]`**. Do not treat [`DEPLOYMENT.md` Rollback Procedure](DEPLOYMENT.md#rollback-procedure) `upgrade <PREVIOUS_WASM_HASH>` as the production ABI.
+
+**Emergency recovery:**
 
 1. Admin: `pause_contract()` immediately.
-2. Follow [`DEPLOYMENT.md` Rollback Procedure](DEPLOYMENT.md#rollback-procedure) to restore a prior WASM hash if required.
-3. Re-run `verify-contract.sh` and keeper health checks before `unpause_contract()`.
+2. Restore a prior WASM via `propose_upgrade` / `commit_upgrade` (previous hash from the `upgraded` event or your release notes).
+3. Re-run `contract_health_check` and `scripts/health-check.ts` before `unpause_contract()`.
+
+Further recovery guidance: [`DEPLOYMENT.md`](DEPLOYMENT.md#rollback-procedure) (storage caveat: newer keys remain on-chain), [`ERROR-CODES.md`](ERROR-CODES.md), [`operations/keeper_runbook.md`](operations/keeper_runbook.md).
+
+---
+
+## Final pre-deposit checklist
+
+Do not deposit or route real Mainnet funds until every item is checked.
+
+- [ ] **Audit approval** — independent audit complete; remediations merged; report published ([`SECURITY.md`](../SECURITY.md))
+- [ ] **Correct network** — CLI `--network mainnet`, passphrase `Public Global Stellar Network ; September 2015`, Mainnet RPC, Mainnet SAC, Mainnet contract ID (no `ALLOW_MAINNET` flag exists; confirm manually)
+- [ ] **Fee bounds** — `get_fee_bounds` matches policy; current `get_fee` is inside bounds
+- [ ] **Volume cap** — `get_global_volume_cap` / `get_global_volume_window` recorded; operators understand compile-time enforcement of `GLOBAL_MAX_VOLUME_PER_HOUR`
+- [ ] **Contract health** — `contract_health_check` `is_healthy`; `scripts/health-check.ts` exit 0; not paused; token + admin set
+- [ ] **Configuration / snapshot verification** — schema version matches release; subscription snapshot retained if migrating or upgrading
+- [ ] **Upgrade safety checks** — `pre-upgrade-check` if a WASM swap is planned; propose/commit understood; no assumption of automatic rollback
+- [ ] **Mainnet authorization controls** — admin/deployer keys as planned; deployer secret not reused as long-term admin; config.json not left on testnet values
+- [ ] **Monitoring / keeper / indexer readiness** — keeper funded and running; indexer `events.db` persistence planned; metrics/Grafana optional but RPC and pause alerts live ([`scripts/README.md`](../scripts/README.md))
 
 ---
 
@@ -199,5 +430,9 @@ FlowPay does not auto-rollback. If a critical issue appears:
 
 - Testnet & general deploy: [`docs/DEPLOYMENT.md`](DEPLOYMENT.md)
 - Audit preparation: [`docs/security/audit-preparation.md`](security/audit-preparation.md)
+- Repository security policy: [`SECURITY.md`](../SECURITY.md)
+- Two-step upgrade: [`docs/architecture/two-step-auth.md`](architecture/two-step-auth.md)
+- Contract API: [`docs/API.md`](API.md)
 - Keeper operations: [`docs/KEEPER.md`](KEEPER.md)
+- Scripts ops (keeper / indexer / metrics / Compose): [`scripts/README.md`](../scripts/README.md)
 - Error recovery: [`docs/ERROR-CODES.md`](ERROR-CODES.md)

--- a/docs/REFERRAL.md
+++ b/docs/REFERRAL.md
@@ -1,150 +1,16 @@
 # Referral System Guide
 
-This guide explains how the PayFlow referral tracking system works and how to use it to build referral reward programs.
+This document has been retired in favor of the canonical guide:
 
-For the full architecture, fee/payout mechanics, referral link workflows, and TypeScript integration examples, see **[`REFERRALS.md`](./REFERRALS.md)** (Referral System Architecture and Integration).
+**[`REFERRALS.md`](./REFERRALS.md)** — Referral System Architecture and Integration
 
----
+Use that document for:
 
-## Table of Contents
+- Data model (`DataKey::Referral`, `Subscription.referrer`)
+- Subscribe authentication (`user.require_auth()`)
+- Self-referral (`ContractError::SelfReferral`, code `11`)
+- The `referred` event
+- Frontend (`ReferralPanel.tsx`, `SubscribeForm.tsx`)
+- Operational queries (no dedicated referral scripts)
 
-- [How Referral Tracking Works](#how-referral-tracking-works)
-- [Subscribing with a Referrer](#subscribing-with-a-referrer)
-- [Reading Referrer Data](#reading-referrer-data)
-- [Referred Event](#referred-event)
-- [Building a Referral Program](#building-a-referral-program)
-- [CLI Examples](#cli-examples)
-
----
-
-## How Referral Tracking Works
-
-PayFlow includes a simple, built-in referral tracking system:
-
-- Stores a referrer address for each subscriber
-- Emits an event when a referred user subscribes
-- Prevents self-referrals
-- Allows updating or clearing the referrer when re-subscribing
-
-Referral data is stored in persistent storage under `DataKey::Referral(user_address)`.
-
----
-
-## Subscribing with a Referrer
-
-To track referrals, pass the referrer address in the `referrer` parameter when calling `subscribe()`.
-
-### Key Points:
-
-- `referrer` is optional (can be `null`)
-- If provided, the referrer cannot be the same as the user (self-referrals are not allowed)
-- If a user re-subscribes with a new referrer, it replaces the old one
-- If a user re-subscribes with `referrer: null`, it clears the stored referrer
-
----
-
-## Reading Referrer Data
-
-Use the `get_referrer()` function to read the referrer for any user:
-
-```rust
-pub fn get_referrer(env: Env, user: Address) -> Option<Address>
-```
-
-This returns:
-
-- `Some(referrer_address)` if a referrer was recorded
-- `None` if no referrer was recorded (or it was cleared)
-
----
-
-## Referred Event
-
-When a user subscribes with a referrer, PayFlow emits a `referred` event:
-
-### Event Details:
-
-- **Event Name**: `referred`
-- **Topic Keys**: `["referred", user_address]`
-- **Payload Schema**: `referrer: Address`
-- **JSON Example**:
-  ```json
-  {
-    "topic": ["referred", "GNEW...USER"],
-    "data": "GREF...ERRER"
-  }
-  ```
-
----
-
-## Building a Referral Program
-
-PayFlow's referral tracking is a building block - you can build your own custom referral reward system on top of it. Here are some ideas:
-
-### Example 1: One-Time Signup Bonus
-
-1. Listen for `referred` events
-2. When a new user subscribes with a referrer, send a bonus token to the referrer
-3. Optional: Require the new user to make their first payment before rewarding the referrer
-
-### Example 2: Recurring Commission
-
-1. Listen for `charged` events
-2. For each charge, check if the user has a referrer using `get_referrer()`
-3. If they do, send a percentage of the charged amount to the referrer as commission
-
-### Example 3: Tiered Rewards
-
-- Track how many referrals each referrer has made
-- Give higher commission rates for referrers with more referrals
-
----
-
-## CLI Examples
-
-### Subscribing with a Referrer
-
-```bash
-soroban contract invoke \
-  --id PAYFLOW_CONTRACT_ADDRESS \
-  --source user \
-  --network testnet \
-  -- subscribe \
-  --user USER_ADDRESS \
-  --merchant MERCHANT_ADDRESS \
-  --amount 50000000 \
-  --interval 2592000 \
-  --token TOKEN_ADDRESS \
-  --trial-period 0 \
-  --referrer REFERRER_ADDRESS
-```
-
-### Reading a Referrer
-
-```bash
-soroban contract invoke \
-  --id PAYFLOW_CONTRACT_ADDRESS \
-  --source any \
-  --network testnet \
-  -- get_referrer \
-  --user USER_ADDRESS
-```
-
-### Clearing a Referrer
-
-To clear a referrer for a user, re-subscribe with `--referrer null`:
-
-```bash
-soroban contract invoke \
-  --id PAYFLOW_CONTRACT_ADDRESS \
-  --source user \
-  --network testnet \
-  -- subscribe \
-  --user USER_ADDRESS \
-  --merchant MERCHANT_ADDRESS \
-  --amount 50000000 \
-  --interval 2592000 \
-  --token TOKEN_ADDRESS \
-  --trial-period 0 \
-  --referrer null
-```
+Do not treat this stub as a second source of truth.

--- a/docs/REFERRALS.md
+++ b/docs/REFERRALS.md
@@ -1,27 +1,54 @@
 # Referral System Architecture and Integration
 
-This document is the canonical reference for PayFlow's referral tracking architecture, fee/payout mechanics for integrators, referral link and code workflows, on-chain APIs, and frontend TypeScript integration.
+This document is the **canonical** referral guide for PayFlow: data model, subscribe authentication, self-referral, events, frontend (`ReferralPanel`), and operations.
 
-A shorter usage overview also lives in [`REFERRAL.md`](./REFERRAL.md). For storage TTL details see [`architecture/storage_and_ttl.md`](./architecture/storage_and_ttl.md). For the full function catalog see [`API.md`](./API.md).
+[`REFERRAL.md`](./REFERRAL.md) is a compatibility stub that points here. For storage TTL details see [`architecture/storage_and_ttl.md`](./architecture/storage_and_ttl.md). For the full function catalog see [`API.md`](./API.md). Errors: [`ERROR-CODES.md`](./ERROR-CODES.md). Event schema: [`EVENTS.md`](./EVENTS.md). Architecture: [`ARCHITECTURE.md`](./ARCHITECTURE.md).
 
 ---
 
 ## Table of Contents
 
+- [Overview](#overview)
 - [Design Summary](#design-summary)
 - [Architecture Overview](#architecture-overview)
 - [On-Chain Data Model](#on-chain-data-model)
 - [Lifecycle and State Transitions](#lifecycle-and-state-transitions)
+- [Subscribe authentication](#subscribe-authentication)
+- [Self-referral](#self-referral)
+- [Referred event](#referred-event)
 - [Integration Points](#integration-points)
 - [Fee Distribution and Payout Mechanics](#fee-distribution-and-payout-mechanics)
 - [Generating and Tracking Referral Links and Codes](#generating-and-tracking-referral-links-and-codes)
 - [API Reference](#api-reference)
 - [CLI Examples](#cli-examples)
+- [Frontend: ReferralPanel](#frontend-referralpanel)
 - [Frontend Integration (TypeScript)](#frontend-integration-typescript)
+- [Scripts and operations](#scripts-and-operations)
 - [Indexer and Analytics Patterns](#indexer-and-analytics-patterns)
 - [Error Handling](#error-handling)
 - [Security Considerations](#security-considerations)
 - [Related Source Files](#related-source-files)
+
+---
+
+## Overview
+
+Referrals are **on-chain attribution**, not an on-chain reward vault. A subscriber may pass an optional referrer address when they subscribe. The contract stores that relationship and emits a `referred` event; payouts (bonuses, commissions) are built by integrators off-chain.
+
+| Where state lives | What |
+| --- | --- |
+| Persistent `DataKey::Referral(subscriber)` | Referrer `Address` (`contract/src/referral.rs`) |
+| `Subscription.referrer: Option<Address>` | Snapshot written at subscribe (`contract/src/lib.rs`) |
+
+| Component | Interaction |
+| --- | --- |
+| Contract `subscribe` / `subscribe_with_metadata` | User signs; optional `referrer` is stored |
+| Contract `get_referrer` / `get_referral` | Public reads of the referral key |
+| Indexer / RPC consumers | Index topic `referred` |
+| Frontend `ReferralPanel` | Share link `/?ref=<ADDRESS>`, referred-count display, self-referral warning |
+| Frontend `SubscribeForm` | Optional referrer text field passed into `buildSubscribeTx` |
+
+This is an attribution layer only. Protocol fees (`fee.rs`) do not pay referrers.
 
 ---
 
@@ -143,6 +170,66 @@ Rules enforced by the running contract (`contract/src/referral.rs` + `subscribe_
 5. **Cancel clears referral storage.** `cancel_inner` calls `referral::remove_referral`. The cancelled `Subscription` record may still show a historical `referrer` field until the user resubscribes; `get_referrer` returns `None` after cancel.
 
 > **Note:** Older lifecycle notes that describe referrals as “immutable after first write” or “surviving cancel” do not match the current implementation. Treat this document and `referral.rs` as authoritative.
+
+---
+
+## Subscribe authentication
+
+Referral data enters the protocol **only** through `subscribe` / `subscribe_with_metadata` → `subscribe_inner` (`contract/src/lib.rs`).
+
+1. **Signer:** `user.require_auth()`. The subscriber must sign. The **referrer does not sign**.
+2. **Parameter:** last optional argument `referrer: Option<Address>` on `subscribe`; `subscribe_with_metadata` takes the same plus `label`.
+3. **Other subscribe checks** still apply (whitelist, frozen merchant, contract pause, amount, interval, token, allowance) before `referral::store_referral`.
+4. **Write:** `store_referral` persists `DataKey::Referral(user)` and `subscribe_inner` copies `referrer` onto `Subscription.referrer`.
+5. **Reads:** `get_referrer` and alias `get_referral` require **no auth**.
+
+There is no separate “set referrer” entrypoint. Changing attribution means a later subscribe (same user auth) with a new address or `None`.
+
+CLI and TypeScript examples: [CLI Examples](#cli-examples), [Frontend Integration (TypeScript)](#frontend-integration-typescript). Contract catalog: [`API.md`](./API.md#subscribe).
+
+---
+
+## Self-referral
+
+The contract **rejects** a referrer that equals the subscriber.
+
+```rust
+// contract/src/referral.rs — store_referral
+if r == user {
+    env.panic_with_error(ContractError::SelfReferral);
+}
+```
+
+| | |
+| --- | --- |
+| Symbol | `ContractError::SelfReferral` |
+| Code | **11** |
+| When | `subscribe` / `subscribe_with_metadata` when `referrer == user` |
+| Recovery | Omit the referrer or pass a different address; resubmit |
+
+Playbook: [`ERROR-CODES.md` — 11 `SelfReferral`](./ERROR-CODES.md#11--selfreferral).
+
+The dashboard [`ReferralPanel`](#frontend-referralpanel) warns when `?ref=` matches the connected wallet. That UI copy currently says the referral “will be ignored”; **on-chain the call panics** with `SelfReferral`. Do not treat self-referral as a silent no-op.
+
+---
+
+## Referred event
+
+Emitted from `events::publish_referred` when `store_referral` writes a `Some` referrer (`contract/src/events.rs`).
+
+| Field | Value |
+| --- | --- |
+| Name | `referred` |
+| Topics | `("referred", user)` — `user` is the **referee** (subscriber) |
+| Payload | `referrer: Address` |
+
+Full schema and JSON example: [`EVENTS.md` — referred](./EVENTS.md#referred).
+
+**Indexer / consumer use:**
+
+- Confirm on-chain attribution when a subscribe includes a referrer.
+- Topic `[1]` is the new subscriber, not the referrer. Counting “users I referred” requires reading the **payload** (or a store keyed by referrer), not filtering topic `[1]` as the referrer.
+- Pair with `charged` for paid-conversion rewards ([Fee Distribution](#fee-distribution-and-payout-mechanics)).
 
 ---
 
@@ -380,6 +467,8 @@ Auth: none.
 
 Returns: `Some(referrer)` if `DataKey::Referral(user)` exists; `None` otherwise (never set, cleared on resubscribe, or removed on cancel).
 
+`get_referral(env, user)` is a public alias of the same read (`lib.rs`).
+
 ### Internal helpers (not public entry points)
 
 | Function          | Module        | Behavior                                        |
@@ -480,9 +569,25 @@ soroban contract invoke \
 
 ---
 
+## Frontend: ReferralPanel
+
+Source: [`frontend/src/components/ReferralPanel.tsx`](../frontend/src/components/ReferralPanel.tsx). Tests: `frontend/src/__tests__/ReferralPanel.test.tsx`. Mounted from `Dashboard.tsx` as `<ReferralPanel publicKey={userKey} />`.
+
+| Surface | Behavior |
+| --- | --- |
+| Referral code | Connected wallet public key (the shareable identifier) |
+| Share link | `buildReferralUrl` → `{VITE_APP_BASE_URL or https://app.payflow.io}/?ref=<ADDRESS>` |
+| Copy | Clipboard buttons for code and full URL (`useClipboard`) |
+| Users referred | `fetchEvents("referred", publicKey)` from `frontend/src/stellar.ts` |
+| Self-referral alert | `getReferrerFromSearch(window.location.search) === publicKey` |
+
+**Subscribe input is not on this panel.** [`frontend/src/components/SubscribeForm.tsx`](../frontend/src/components/SubscribeForm.tsx) has an optional “Referrer (optional)” field; on submit it passes `referrer.trim() || null` into `buildSubscribeTx`. The form does **not** auto-fill from `?ref=` (the helper `getReferrerFromSearch` is used on the panel for the warning only). Integrators who want `?ref=` → subscribe should wire that themselves (see snippets below).
+
+---
+
 ## Frontend Integration (TypeScript)
 
-The in-repo helper `buildSubscribeTx` in `frontend/src/stellar.ts` already accepts `referrer: string | null`. The default subscribe form currently passes `null`; the snippets below show how to wire referral links end-to-end.
+The in-repo helper `buildSubscribeTx` in `frontend/src/stellar.ts` accepts `referrer: string | null`. `SubscribeForm` exposes a manual referrer field. The snippets below show an end-to-end `?ref=` → resolve → subscribe pattern (off-chain codes still need a backend lookup).
 
 ### Resolve URL code and subscribe
 
@@ -665,6 +770,23 @@ Prefer constructing topic filters with `xdr.ScVal.scvSymbol("referred").toXDR("b
 
 ---
 
+## Scripts and operations
+
+There are **no** dedicated referral scripts under `scripts/` (no `referral` / `get_referrer` / `referred` usage in that tree).
+
+Useful operational workflows using existing tools:
+
+| Goal | How |
+| --- | --- |
+| Read referrer | `soroban contract invoke ... -- get_referrer --user <USER>` (or `get_referral`) |
+| Confirm attribution | Index `referred` via [`indexer.ts`](../scripts/indexer.ts) / [`query-events.ts`](../scripts/query-events.ts) `--type referred` |
+| Backfill events | [`EVENT-DRIVEN-GUIDE.md`](./EVENT-DRIVEN-GUIDE.md) + [`replay-events.ts`](../scripts/replay-events.ts) |
+| Subscribe with referrer | CLI examples above (user must sign) |
+
+Do not invent a keeper or payout daemon in this repo; commission settlement is integrator-owned.
+
+---
+
 ## Indexer and Analytics Patterns
 
 Recommended off-chain tables:
@@ -726,9 +848,12 @@ See [`ERROR-CODES.md`](./ERROR-CODES.md) for the full catalog.
 | [`contract/src/errors.rs`](../contract/src/errors.rs)     | `SelfReferral = 11`                                                       |
 | [`contract/src/fee.rs`](../contract/src/fee.rs)           | Protocol fee split (not referrer-aware)                                   |
 | [`frontend/src/stellar.ts`](../frontend/src/stellar.ts)   | `buildSubscribeTx(..., referrer, ...)`                                    |
-| [`docs/REFERRAL.md`](./REFERRAL.md)                       | Short usage guide                                                         |
+| [`frontend/src/components/ReferralPanel.tsx`](../frontend/src/components/ReferralPanel.tsx) | Share link, referred count, self-referral warning |
+| [`frontend/src/components/SubscribeForm.tsx`](../frontend/src/components/SubscribeForm.tsx) | Optional referrer field on subscribe |
+| [`docs/REFERRAL.md`](./REFERRAL.md)                       | Compatibility stub → this file                                            |
 | [`docs/EVENTS.md`](./EVENTS.md)                           | `referred` event schema                                                   |
 | [`docs/API.md`](./API.md)                                 | Full API reference                                                        |
+| [`docs/ERROR-CODES.md`](./ERROR-CODES.md)                 | `SelfReferral` (11)                                                       |
 
 ---
 

--- a/docs/STRUCTURE.md
+++ b/docs/STRUCTURE.md
@@ -149,8 +149,8 @@ docs/
 ├── DEPLOYMENT.md     # Build, deploy, keeper setup
 ├── TESTING.md        # How to run and write tests
 ├── API.md            # Full contract function reference
-├── REFERRALS.md      # Referral architecture, payouts, and integration
-├── REFERRAL.md       # Short referral usage guide
+├── REFERRALS.md      # Canonical referral architecture, payouts, and integration
+├── REFERRAL.md       # Compatibility stub → REFERRALS.md
 ├── STRUCTURE.md      # This file
 └── SECURITY.md       # Security model and disclosure policy
 ├── ARCHITECTURE.md        # System design, data model, storage strategy

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -4,6 +4,22 @@ Operational scripts for the FlowPay recurring-billing contract. All scripts are
 written in TypeScript and executed with [tsx](https://github.com/privatenumber/tsx)
 (no compile step needed for local use).
 
+## Scope of this guide
+
+This README's **operations guide** covers four areas only:
+
+- **Keeper** (`keeper.ts`)
+- **Indexer** (`indexer.ts`)
+- **Metrics server** (`metrics-server.ts`) plus the Grafana dashboard JSON
+- **Docker Compose** (`docker-compose.yml` / `Dockerfile`)
+
+It does **not** document every other script in this directory (allowance alerts,
+analytics, deploy pipeline, snapshots, and so on). Those remain listed under
+[Other scripts](#other-scripts) for discovery only.
+
+DLQ / replay and RPC failover already have dedicated docs; this guide links them
+instead of duplicating them. See [DLQ, replay, and failover](#dlq-replay-and-failover).
+
 ## Prerequisites
 
 - Node.js 20+
@@ -16,20 +32,410 @@ npm install
 
 ---
 
-## Scripts
+## Testnet quick start
 
-| Script                         | Purpose                                                   |
-| ------------------------------ | --------------------------------------------------------- |
-| `keeper.ts`                    | Autonomous keeper — calls `batch_charge` on a schedule    |
-| `watch-events.ts`              | Real-time contract event monitor                          |
-| `check-allowances.ts`          | Audit subscriber token allowances                         |
-| `alert-expiring-allowances.ts` | Alert on allowances expiring within a configurable window |
-| `indexer.ts`                   | Persist contract events to SQLite                         |
-| `query-events.ts`              | Query the SQLite event database                           |
-| `health-check.ts`              | Contract responsiveness check                             |
-| `subscription-snapshot.ts`     | Snapshot all subscription states                          |
-| `daily-revenue-summary.ts`     | Daily revenue report                                      |
-| `export-merchant-report.ts`    | Per-merchant activity report                              |
+Copy-pastable **testnet** commands. Use placeholder keys only; do not put Mainnet
+secrets in this file or in committed `.env` files.
+
+```bash
+cd scripts
+npm install
+cp .env.example .env
+# edit .env — set CONTRACT_ID (C…) and KEEPER_SECRET (S… testnet account)
+
+# Keeper (package script)
+npm run keeper
+# equivalent: tsx keeper.ts
+
+# Indexer (package script)
+npm run indexer
+# equivalent: CONTRACT_ID=C... tsx indexer.ts
+
+# Metrics exporter (no package.json script — run directly)
+tsx metrics-server.ts
+
+# Docker Compose (keeper service only)
+docker compose up -d
+docker compose logs -f keeper
+docker compose down
+```
+
+`scripts/package.json` defines `keeper` → `tsx keeper.ts` and `indexer` →
+`tsx indexer.ts`. There is no npm script for `metrics-server.ts`. Root
+`package.json` does not wrap these commands.
+
+---
+
+## Keeper
+
+### Purpose
+
+The keeper is an off-chain loop that pages through subscriptions and invokes
+`batch_charge` so recurring charges run without a user in the loop. Soroban has
+no native scheduler; keepers supply that cadence.
+
+The file header describes paging `batch_charge(offset, limit)` then sleeping
+until the next cycle. A second block in the same file also documents optimized
+batches, `DRY_RUN`, and a `--once` flag.
+
+### Prerequisites
+
+- Testnet (or other) FlowPay **contract ID**
+- A funded Stellar account whose **secret key** can pay transaction fees
+- Reachable Soroban RPC
+- Node 20+ and dependencies from `npm install` in `scripts/`
+
+### Required environment variables
+
+| Variable | Required | Notes |
+| --- | --- | --- |
+| `CONTRACT_ID` | yes | Empty value exits 1 |
+| `KEEPER_SECRET` | yes (live signing) | Secret key `S…`; first config block always requires it |
+
+`scripts/.env.example` is the Compose / Docker contract: `CONTRACT_ID` and
+`KEEPER_SECRET` at minimum.
+
+### Testnet startup
+
+```bash
+cd scripts
+CONTRACT_ID=C... \
+KEEPER_SECRET=S... \
+tsx keeper.ts
+```
+
+Or `npm run keeper` after exporting the same variables (or loading `.env` in
+your shell). Docker: see [Docker Compose](#docker-compose).
+
+### Expected health / behavior
+
+- Local process: logs a startup line such as `"FlowPay Keeper starting"` (JSON
+  fields include contract, keeper public key, RPC, `charge_interval_ms`,
+  `page_size`, `max_retries` in the first logger). SIGINT/SIGTERM finish the
+  current cycle then exit 0.
+- Docker image `HEALTHCHECK`: `wget` POST `getHealth` to
+  `${RPC_URL:-https://soroban-testnet.stellar.org}` and grep
+  `"status":"healthy"` (60 s interval). This probes **RPC**, not the keeper
+  loop itself.
+- Compose: `restart: unless-stopped`, `stop_grace_period: 60s`.
+
+Smoke after Compose:
+
+```bash
+docker compose logs keeper | grep '"msg":"FlowPay Keeper starting"'
+```
+
+### Logs and metrics
+
+- First logger: JSON lines on stdout/stderr (`LOG_LEVEL`).
+- Second logger (same file): `[DRY-RUN]` / `[LIVE]` prefixes; `--once` then
+  sleep `INTERVAL_SECONDS`.
+- Prometheus metrics are implemented in `metrics-server.ts`. **`keeper.ts` does
+  not import that module**, so running the keeper alone does not expose
+  `/metrics`. Run the metrics server separately if you need scrape targets.
+
+### Additional variables the file reads
+
+`keeper.ts` currently contains two overlapping configuration blocks. Docker and
+`.env.example` follow the first. The second also reads:
+
+| Variable | Default in that block | Role |
+| --- | --- | --- |
+| `DRY_RUN` | `"true"` (boolean if equal to `"true"`) | Simulation mode; secret not required when true |
+| `KEEPER_PUBLIC_KEY` | `""` | Required by `validateEnv` in that block |
+| `BATCH_SIZE` | `50` (clamped 1–50) | Page size in that block |
+| `INTERVAL_SECONDS` | `3600` (min 1) | Loop interval in that block |
+
+Set the variables that match how you start the process. Prefer the
+`.env.example` names for Compose.
+
+---
+
+## Indexer
+
+### Purpose
+
+Polls Soroban RPC `getEvents` for the configured contract and upserts events
+into a local SQLite database. On restart it resumes from `meta.last_ledger`
+so the same events are not re-fetched as duplicates (upsert key
+`tx_hash:event_name`).
+
+### Prerequisites
+
+- `CONTRACT_ID`
+- Reachable Soroban RPC
+- Write permission for the SQLite path (`DATA_DIR` / `DB_FILE`)
+- Node 20+ (uses `node:sqlite` `DatabaseSync`)
+
+### Environment variables
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `CONTRACT_ID` | (required) | Contract to filter |
+| `RPC_URL` | `https://soroban-testnet.stellar.org` | Soroban RPC |
+| `POLL_INTERVAL_MS` | `10000` | Poll interval |
+| `LOG_LEVEL` | `info` | `debug` \| `info` \| `error` |
+| `DATA_DIR` | `data` | Directory for the DB file |
+| `DB_FILE` | `resolve(DATA_DIR, "events.db")` | Full path override |
+| `START_LEDGER` | unset → latest ledger | First-run start when no `last_ledger` |
+
+The indexer header mentions `NETWORK_PASSPHRASE`; the implementation does **not**
+read that env var.
+
+### Startup
+
+```bash
+cd scripts
+CONTRACT_ID=C... tsx indexer.ts
+# or
+npm run indexer
+```
+
+### Persistence and `events.db`
+
+See [events.db persistence](#eventsdb-persistence) below. Schema: tables `meta`
+and `events`; WAL mode; `mkdirSync` on the DB directory. Poll limit 200 events
+per RPC call. Graceful SIGINT/SIGTERM (exit 0).
+
+### Expected health / behavior
+
+- Missing `CONTRACT_ID` → stderr + exit 1
+- First run: “First run” path, start ledger = `START_LEDGER` if `> 0`, else
+  `getLatestLedger().sequence`
+- Subsequent runs: resume from stored `last_ledger`
+- Fatal DB or config errors → exit 1
+
+### Query stored events
+
+`query-events.ts` is a companion, not part of the four-area ops stack beyond
+reading the same DB:
+
+```bash
+tsx query-events.ts --recent --pretty
+tsx query-events.ts --address GXYZ... --pretty
+tsx query-events.ts --type charged --pretty
+tsx query-events.ts --ledger 500000 --to 510000
+```
+
+---
+
+## Metrics server
+
+### Purpose
+
+Standalone Prometheus exporter (`prom-client`) for keeper-oriented metrics.
+Starts an HTTP server and serves Prometheus text on **every path** (documented
+scrape URL is `/metrics`).
+
+### Startup
+
+There is **no** `package.json` script. From `scripts/`:
+
+```bash
+tsx metrics-server.ts
+```
+
+From repo root (as the file header states):
+
+```bash
+tsx scripts/metrics-server.ts
+```
+
+### Environment
+
+| Variable | Default | Actually read? |
+| --- | --- | --- |
+| `METRICS_PORT` | `9090` | **Yes** — listen port |
+| `CONTRACT_ID` | — | Header only; **not** read |
+| `RPC_URL` | — | Header only; **not** read |
+| `NETWORK_PASSPHRASE` | — | Header only; **not** read |
+
+### Endpoint / port
+
+- Listen: `METRICS_PORT` (default **9090**)
+- Content-Type: `text/plain; version=0.0.4`
+- If the port is in use: logs that the keeper would continue without metrics
+  and does not crash the process
+
+Exposed series (plus Node default metrics):
+
+- `keeper_charges_total{status}`
+- `keeper_batch_duration_seconds`
+- `keeper_rpc_errors_total`
+- `keeper_active_subscribers`
+- `keeper_batch_size`
+- `keeper_cycles_total`
+
+`startMetricsServer()` is exportable for embedding, but **nothing else in
+`scripts/` currently imports this module**. Compose does not run it. Scrapes
+stay empty unless a process records into this registry.
+
+### Grafana
+
+Dashboard JSON: [`grafana-dashboard.json`](grafana-dashboard.json)
+
+| Property | Value |
+| --- | --- |
+| Title | PayFlow Keeper |
+| uid | `payflow-keeper` |
+| Tags | `payflow`, `keeper`, `prometheus` |
+| Datasource template | `DS_PROMETHEUS` (Prometheus) |
+| Refresh | 10s, timezone `utc`, default range `now-6h` |
+
+Import the JSON into Grafana and select a Prometheus datasource that scrapes
+the metrics server. This repository does **not** ship a Grafana or Prometheus
+Compose service.
+
+---
+
+## Docker Compose
+
+### Services and topology
+
+`docker-compose.yml` defines **one** service:
+
+```text
+.host .env
+    └── keeper (container_name: payflow-keeper, image: payflow-keeper:latest)
+            ├── env_file: .env
+            ├── volume: keeper-data → /app/data
+            ├── restart: unless-stopped
+            └── stop_grace_period: 60s
+```
+
+There is **no** `depends_on`, **no** `ports:` mapping, and **no** indexer,
+metrics-server, Prometheus, or Grafana service.
+
+### Ports
+
+None published. The keeper does not listen for HTTP. Metrics, if run on the
+host, use `METRICS_PORT` (default 9090) outside Compose.
+
+### Environment
+
+Compose loads `scripts/.env` via `env_file`. Copy from `.env.example`. The
+`.env` file is **not** baked into the image.
+
+### Persistent volumes
+
+Named volume `keeper-data` mounted at `/app/data`. The Compose comment says
+this is for the SQLite DB written by `indexer.ts`. The Compose file **does not
+start the indexer**, so `/app/data` stays empty unless you run indexer yourself
+with `DATA_DIR=/app/data` (or bind-mount the same volume).
+
+### Startup / shutdown
+
+```bash
+cd scripts
+cp .env.example .env   # then edit CONTRACT_ID and KEEPER_SECRET
+docker compose up -d
+docker compose logs -f keeper
+docker compose down
+```
+
+Build without Compose:
+
+```bash
+cd scripts
+docker build -t payflow-keeper .
+docker run --rm --env-file .env --name payflow-keeper payflow-keeper
+```
+
+### Dockerfile
+
+Two stages (`scripts/Dockerfile`):
+
+1. **builder** (`node:20-alpine`): `npm ci --frozen-lockfile`, compiles
+   `keeper.ts` via `npm run build` (`tsconfig.build.json` includes **only**
+   `keeper.ts`) → `/build/dist/keeper.js`
+2. **runtime**: production `npm ci --omit=dev`, `USER node`, `CMD`
+   `["node", "dist/keeper.js"]`, `NODE_ENV=production`,
+   `NODE_OPTIONS=--unhandled-rejections=throw`
+
+`HEALTH_CHECK_URL` is mentioned in a comment; the `HEALTHCHECK` command uses
+`RPC_URL` only.
+
+| Property | Value |
+| --- | --- |
+| Base image | `node:20-alpine` |
+| Run user | `node` (non-root) |
+| Entrypoint / CMD | `node dist/keeper.js` |
+| Health check | `wget` → RPC `getHealth` (60 s / timeout 10 s / start 15 s / retries 3) |
+| Restart policy | `unless-stopped` |
+| Log driver | `json-file` (max-size 10m, max-file 5) |
+| Resources (Compose) | limits 0.50 CPU / 256M; reservations 0.05 / 64M |
+
+---
+
+## Environment matrix
+
+Variables actually used by keeper, indexer, metrics-server, Compose, or the
+keeper Dockerfile. Defaults are from source or `.env.example`.
+
+| Variable | Default / example | Used by | Purpose | Notes |
+| --- | --- | --- | --- | --- |
+| `CONTRACT_ID` | empty; `.env.example` blank | keeper, indexer | Deployed contract ID | Required (exit 1 if missing). Metrics header lists it but does not read it. Compose via `.env`. |
+| `KEEPER_SECRET` | empty | keeper | Sign keeper transactions | Required in the primary config block. Testnet `S…` only in examples. |
+| `KEEPER_PUBLIC_KEY` | `""` | keeper (second block) | Source account pubkey | Required by that block's `validateEnv`. Not in `.env.example`. |
+| `DRY_RUN` | `"true"` in second block | keeper (second block) | Simulation vs live | Not in `.env.example`. |
+| `RPC_URL` | `https://soroban-testnet.stellar.org` | keeper, indexer, Dockerfile HEALTHCHECK | Soroban RPC | Compose via `.env`. Metrics header only. |
+| `NETWORK_PASSPHRASE` | `Networks.TESTNET` / `.env.example`: `Test SDF Network ; September 2015` | keeper | Network passphrase | Indexer header only — not read by indexer. |
+| `CHARGE_INTERVAL_MS` | `3600000` | keeper (first block) | Sleep between full cycles | `.env.example` |
+| `PAGE_SIZE` | `100` (capped at 100) | keeper (first block) | Page size for `batch_charge` | `.env.example` |
+| `MAX_RETRIES` | `3` | keeper (first block) | Per-page retries | `.env.example` |
+| `BATCH_SIZE` | `50` (clamped 1–50) | keeper (second block) | Alternate page size | Conflicts in name with `PAGE_SIZE`. |
+| `INTERVAL_SECONDS` | `3600` | keeper (second block) | Alternate loop interval | |
+| `LOG_LEVEL` | `info` | keeper, indexer | Log verbosity | Indexer: `debug` \| `info` \| `error` |
+| `DATA_DIR` | `data` | indexer | SQLite directory | Compose volume is `/app/data` if indexer is run there. Not in `.env.example`. |
+| `DB_FILE` | `DATA_DIR/events.db` | indexer | SQLite path override | Not in `.env.example`. |
+| `POLL_INTERVAL_MS` | `10000` | indexer | Event poll interval | Not in `.env.example`. |
+| `START_LEDGER` | unset → latest | indexer | First-run start ledger | Not in `.env.example`. |
+| `METRICS_PORT` | `9090` | metrics-server | HTTP listen port | Not in `.env.example` or Compose. |
+| `NODE_ENV` | `production` (image) | Docker runtime | Node environment | Set in Dockerfile. |
+| `NODE_OPTIONS` | `--unhandled-rejections=throw` | Docker runtime | Crash on unhandled rejections | Set in Dockerfile. |
+
+Compose itself declares no `environment:` keys; it only loads `.env`.
+
+---
+
+## events.db persistence
+
+| Question | Answer |
+| --- | --- |
+| Where is it stored? | Default `data/events.db` relative to the process cwd (`DATA_DIR` + `events.db`), or `DB_FILE` if set. |
+| Which component uses it? | **`indexer.ts`** (and `query-events.ts` when pointed at the same file). The keeper image/CMD does not write this DB. |
+| Must it survive restarts? | **Yes**, if you need cursor continuity. `meta.last_ledger` lives in the same file. |
+| Docker volume? | Compose mounts named volume `keeper-data` at `/app/data`. That path matches the indexer default directory name `data` only if the process cwd is `/app` **and** you run the indexer with `DATA_DIR=/app/data` (or default `data` from `/app`). Compose does not start the indexer. |
+| If the database is deleted/reset? | A new empty DB is opened and schema is recreated. `last_ledger` is missing, so the indexer takes the first-run path: `START_LEDGER` if set and `> 0`, otherwise the **latest** ledger. Local event history is gone; the indexer does not walk the full chain unless you set `START_LEDGER` (and RPC still has those ledgers). |
+| Backup / replay? | Back up the SQLite file (and WAL) if you need history. Historical backfill is documented in [`docs/EVENT-DRIVEN-GUIDE.md`](../docs/EVENT-DRIVEN-GUIDE.md) via [`replay-events.ts`](replay-events.ts) — that is a separate RPC replay path, not an automatic restore of `events.db`. |
+
+---
+
+## DLQ, replay, and failover
+
+This ops guide does not reproduce those playbooks:
+
+| Topic | Where |
+| --- | --- |
+| Keeper overview + runbook pointer | [`docs/KEEPER.md`](../docs/KEEPER.md) |
+| Dead-letter queue recovery | [`docs/operations/keeper_runbook.md`](../docs/operations/keeper_runbook.md) (section “Dead-Letter Queue Recovery”) |
+| RPC failover (runbook) | Same file, section “RPC Failover Configuration” |
+| TS DLQ replay helper | [`replay-dlq.ts`](replay-dlq.ts) (default `DLQ_FILE=dlq/failed-batches.jsonl`) |
+| Event backfill | [`docs/EVENT-DRIVEN-GUIDE.md`](../docs/EVENT-DRIVEN-GUIDE.md), [`replay-events.ts`](replay-events.ts) |
+| Multi-endpoint RPC helper | [`rpc-client.ts`](rpc-client.ts) (`RPC_URLS`) — **not** imported by the current keeper/indexer entrypoints |
+
+`replay-dlq.ts` states that `keeper.ts` writes the JSONL DLQ. Confirm that path
+against the keeper you actually run before relying on it in production.
+
+---
+
+## Other scripts
+
+Out of scope for this ops-guide revision. Existing helpers include (non-exhaustive):
+`watch-events.ts`, `check-allowances.ts`, `alert-expiring-allowances.ts`,
+`health-check.ts`, `subscription-snapshot.ts`, `daily-revenue-summary.ts`,
+`export-merchant-report.ts`, `pre-upgrade-check.ts`, `snapshot-diff.ts`,
+`deploy-pipeline.ts`, `replay-dlq.ts`, `replay-events.ts`.
 
 ### Daily revenue delivery
 
@@ -44,167 +450,6 @@ WEBHOOK_URL=https://hooks.example.com/payflow \
 Set `SLACK_WEBHOOK_URL` to deliver a Slack Block Kit message. A cached report
 is skipped, including delivery, unless `--force` is provided. Webhook failures
 are logged but do not change the successful report exit status.
-
----
-
-## Keeper
-
-The keeper bot pages through every active subscription and invokes
-`batch_charge(offset, limit)` until all pages are processed, then sleeps until
-the next cycle.
-
-### Run locally
-
-```bash
-CONTRACT_ID=C...  \
-KEEPER_SECRET=S...  \
-tsx keeper.ts
-```
-
-Optional variables (all have defaults):
-
-| Variable             | Default            | Description                                     |
-| -------------------- | ------------------ | ----------------------------------------------- |
-| `RPC_URL`            | testnet RPC        | Soroban RPC endpoint                            |
-| `NETWORK_PASSPHRASE` | testnet passphrase | Stellar network passphrase                      |
-| `CHARGE_INTERVAL_MS` | `3600000` (1 h)    | Sleep between full charge cycles                |
-| `PAGE_SIZE`          | `100`              | Subscriptions per `batch_charge` call (max 100) |
-| `MAX_RETRIES`        | `3`                | Per-page retries before skipping                |
-| `LOG_LEVEL`          | `info`             | `debug` \| `info` \| `warn` \| `error`          |
-
----
-
-## Docker
-
-### 1. Configure environment
-
-Copy the example env file and fill in the required values:
-
-```bash
-cp .env.example .env
-# edit .env — set CONTRACT_ID and KEEPER_SECRET at minimum
-```
-
-The `.env` file is loaded by Docker Compose at runtime and is **never baked
-into the image**.
-
-### 2. Build the image
-
-```bash
-# From the scripts/ directory:
-docker build -t payflow-keeper .
-```
-
-The build uses two stages:
-
-1. **builder** — installs all dependencies and compiles `keeper.ts` → `dist/keeper.js`
-2. **runtime** — copies only `dist/` and production dependencies into a slim
-   `node:20-alpine` image running as the non-root `node` user
-
-### 3. Run with Docker Compose
-
-```bash
-docker compose up -d
-```
-
-To follow logs:
-
-```bash
-docker compose logs -f keeper
-```
-
-To stop:
-
-```bash
-docker compose down
-```
-
-### 4. Run with plain `docker run`
-
-```bash
-docker run --rm \
-  --env-file .env \
-  --name payflow-keeper \
-  payflow-keeper
-```
-
-### 5. Smoke test
-
-After the container starts, check that it logged a successful startup line:
-
-```bash
-docker compose logs keeper | grep '"msg":"FlowPay Keeper starting"'
-```
-
-A healthy keeper emits a JSON log line like:
-
-```json
-{
-  "ts": "2026-01-01T00:00:00.000Z",
-  "level": "info",
-  "msg": "FlowPay Keeper starting",
-  "contract": "C...",
-  "keeper": "G...",
-  "rpc": "https://...",
-  "charge_interval_ms": 3600000,
-  "page_size": 100,
-  "max_retries": 3
-}
-```
-
-### Docker image details
-
-| Property       | Value                                    |
-| -------------- | ---------------------------------------- |
-| Base image     | `node:20-alpine`                         |
-| Run user       | `node` (non-root, UID 1000)              |
-| Entrypoint     | `node dist/keeper.js`                    |
-| Health check   | `wget` → RPC `getHealth` (60 s interval) |
-| Restart policy | `unless-stopped`                         |
-| Log driver     | `json-file` (10 MB × 5 files)            |
-| Graceful stop  | 60 s before SIGKILL                      |
-
----
-
-## Event Indexer
-
-Persists contract events to a local SQLite database (`data/events.db`).
-Resumes from the last indexed ledger on restart.
-
-```bash
-CONTRACT_ID=C... tsx indexer.ts
-```
-
-Optional variables:
-
-| Variable           | Default          | Description               |
-| ------------------ | ---------------- | ------------------------- |
-| `RPC_URL`          | testnet RPC      | Soroban RPC endpoint      |
-| `DATA_DIR`         | `data`           | Directory for `events.db` |
-| `DB_FILE`          | `data/events.db` | Full path override        |
-| `POLL_INTERVAL_MS` | `10000` (10 s)   | Polling interval          |
-| `START_LEDGER`     | latest ledger    | First-run start ledger    |
-| `LOG_LEVEL`        | `info`           | Log verbosity             |
-
-### Query stored events
-
-```bash
-# Most recent 20 events
-tsx query-events.ts --recent --pretty
-
-# All events for a subscriber
-tsx query-events.ts --address GXYZ... --pretty
-
-# Events of a specific type
-tsx query-events.ts --type charged --pretty
-
-# Events in a ledger range
-tsx query-events.ts --ledger 500000 --to 510000
-```
-
----
-
-## Other Scripts
 
 ### check-allowances
 
@@ -230,7 +475,9 @@ Exits with code `1` if any allowances are expiring soon.
 
 ### health-check
 
-Verify the contract is responsive (suitable for cron or Docker `HEALTHCHECK`):
+Shallow contract responsiveness check (`get_schema_version` + `get_active_count`).
+Not a substitute for on-chain `contract_health_check`. See
+[`docs/MAINNET-DEPLOYMENT.md`](../docs/MAINNET-DEPLOYMENT.md#3-health).
 
 ```bash
 CONTRACT_ID=C... tsx health-check.ts
@@ -239,24 +486,8 @@ CONTRACT_ID=C... tsx health-check.ts
 
 ---
 
-## Environment variable reference
+## Related
 
-All scripts read configuration from environment variables. The full set used
-across all scripts:
-
-| Variable               | Used by                                         | Description                                      |
-| ---------------------- | ----------------------------------------------- | ------------------------------------------------ |
-| `CONTRACT_ID`          | all                                             | Deployed FlowPay contract ID                     |
-| `RPC_URL`              | all                                             | Soroban RPC endpoint                             |
-| `NETWORK_PASSPHRASE`   | keeper, check-allowances                        | Stellar network passphrase                       |
-| `KEEPER_SECRET`        | keeper                                          | Stellar secret key (S…) for signing transactions |
-| `CHARGE_INTERVAL_MS`   | keeper                                          | Sleep between charge cycles                      |
-| `PAGE_SIZE`            | keeper                                          | Subscriptions per batch_charge page              |
-| `MAX_RETRIES`          | keeper                                          | Per-page retry limit                             |
-| `WEBHOOK_URL`          | alert-expiring-allowances, alert-failed-charges | Webhook POST target                              |
-| `ALERT_WINDOW_LEDGERS` | alert-expiring-allowances                       | Expiry alert threshold                           |
-| `DATA_DIR`             | indexer, query-events                           | SQLite database directory                        |
-| `DB_FILE`              | indexer, query-events                           | SQLite database path override                    |
-| `POLL_INTERVAL_MS`     | indexer                                         | Event polling interval                           |
-| `START_LEDGER`         | indexer                                         | First-run start ledger                           |
-| `LOG_LEVEL`            | keeper, indexer                                 | Log verbosity                                    |
+- Mainnet gates: [`docs/MAINNET-DEPLOYMENT.md`](../docs/MAINNET-DEPLOYMENT.md)
+- Keeper handbook: [`docs/KEEPER.md`](../docs/KEEPER.md)
+- Contract API (`batch_charge`, health, estimates): [`docs/API.md`](../docs/API.md)


### PR DESCRIPTION
﻿Closes #906
Closes #905
Closes #903
Closes #902

## Summary

- Updated mainnet deployment gates for fee bounds, volume caps, health, audit, and upgrade safety.
- Added focused keeper/indexer/metrics/Docker operations documentation.
- Documented the bounded health, estimate, fee-bounds, pause, and subscriber-page API delta.
- Consolidated referral documentation into one canonical guide with compatibility stubs and corrected links.

## Test plan

- [x] MAINNET-DEPLOYMENT.md checked against deployment scripts and contract admin APIs
- [x] scripts/README.md checked against keeper/indexer/metrics/compose/Dockerfile/env examples
- [x] API.md checked against the bounded contract symbol list
- [x] Referral guide checked against referral.rs/events.rs/ReferralPanel
- [x] Internal documentation links verified
- [x] Commands and environment variables verified
- [x] No mainnet deployment performed
- [x] No secrets added
- [x] Existing tests/build checks pass (CI)

### Bounded API delta (Issue 110 / #903)

- [x] `contract_health_check`
- [x] `HealthReport`
- [x] `simulate_charge`
- [x] `get_batch_charge_estimate`
- [x] `ChargeResult`
- [x] `ChargeSimResult`
- [x] `set_fee_bounds`
- [x] `get_fee_bounds`
- [x] `pause_until`
- [x] pause expiry getter, if exposed ΓÇö not a public contract method (internal `storage::get_pause_expiry` only)
- [x] `get_active_subscriber_page`

### Canonical referral guide (Issue 109 / #902)

- [x] data model
- [x] subscribe authentication
- [x] self-referral behavior
- [x] self-referral error
- [x] events
- [x] frontend usage
- [x] operational/script touchpoints
- [x] architecture references
- [x] error references

Made with [Cursor](https://cursor.com)
