### PR TITLE
docs: update deployment, operations, API, and referral guides

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -112,7 +112,7 @@ This revision documents only the following symbols against `contract/src/lib.rs`
 - [x] `HealthReport`
 - [x] `simulate_charge`
 - [x] `get_batch_charge_estimate`
-- [x] `ChargeResult`
+- [x] `ChargeResult` (including `AllowanceInsufficient`; not `ChargeSimResult::InsufficientAllowance`)
 - [x] `ChargeSimResult`
 - [x] `set_fee_bounds`
 - [x] `get_fee_bounds`
@@ -120,7 +120,7 @@ This revision documents only the following symbols against `contract/src/lib.rs`
 - [x] pause-expiry getter — **not exposed** (internal `storage::get_pause_expiry` only; no public contract method)
 - [x] `get_active_subscriber_page`
 
-Related ops: [`EVENTS.md`](./EVENTS.md) (`paused`, `subscription_auto_resumed`, `charged`), [`KEEPER.md`](./KEEPER.md) (`batch_charge`), [`MAINNET-DEPLOYMENT.md`](./MAINNET-DEPLOYMENT.md) (fee bounds / health gates).
+Related ops: [`EVENTS.md`](./EVENTS.md) (`paused`, `subscription_auto_resumed`, `charged`, `batch_charge_skips`), [`KEEPER.md`](./KEEPER.md) (`batch_charge`), [`MAINNET-DEPLOYMENT.md`](./MAINNET-DEPLOYMENT.md) (fee bounds / health gates).
 
 ---
 
@@ -149,23 +149,27 @@ Returned by live `batch_charge` and by `get_batch_charge_estimate`. Defined in `
 
 ```rust
 pub enum ChargeResult {
-  Charged,            // live: funds transferred; estimate: would charge (see caveats)
-  Skipped,            // interval has not elapsed
-  NoSubscription,     // no subscription record
-  Inactive,           // cancelled / inactive
-  Paused,             // still paused
-  GracePeriodElapsed, // past the grace window
+  Charged,                 // live: funds transferred; estimate: would charge (no transfer)
+  Skipped,                 // interval has not elapsed
+  NoSubscription,          // no subscription record
+  Inactive,                // cancelled / inactive
+  Paused,                  // still paused
+  GracePeriodElapsed,      // past the grace window
+  AllowanceInsufficient,   // SAC allowance < gross `sub.amount`; appended (discriminant 6)
 }
 ```
 
+New variants must be **appended** so off-chain parsers keep decoding 0–5. Do not confuse `AllowanceInsufficient` with [`ChargeSimResult::InsufficientAllowance`](#chargesimresult) or `ContractError::InsufficientAllowance` (8) — those are different symbols.
+
 | Variant | Meaning on `batch_charge` | Meaning on `get_batch_charge_estimate` |
 | --- | --- | --- |
-| `Charged` | Transfer succeeded | Precheck passed (or auto-resume short-circuit; **no transfer**) |
+| `Charged` | Transfer succeeded | Precheck + allowance passed (**no transfer**) |
 | `Skipped` | Interval not elapsed | Same (via `precheck_charge`) |
 | `NoSubscription` | No record | Same |
 | `Inactive` | Cancelled / inactive | Same |
 | `Paused` | Still paused | Same |
 | `GracePeriodElapsed` | Past grace window | Same |
+| `AllowanceInsufficient` | Gross allowance too low; rest of batch continues | Same check; **no transfer** |
 
 This type is **not** the dry-run enum. Single-user simulation uses [`ChargeSimResult`](#chargesimresult).
 
@@ -412,9 +416,9 @@ simulate_charge(env: Env, user: Address) -> ChargeSimResult
 | --- | --- | --- | --- |
 | Transfers | Yes | No | No |
 | Storage writes | Yes on success / auto-resume | No (auto-resume is memory-only) | **Yes** if `try_auto_resume` fires |
-| Contract pause | Enforced (panic / skip) | `ContractPaused` | **Ignored** |
-| Allowance | Required for success | Checked | **Not checked** |
-| Return | void / `ChargeResult` | `ChargeSimResult` | `Vec<ChargeResult>` |
+| Contract pause | `charge` and `batch_charge` panic `ContractPaused` (18) | `ContractPaused` | **Ignored** |
+| Allowance | `charge` panics `InsufficientAllowance` (8); `batch_charge` returns `AllowanceInsufficient` | `InsufficientAllowance` | `ChargeResult::AllowanceInsufficient` |
+| Return | void / `Vec<ChargeResult>` | `ChargeSimResult` | `Vec<ChargeResult>` |
 
 Keeper ops still use live `batch_charge`; see [`KEEPER.md`](./KEEPER.md). Events for a real charge are in [`EVENTS.md`](./EVENTS.md).
 
@@ -1324,9 +1328,15 @@ batch_charge(env: Env, users: Vec<Address>) -> Vec<ChargeResult>
 
 Auth: none.
 
-Returns: `Vec<ChargeResult>`.
+Returns: `Vec<ChargeResult>` — one entry per input address, in order.
 
-Errors: the function returns per-user results instead of aborting on ordinary charge failures.
+A non-`Charged` result for one user never aborts the rest of the batch. Insufficient SAC allowance is `ChargeResult::AllowanceInsufficient` (not a transaction panic). When the batch includes at least one *interesting* non-success (`NoSubscription`, `Inactive`, `Paused`, `GracePeriodElapsed`, `AllowanceInsufficient`), the contract emits [`batch_charge_skips`](./EVENTS.md#batch_charge_skips). All-charged or all-not-due (`Skipped`) batches emit no summary.
+
+The public wrapper calls `ensure_contract_not_paused` first: a paused protocol panics `ContractPaused` (18) for the whole invoke (not a per-user result).
+
+Errors: `ContractError::BatchTooLarge` (20) if `users.len()` exceeds `get_max_batch_size` (default 50). Ordinary per-user outcomes are enum values.
+
+Keeper ops: [`KEEPER.md`](./KEEPER.md).
 
 CLI example:
 
@@ -1350,18 +1360,18 @@ get_batch_charge_estimate(env: Env, users: Vec<Address>) -> Vec<ChargeResult>
 
 **Returns:** one `ChargeResult` per input address, in order.
 
-**Success behavior:** for each user, missing sub → `NoSubscription`. If paused and `try_auto_resume` returns true → **`Charged` immediately** (skips `precheck_charge`). Otherwise maps `precheck_charge` to `Charged` / skip variants.
+**Success behavior:** for each user, missing sub → `NoSubscription`. If paused, `try_auto_resume` may persist an auto-resume. Then `precheck_charge` runs. If that returns `Ok`, the estimate reads SAC `allowance(user, contract)` against gross `sub.amount` and returns `Charged` or `AllowanceInsufficient`.
 
 **Errors:** `ContractError::BatchTooLarge` (20) if `users.len() > 200` (hardcoded; not `get_max_batch_size`). Ordinary per-user outcomes are enum values, not panics.
 
 **Operational caveats (from `lib.rs`):**
 
 1. Calls real `try_auto_resume`, which **writes** the subscription, clears pause expiry, and emits `subscription_auto_resumed` — **not a pure view**.
-2. Does **not** check contract pause or token allowance (unlike `simulate_charge`).
-3. Auto-resume short-circuit to `Charged` can disagree with live `batch_charge`, which still runs `precheck_charge` after resume (estimate may say `Charged` when live would `Skipped`).
+2. Does **not** check protocol pause (`is_contract_paused`). `simulate_charge` returns `ContractPaused` instead.
+3. Allowance **is** checked (same gross-amount test as live `batch_charge`). A keeper file-header comment that says otherwise is stale.
 4. Cap 200 vs live batch max (default 50 via `MaxBatchSize`).
 
-Use `simulate_charge` for a no-write, allowance-aware single-user dry-run. Keepers that charge should still call `batch_charge` ([`KEEPER.md`](./KEEPER.md)). Auto-resume event: [`EVENTS.md`](./EVENTS.md).
+Use `simulate_charge` when you need a no-write, pause-aware single-user dry-run. Keepers that charge should still call `batch_charge` ([`KEEPER.md`](./KEEPER.md)). Auto-resume event: [`EVENTS.md`](./EVENTS.md).
 
 CLI example:
 

--- a/docs/MAINNET-DEPLOYMENT.md
+++ b/docs/MAINNET-DEPLOYMENT.md
@@ -422,7 +422,7 @@ Do not deposit or route real Mainnet funds until every item is checked.
 - [ ] **Configuration / snapshot verification** — schema version matches release; subscription snapshot retained if migrating or upgrading
 - [ ] **Upgrade safety checks** — `pre-upgrade-check` if a WASM swap is planned; propose/commit understood; no assumption of automatic rollback
 - [ ] **Mainnet authorization controls** — admin/deployer keys as planned; deployer secret not reused as long-term admin; config.json not left on testnet values
-- [ ] **Monitoring / keeper / indexer readiness** — keeper funded and running; indexer `events.db` persistence planned; metrics/Grafana optional but RPC and pause alerts live ([`scripts/README.md`](../scripts/README.md))
+- [ ] **Monitoring / keeper / indexer readiness** — keeper funded and running with `CONTRACT_ID`, `KEEPER_PUBLIC_KEY`, and live `KEEPER_SECRET`; indexer `events.db` persistence planned; metrics/Grafana optional but RPC and pause alerts live ([`scripts/README.md`](../scripts/README.md))
 
 ---
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -46,6 +46,7 @@ npm install
 | `subscription-snapshot.ts`     | Snapshot all subscription states                          |
 | `daily-revenue-summary.ts`     | Daily revenue report                                      |
 | `export-merchant-report.ts`    | Per-merchant activity report                              |
+
 ## Testnet quick start
 
 Copy-pastable **testnet** commands. Use placeholder keys only; do not put Mainnet
@@ -55,14 +56,18 @@ secrets in this file or in committed `.env` files.
 cd scripts
 npm install
 cp .env.example .env
-# edit .env — set CONTRACT_ID (C…) and KEEPER_SECRET (S… testnet account)
+# edit .env — set CONTRACT_ID (C…), KEEPER_PUBLIC_KEY (G…), KEEPER_SECRET (S…)
+# Current keeper.ts requires KEEPER_PUBLIC_KEY even though .env.example omits it.
 
-# Keeper (package script)
-npm run keeper
+# Keeper (package script) — export the vars above, or pass them inline
+CONTRACT_ID=C... KEEPER_PUBLIC_KEY=G... KEEPER_SECRET=S... npm run keeper
 # equivalent: tsx keeper.ts
 
+# Dry-run one cycle (no live submit)
+CONTRACT_ID=C... KEEPER_PUBLIC_KEY=G... DRY_RUN=true tsx keeper.ts --once
+
 # Indexer (package script)
-npm run indexer
+CONTRACT_ID=C... npm run indexer
 # equivalent: CONTRACT_ID=C... tsx indexer.ts
 
 # Metrics exporter (no package.json script — run directly)
@@ -82,24 +87,21 @@ docker compose down
 
 ## Keeper
 
-The keeper bot uses `buildOptimizedBatches()` to select only ready subscribers
-(ordered by grace urgency and overdue age) and calls `batch_charge()` on each
-batch, then sleeps until the next cycle. Supports a `DRY_RUN` mode that
-simulates charges without submitting any transactions.
 ### Purpose
 
-The keeper is an off-chain loop that pages through subscriptions and invokes
+The keeper is an off-chain loop that selects ready subscribers with
+`buildOptimizedBatches()` (grace urgency and overdue age) and invokes
 `batch_charge` so recurring charges run without a user in the loop. Soroban has
 no native scheduler; keepers supply that cadence.
 
-The file header describes paging `batch_charge(offset, limit)` then sleeping
-until the next cycle. A second block in the same file also documents optimized
-batches, `DRY_RUN`, and a `--once` flag.
+`DRY_RUN=true` simulates with `get_batch_charge_estimate` and does not submit
+transactions. Flags: `--once` (one cycle then exit), `--help` / `-h`.
 
 ### Prerequisites
 
 - Testnet (or other) FlowPay **contract ID**
-- A funded Stellar account whose **secret key** can pay transaction fees
+- A funded Stellar account: **public key always required**; **secret key**
+  required unless `DRY_RUN=true`
 - Reachable Soroban RPC
 - Node 20+ and dependencies from `npm install` in `scripts/`
 
@@ -107,40 +109,44 @@ batches, `DRY_RUN`, and a `--once` flag.
 
 | Variable | Required | Notes |
 | --- | --- | --- |
-| `CONTRACT_ID` | yes | Empty value exits 1 |
-| `KEEPER_SECRET` | yes (live signing) | Secret key `S…`; first config block always requires it |
+| `CONTRACT_ID` | yes | Empty value fails `validateEnv` |
+| `KEEPER_PUBLIC_KEY` | yes | Source account `G…`; required even in dry-run |
+| `KEEPER_SECRET` | yes unless `DRY_RUN=true` | Secret key `S…` for live signing |
 
-`scripts/.env.example` is the Compose / Docker contract: `CONTRACT_ID` and
-`KEEPER_SECRET` at minimum.
+`scripts/.env.example` lists `CONTRACT_ID` and `KEEPER_SECRET` plus
+`CHARGE_INTERVAL_MS` / `PAGE_SIZE` / `MAX_RETRIES` / `LOG_LEVEL`. **Current
+`keeper.ts` does not read those four tuning names.** Add `KEEPER_PUBLIC_KEY`
+(and optionally `DRY_RUN`, `BATCH_SIZE`, `INTERVAL_SECONDS`, `REPORT_DIR`)
+yourself. Compose loads `.env` as-is.
 
 ### Testnet startup
 
 ```bash
-# Live mode
-CONTRACT_ID=C...  \
-KEEPER_PUBLIC_KEY=G...  \
-KEEPER_SECRET=S...  \
 cd scripts
+
+# Live mode
 CONTRACT_ID=C... \
+KEEPER_PUBLIC_KEY=G... \
 KEEPER_SECRET=S... \
 tsx keeper.ts
 
 # Dry-run (simulate only, no transactions submitted)
-CONTRACT_ID=C...  \
-KEEPER_PUBLIC_KEY=G...  \
-DRY_RUN=true  \
+CONTRACT_ID=C... \
+KEEPER_PUBLIC_KEY=G... \
+DRY_RUN=true \
 tsx keeper.ts --once
 ```
 
-Or `npm run keeper` after exporting the same variables (or loading `.env` in
-your shell). Docker: see [Docker Compose](#docker-compose).
+Or `npm run keeper` after exporting the same variables. Docker: see
+[Docker Compose](#docker-compose).
 
 ### Expected health / behavior
 
-- Local process: logs a startup line such as `"FlowPay Keeper starting"` (JSON
-  fields include contract, keeper public key, RPC, `charge_interval_ms`,
-  `page_size`, `max_retries` in the first logger). SIGINT/SIGTERM finish the
-  current cycle then exit 0.
+- Local process: logs `[LIVE] Keeper started in LIVE mode` or
+  `[DRY-RUN] Keeper started in DRY-RUN mode — no transactions will be submitted`.
+  There is **no** SIGINT/SIGTERM handler; loop mode sleeps `INTERVAL_SECONDS`
+  between cycles. `--once` exits 0 unless the cycle had errors and
+  `totalCharged === 0` (then exit 1).
 - Docker image `HEALTHCHECK`: `wget` POST `getHealth` to
   `${RPC_URL:-https://soroban-testnet.stellar.org}` and grep
   `"status":"healthy"` (60 s interval). This probes **RPC**, not the keeper
@@ -150,14 +156,13 @@ your shell). Docker: see [Docker Compose](#docker-compose).
 Smoke after Compose:
 
 ```bash
-docker compose logs keeper | grep '"msg":"FlowPay Keeper starting"'
+docker compose logs keeper | grep -E "Keeper started in (LIVE|DRY-RUN) mode"
 ```
 
 ### Logs and metrics
 
-- First logger: JSON lines on stdout/stderr (`LOG_LEVEL`).
-- Second logger (same file): `[DRY-RUN]` / `[LIVE]` prefixes; `--once` then
-  sleep `INTERVAL_SECONDS`.
+- Prefix logger: `[DRY-RUN]` or `[LIVE]` on stdout. `keeper.ts` does **not**
+  read `LOG_LEVEL`.
 - Prometheus metrics are implemented in `metrics-server.ts`. **`keeper.ts` does
   not import that module**, so running the keeper alone does not expose
   `/metrics`. Run the metrics server separately if you need scrape targets.
@@ -166,12 +171,17 @@ docker compose logs keeper | grep '"msg":"FlowPay Keeper starting"'
 
 | Variable             | Default                          | Description                                         |
 | -------------------- | -------------------------------- | --------------------------------------------------- |
-| `RPC_URL`            | testnet RPC                      | Soroban RPC endpoint                                |
-| `NETWORK_PASSPHRASE` | testnet passphrase               | Stellar network passphrase                          |
-| `BATCH_SIZE`         | `50`                             | Subscribers per `batch_charge` call (max 50)        |
-| `INTERVAL_SECONDS`   | `3600` (1 h)                     | Seconds between full charge cycles                  |
-| `DRY_RUN`            | `false`                          | Set `true` to simulate charges without submitting   |
-| `REPORT_DIR`         | `<script_dir>/data/benchmarks`   | Directory for dry-run reports and live-cycle pointer|
+| `RPC_URL`            | `https://soroban-testnet.stellar.org` | Soroban RPC endpoint                          |
+| `NETWORK_PASSPHRASE` | `Networks.TESTNET`               | Stellar network passphrase                          |
+| `BATCH_SIZE`         | `50` (clamped 1–50)              | Subscribers per `batch_charge` call                 |
+| `INTERVAL_SECONDS`   | `3600` (min 1)                   | Seconds between full charge cycles                  |
+| `DRY_RUN`            | unset → live (`=== "true"` only) | Simulate with `get_batch_charge_estimate`           |
+| `REPORT_DIR`         | `<script_dir>/data/benchmarks`   | Dry-run reports and live-cycle pointer              |
+
+The `keeper.ts` file header still says `get_batch_charge_estimate` does not
+check allowances. **The contract now does** (see
+[`docs/API.md`](../docs/API.md#get_batch_charge_estimate)). Treat the header as
+stale; the ABI wins.
 
 ### Dry-run report
 
@@ -185,9 +195,8 @@ keeper-dryrun-report-2026-08-26T10-00-00.000Z.json
 The report contains:
 
 - **`estimatedOutcomes`** — aggregate counts: `totalChecked`, `totalCharged`,
-  `totalVolumeStroops`, and `skipCounts` broken down by each `ChargeResult`
-  variant (`Charged`, `Skipped`, `GracePeriodElapsed`, `Paused`,
-  `NoSubscription`, `Inactive`).
+  `totalVolumeStroops`, and `skipCounts` keyed by decoded `ChargeResult`
+  variant names (including `AllowanceInsufficient` when the contract returns it).
 - **`candidates`** — full per-subscriber detail: address, decoded
   `ChargeResult` variant, and the subscription amount in stroops (for
   `Charged` entries).
@@ -208,18 +217,6 @@ for the full expected shape.
 > **Note:** The benchmark files produced by `keeper-benchmark.ts`
 > (`keeper-bench-*.json`) have a completely different schema (submission and
 > confirmation latency percentiles) and are unrelated to these reports.
-`keeper.ts` currently contains two overlapping configuration blocks. Docker and
-`.env.example` follow the first. The second also reads:
-
-| Variable | Default in that block | Role |
-| --- | --- | --- |
-| `DRY_RUN` | `"true"` (boolean if equal to `"true"`) | Simulation mode; secret not required when true |
-| `KEEPER_PUBLIC_KEY` | `""` | Required by `validateEnv` in that block |
-| `BATCH_SIZE` | `50` (clamped 1–50) | Page size in that block |
-| `INTERVAL_SECONDS` | `3600` (min 1) | Loop interval in that block |
-
-Set the variables that match how you start the process. Prefer the
-`.env.example` names for Compose.
 
 ---
 
@@ -399,7 +396,7 @@ with `DATA_DIR=/app/data` (or bind-mount the same volume).
 
 ```bash
 cd scripts
-cp .env.example .env   # then edit CONTRACT_ID and KEEPER_SECRET
+cp .env.example .env   # then set CONTRACT_ID, KEEPER_PUBLIC_KEY, KEEPER_SECRET
 docker compose up -d
 docker compose logs -f keeper
 docker compose down
@@ -417,9 +414,12 @@ docker run --rm --env-file .env --name payflow-keeper payflow-keeper
 
 Two stages (`scripts/Dockerfile`):
 
-1. **builder** (`node:20-alpine`): `npm ci --frozen-lockfile`, compiles
-   `keeper.ts` via `npm run build` (`tsconfig.build.json` includes **only**
-   `keeper.ts`) → `/build/dist/keeper.js`
+1. **builder** (`node:20-alpine`): `npm ci --frozen-lockfile`, copies
+   `keeper.ts` only, compiles via `npm run build` (`tsconfig.build.json`
+   includes **only** `keeper.ts`) → `/build/dist/keeper.js`. Current
+   `keeper.ts` imports `./batch-optimizer`, which this `COPY` list does not
+   include — confirm `docker build` succeeds in your tree before relying on
+   Compose.
 2. **runtime**: production `npm ci --omit=dev`, `USER node`, `CMD`
    `["node", "dist/keeper.js"]`, `NODE_ENV=production`,
    `NODE_OPTIONS=--unhandled-rejections=throw`
@@ -446,18 +446,19 @@ keeper Dockerfile. Defaults are from source or `.env.example`.
 
 | Variable | Default / example | Used by | Purpose | Notes |
 | --- | --- | --- | --- | --- |
-| `CONTRACT_ID` | empty; `.env.example` blank | keeper, indexer | Deployed contract ID | Required (exit 1 if missing). Metrics header lists it but does not read it. Compose via `.env`. |
-| `KEEPER_SECRET` | empty | keeper | Sign keeper transactions | Required in the primary config block. Testnet `S…` only in examples. |
-| `KEEPER_PUBLIC_KEY` | `""` | keeper (second block) | Source account pubkey | Required by that block's `validateEnv`. Not in `.env.example`. |
-| `DRY_RUN` | `"true"` in second block | keeper (second block) | Simulation vs live | Not in `.env.example`. |
+| `CONTRACT_ID` | empty; `.env.example` blank | keeper, indexer | Deployed contract ID | Required (validateEnv / indexer exit 1). Metrics header lists it but does not read it. Compose via `.env`. |
+| `KEEPER_SECRET` | empty | keeper | Sign keeper transactions | Required unless `DRY_RUN=true`. Testnet `S…` only in examples. |
+| `KEEPER_PUBLIC_KEY` | `""` | keeper | Source account pubkey | Required by `validateEnv` (including dry-run). **Not** in `.env.example`. |
+| `DRY_RUN` | unset → live | keeper | Simulation vs live | Only `"true"` enables dry-run. Not in `.env.example`. |
 | `RPC_URL` | `https://soroban-testnet.stellar.org` | keeper, indexer, Dockerfile HEALTHCHECK | Soroban RPC | Compose via `.env`. Metrics header only. |
 | `NETWORK_PASSPHRASE` | `Networks.TESTNET` / `.env.example`: `Test SDF Network ; September 2015` | keeper | Network passphrase | Indexer header only — not read by indexer. |
-| `CHARGE_INTERVAL_MS` | `3600000` | keeper (first block) | Sleep between full cycles | `.env.example` |
-| `PAGE_SIZE` | `100` (capped at 100) | keeper (first block) | Page size for `batch_charge` | `.env.example` |
-| `MAX_RETRIES` | `3` | keeper (first block) | Per-page retries | `.env.example` |
-| `BATCH_SIZE` | `50` (clamped 1–50) | keeper (second block) | Alternate page size | Conflicts in name with `PAGE_SIZE`. |
-| `INTERVAL_SECONDS` | `3600` | keeper (second block) | Alternate loop interval | |
-| `LOG_LEVEL` | `info` | keeper, indexer | Log verbosity | Indexer: `debug` \| `info` \| `error` |
+| `BATCH_SIZE` | `50` (clamped 1–50) | keeper | Page size for `batch_charge` | Not in `.env.example`. |
+| `INTERVAL_SECONDS` | `3600` (min 1) | keeper | Loop interval | Not in `.env.example`. |
+| `REPORT_DIR` | `<script_dir>/data/benchmarks` | keeper | Dry-run reports / live pointer | Not in `.env.example`. |
+| `CHARGE_INTERVAL_MS` | `3600000` in `.env.example` | **none (stale example)** | — | Listed in `.env.example`; **not read** by current `keeper.ts`. |
+| `PAGE_SIZE` | `100` in `.env.example` | **none (stale example)** | — | Listed in `.env.example`; **not read** by current `keeper.ts`. |
+| `MAX_RETRIES` | `3` in `.env.example` | **none (stale example)** | — | Listed in `.env.example`; **not read** by current `keeper.ts`. |
+| `LOG_LEVEL` | `info` | indexer | Log verbosity | Indexer: `debug` \| `info` \| `error`. Keeper does not read it. `.env.example` still lists it. |
 | `DATA_DIR` | `data` | indexer | SQLite directory | Compose volume is `/app/data` if indexer is run there. Not in `.env.example`. |
 | `DB_FILE` | `DATA_DIR/events.db` | indexer | SQLite path override | Not in `.env.example`. |
 | `POLL_INTERVAL_MS` | `10000` | indexer | Event poll interval | Not in `.env.example`. |


### PR DESCRIPTION
Closes #906
Closes #905
Closes #903
Closes #902

## Summary

- Updated mainnet deployment gates for fee bounds, volume caps, health, audit, and upgrade safety.
- Added focused keeper/indexer/metrics/Docker operations documentation.
- Documented the bounded health, estimate, fee-bounds, pause, and subscriber-page API delta.
- Consolidated referral documentation into one canonical guide with compatibility stubs and corrected links.

This follow-up resyncs those guides to current `master` after later contract/keeper changes: `ChargeResult::AllowanceInsufficient`, allowance-aware `get_batch_charge_estimate`, and the single keeper env block (`KEEPER_PUBLIC_KEY`, `BATCH_SIZE`, `INTERVAL_SECONDS`, `DRY_RUN`). Referral canonicalization from #932 is unchanged.

## Test plan

- [x] MAINNET-DEPLOYMENT.md checked against deployment scripts and contract admin APIs
- [x] scripts/README.md checked against keeper/indexer/metrics/compose/Dockerfile/env examples
- [x] API.md checked against the bounded contract symbol list
- [x] Referral guide checked against referral.rs/events.rs/ReferralPanel
- [x] Internal documentation links verified
- [x] Commands and environment variables verified
- [x] No mainnet deployment performed
- [x] No secrets added
- [ ] Existing tests/build checks pass (CI)

### Bounded API delta (Issue 110 / #903)

- [x] `contract_health_check`
- [x] `HealthReport`
- [x] `simulate_charge`
- [x] `get_batch_charge_estimate`
- [x] `ChargeResult`
- [x] `ChargeSimResult`
- [x] `set_fee_bounds`
- [x] `get_fee_bounds`
- [x] `pause_until`
- [x] pause expiry getter, if exposed — not a public contract method (internal `storage::get_pause_expiry` only)
- [x] `get_active_subscriber_page`

### Canonical referral guide (Issue 109 / #902)

- [x] data model
- [x] subscribe authentication
- [x] self-referral behavior
- [x] self-referral error
- [x] events
- [x] frontend usage
- [x] operational/script touchpoints
- [x] architecture references
- [x] error references