### PR TITLE
[844] Issue 049: Surface subscription health and simulate_charge before pay/charge actions

### DIFF
--- a/frontend/src/__tests__/Dashboard.responsive.test.tsx
+++ b/frontend/src/__tests__/Dashboard.responsive.test.tsx
@@ -13,6 +13,18 @@ vi.mock("../stellar", async (importOriginal) => {
     getSubscription: vi.fn(() => Promise.resolve(null)),
     getDailyLimit: vi.fn(() => Promise.resolve(null)),
     getDailySpent: vi.fn(() => Promise.resolve(0n)),
+    getSubscriptionHealth: vi.fn(() =>
+      Promise.resolve({
+        active: true,
+        charge_due: false,
+        within_grace: false,
+        has_sufficient_allowance: true,
+        is_paused: false,
+        trial_active: false,
+        daily_limit_set: false,
+      })
+    ),
+    simulateCharge: vi.fn(() => Promise.resolve("WouldSucceed")),
     buildCancelTx: vi.fn(),
     buildPayPerUseTx: vi.fn(),
     explorerTxUrl: vi.fn((hash: string) => `https://stellar.expert/tx/${hash}`),
@@ -45,6 +57,7 @@ function setViewport(width: number) {
 }
 
 import * as stellar from "../stellar";
+import { useRpcHealth } from "../hooks/useRpcHealth";
 import Dashboard from "../components/Dashboard";
 
 const ACTIVE_SUB = {
@@ -61,12 +74,27 @@ function setupMocks(sub: typeof ACTIVE_SUB | null = ACTIVE_SUB) {
   vi.mocked(stellar.getAllowance).mockResolvedValue(0n);
   vi.mocked(stellar.getDailyLimit).mockResolvedValue(null);
   vi.mocked(stellar.getDailySpent).mockResolvedValue(0n);
+  vi.mocked(stellar.getSubscriptionHealth).mockResolvedValue({
+    active: true,
+    charge_due: false,
+    within_grace: false,
+    has_sufficient_allowance: true,
+    is_paused: false,
+    trial_active: false,
+    daily_limit_set: false,
+  });
+  vi.mocked(stellar.simulateCharge).mockResolvedValue("WouldSucceed");
   vi.mocked(stellar.server.getTransaction).mockResolvedValue({ status: "SUCCESS" } as any);
+  vi.mocked(useRpcHealth).mockReturnValue({
+    status: "healthy",
+    latencyMs: 50,
+    error: null,
+  } as ReturnType<typeof useRpcHealth>);
 }
 
 describe("Dashboard – responsive layout", () => {
   afterEach(() => {
-    vi.resetAllMocks();
+    vi.clearAllMocks();
   });
 
   it("applies dashboard--mobile class on mobile viewport (375px)", async () => {

--- a/frontend/src/__tests__/Dashboard.test.tsx
+++ b/frontend/src/__tests__/Dashboard.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { vi } from "vitest";
 
@@ -40,6 +40,18 @@ vi.mock("../stellar", async (importOriginal) => {
     getSubscription: vi.fn(() => Promise.resolve(null)),
     getDailyLimit: vi.fn(() => Promise.resolve(null)),
     getDailySpent: vi.fn(() => Promise.resolve(0n)),
+    getSubscriptionHealth: vi.fn(() =>
+      Promise.resolve({
+        active: true,
+        charge_due: false,
+        within_grace: false,
+        has_sufficient_allowance: true,
+        is_paused: false,
+        trial_active: false,
+        daily_limit_set: false,
+      })
+    ),
+    simulateCharge: vi.fn(() => Promise.resolve("WouldSucceed")),
     fetchEvents: vi.fn(() => Promise.resolve([])),
     buildCancelTx: vi.fn(),
     buildPayPerUseTx: vi.fn(),
@@ -58,6 +70,7 @@ vi.mock("../components/SubscriptionHistory", () => ({
 }));
 
 import * as stellar from "../stellar";
+import type { ChargeSimResult, SubscriptionHealth } from "../stellar";
 import { useRpcHealth } from "../hooks/useRpcHealth";
 import Dashboard from "../components/Dashboard";
 
@@ -70,11 +83,27 @@ const ACTIVE_SUB = {
   paused: false,
 };
 
-function setup(sub: typeof ACTIVE_SUB | null = ACTIVE_SUB) {
+const HEALTHY_HEALTH: SubscriptionHealth = {
+  active: true,
+  charge_due: false,
+  within_grace: false,
+  has_sufficient_allowance: true,
+  is_paused: false,
+  trial_active: false,
+  daily_limit_set: false,
+};
+
+function setup(
+  sub: typeof ACTIVE_SUB | null = ACTIVE_SUB,
+  health: SubscriptionHealth | null = HEALTHY_HEALTH,
+  sim: ChargeSimResult | null = "WouldSucceed"
+) {
   vi.mocked(stellar.getSubscription).mockResolvedValue(sub);
   vi.mocked(stellar.getAllowance).mockResolvedValue(BigInt(0));
   vi.mocked(stellar.getDailyLimit).mockResolvedValue(null);
   vi.mocked(stellar.getDailySpent).mockResolvedValue(BigInt(0));
+  vi.mocked(stellar.getSubscriptionHealth).mockResolvedValue(health);
+  vi.mocked(stellar.simulateCharge).mockResolvedValue(sim);
   vi.mocked(stellar.server.getTransaction).mockResolvedValue({ status: "SUCCESS" } as any);
 
   const onSign = vi.fn().mockResolvedValue("txhash1234567890");
@@ -87,7 +116,12 @@ function setup(sub: typeof ACTIVE_SUB | null = ACTIVE_SUB) {
 
 describe("Dashboard", () => {
   afterEach(() => {
-    vi.resetAllMocks();
+    vi.clearAllMocks();
+    vi.mocked(useRpcHealth).mockReturnValue({
+      status: "healthy",
+      latencyMs: 50,
+      error: null,
+    } as ReturnType<typeof useRpcHealth>);
     toast.error.mockClear();
     toast.success.mockClear();
   });
@@ -165,5 +199,52 @@ describe("Dashboard", () => {
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith(expect.stringMatching(/user rejected/i));
     });
+  });
+
+  it("shows health Good and keeps pay enabled for a healthy subscription", async () => {
+    vi.mocked(stellar.buildPayPerUseTx).mockResolvedValue("ppu-xdr");
+    setup();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("subscription-health-status")).toHaveTextContent("Good");
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("simulate-charge-readout")).toHaveTextContent(/would succeed/i);
+    });
+    expect(screen.queryByTestId("ppu-blocked-reason")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("error-recovery")).not.toBeInTheDocument();
+  });
+
+  it("disables pay-per-use when the subscription is paused", async () => {
+    setup(
+      { ...ACTIVE_SUB, paused: true },
+      { ...HEALTHY_HEALTH, is_paused: true },
+      "SubscriptionPaused"
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("ppu-blocked-reason")).toHaveTextContent(/paused/i);
+    });
+    expect(screen.getByRole("button", { name: /pay now/i })).toBeDisabled();
+  });
+
+  it("warns but does not disable pay when allowance is insufficient", async () => {
+    setup(
+      ACTIVE_SUB,
+      { ...HEALTHY_HEALTH, has_sufficient_allowance: false },
+      "InsufficientAllowance"
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("ppu-warning-reason")).toHaveTextContent(
+        /allowance is insufficient/i
+      );
+    });
+    expect(screen.getByTestId("error-recovery")).toHaveAttribute("data-proactive", "true");
+    expect(
+      within(screen.getByTestId("error-recovery")).getByRole("button", {
+        name: /increase allowance/i,
+      })
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/__tests__/ErrorRecovery.test.tsx
+++ b/frontend/src/__tests__/ErrorRecovery.test.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import ErrorRecovery from "../components/ErrorRecovery";
+import type { SubscriptionHealth } from "../stellar";
+
+const HEALTHY: SubscriptionHealth = {
+  active: true,
+  charge_due: false,
+  within_grace: false,
+  has_sufficient_allowance: true,
+  is_paused: false,
+  trial_active: false,
+  daily_limit_set: false,
+};
+
+describe("ErrorRecovery", () => {
+  it("renders nothing when there is no error and health is good", () => {
+    const { container } = render(<ErrorRecovery error={null} health={HEALTHY} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("shows Increase Allowance for insufficient-allowance errors", async () => {
+    const onIncreaseAllowance = vi.fn();
+    render(
+      <ErrorRecovery
+        error="HostError: InsufficientAllowance"
+        onIncreaseAllowance={onIncreaseAllowance}
+      />
+    );
+    expect(screen.getByTestId("error-recovery")).toHaveTextContent(
+      "Your token allowance is too low to complete this charge."
+    );
+    await userEvent.click(screen.getByRole("button", { name: /increase allowance/i }));
+    expect(onIncreaseAllowance).toHaveBeenCalled();
+  });
+
+  it("shows proactive allowance guidance from health without an error", () => {
+    const onIncreaseAllowance = vi.fn();
+    render(
+      <ErrorRecovery
+        error={null}
+        health={{ ...HEALTHY, has_sufficient_allowance: false }}
+        onIncreaseAllowance={onIncreaseAllowance}
+      />
+    );
+    expect(screen.getByTestId("error-recovery")).toHaveAttribute("data-proactive", "true");
+    expect(screen.getByText(/Token allowance is insufficient/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /increase allowance/i })).toBeInTheDocument();
+  });
+
+  it("shows paused guidance from health", () => {
+    render(<ErrorRecovery error={null} health={{ ...HEALTHY, is_paused: true }} />);
+    expect(screen.getByTestId("error-recovery")).toHaveTextContent(/paused/i);
+  });
+
+  it("shows grace-period guidance from health", () => {
+    render(<ErrorRecovery error={null} health={{ ...HEALTHY, within_grace: true }} />);
+    expect(screen.getByTestId("error-recovery")).toHaveTextContent(/grace period/i);
+  });
+
+  it("shows simulate_charge InsufficientAllowance guidance", () => {
+    const onIncreaseAllowance = vi.fn();
+    render(
+      <ErrorRecovery
+        error={null}
+        health={HEALTHY}
+        simulateResult="InsufficientAllowance"
+        onIncreaseAllowance={onIncreaseAllowance}
+      />
+    );
+    expect(screen.getByText(/Token allowance is insufficient/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /increase allowance/i })).toBeInTheDocument();
+  });
+
+  it("shows contract-paused guidance from simulate_charge", () => {
+    render(<ErrorRecovery error={null} simulateResult="ContractPaused" />);
+    expect(screen.getByTestId("error-recovery")).toHaveTextContent(/protocol is paused/i);
+  });
+});

--- a/frontend/src/__tests__/SubscriptionCard.responsive.test.tsx
+++ b/frontend/src/__tests__/SubscriptionCard.responsive.test.tsx
@@ -24,6 +24,18 @@ vi.mock("../stellar", async (importOriginal) => {
     buildPayPerUseTx: vi.fn(),
     buildPauseTx: vi.fn(),
     buildResumeTx: vi.fn(),
+    getSubscriptionHealth: vi.fn(() =>
+      Promise.resolve({
+        active: true,
+        charge_due: false,
+        within_grace: false,
+        has_sufficient_allowance: true,
+        is_paused: false,
+        trial_active: false,
+        daily_limit_set: false,
+      })
+    ),
+    simulateCharge: vi.fn(() => Promise.resolve("WouldSucceed")),
   };
 });
 

--- a/frontend/src/__tests__/SubscriptionCard.test.tsx
+++ b/frontend/src/__tests__/SubscriptionCard.test.tsx
@@ -33,11 +33,19 @@ vi.mock("../components/IncreaseAllowanceModal", () => ({
 // Mock the stellar module — getAllowance and getTrialEnd are used by SubscriptionCard
 const mockGetAllowance = vi.fn();
 const mockGetTrialEnd = vi.fn();
-vi.mock("../stellar", () => ({
-  getAllowance: (...args: unknown[]) => mockGetAllowance(...args),
-  getTrialEnd: (...args: unknown[]) => mockGetTrialEnd(...args),
-  buildCancelTx: vi.fn().mockResolvedValue("cancel-xdr"),
-}));
+const mockGetSubscriptionHealth = vi.fn();
+const mockSimulateCharge = vi.fn();
+vi.mock("../stellar", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../stellar")>();
+  return {
+    ...actual,
+    getAllowance: (...args: unknown[]) => mockGetAllowance(...args),
+    getTrialEnd: (...args: unknown[]) => mockGetTrialEnd(...args),
+    getSubscriptionHealth: (...args: unknown[]) => mockGetSubscriptionHealth(...args),
+    simulateCharge: (...args: unknown[]) => mockSimulateCharge(...args),
+    buildCancelTx: vi.fn().mockResolvedValue("cancel-xdr"),
+  };
+});
 
 // Mock hooks used by SubscriptionCard
 vi.mock("../hooks/useSubscriptionSync", () => ({
@@ -87,6 +95,16 @@ describe("SubscriptionCard", () => {
     mockGetAllowance.mockResolvedValue(300000000n);
     // Default: no trial active
     mockGetTrialEnd.mockResolvedValue(null);
+    mockGetSubscriptionHealth.mockResolvedValue({
+      active: true,
+      charge_due: false,
+      within_grace: false,
+      has_sufficient_allowance: true,
+      is_paused: false,
+      trial_active: false,
+      daily_limit_set: false,
+    });
+    mockSimulateCharge.mockResolvedValue("WouldSucceed");
   });
 
   // ── computeAllowanceHealth unit tests ──────────────────────────────────────
@@ -650,6 +668,113 @@ describe("SubscriptionCard", () => {
       );
       expect(screen.queryByRole("button", { name: /^pause$/i })).not.toBeInTheDocument();
       expect(screen.queryByRole("button", { name: /resume/i })).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Subscription health widget", () => {
+    it("shows Good health for an active healthy subscription", async () => {
+      render(
+        <SubscriptionCard
+          subscription={createMockSubscription({ active: true })}
+          userKey={mockUserKey}
+          onSign={mockOnSign}
+          onRefresh={mockOnRefresh}
+        />
+      );
+      await waitFor(() => {
+        expect(screen.getByTestId("subscription-health-status")).toHaveTextContent("Good");
+      });
+      expect(screen.queryByTestId("health-action-warning")).not.toBeInTheDocument();
+    });
+
+    it("shows loading skeleton while health is fetching", () => {
+      mockGetSubscriptionHealth.mockReturnValue(new Promise(() => {}));
+      render(
+        <SubscriptionCard
+          subscription={createMockSubscription({ active: true })}
+          userKey={mockUserKey}
+          onSign={mockOnSign}
+          onRefresh={mockOnRefresh}
+        />
+      );
+      expect(screen.getByTestId("subscription-health-loading")).toBeInTheDocument();
+    });
+
+    it("warns on pause/cancel when health is unhealthy but does not disable them", async () => {
+      mockGetSubscriptionHealth.mockResolvedValue({
+        active: true,
+        charge_due: false,
+        within_grace: false,
+        has_sufficient_allowance: false,
+        is_paused: false,
+        trial_active: false,
+        daily_limit_set: false,
+      });
+      render(
+        <SubscriptionCard
+          subscription={createMockSubscription({ active: true, paused: false })}
+          userKey={mockUserKey}
+          onSign={mockOnSign}
+          onRefresh={mockOnRefresh}
+        />
+      );
+      await waitFor(() => {
+        expect(screen.getByTestId("health-action-warning")).toBeInTheDocument();
+      });
+      expect(screen.getByRole("button", { name: /^pause$/i })).not.toBeDisabled();
+      expect(screen.getByRole("button", { name: /cancel subscription/i })).not.toBeDisabled();
+    });
+
+    it("surfaces grace period in the health widget", async () => {
+      mockGetSubscriptionHealth.mockResolvedValue({
+        active: true,
+        charge_due: true,
+        within_grace: true,
+        has_sufficient_allowance: true,
+        is_paused: false,
+        trial_active: false,
+        daily_limit_set: false,
+      });
+      render(
+        <SubscriptionCard
+          subscription={createMockSubscription({ active: true })}
+          userKey={mockUserKey}
+          onSign={mockOnSign}
+          onRefresh={mockOnRefresh}
+        />
+      );
+      await waitFor(() => {
+        expect(screen.getByText(/Subscription is in its grace period/)).toBeInTheDocument();
+      });
+    });
+
+    it("does not show health widget for cancelled subscriptions", () => {
+      render(
+        <SubscriptionCard
+          subscription={createMockSubscription({ active: false })}
+          userKey={mockUserKey}
+          onSign={mockOnSign}
+          onRefresh={mockOnRefresh}
+        />
+      );
+      expect(mockGetSubscriptionHealth).not.toHaveBeenCalled();
+      expect(screen.queryByTestId("subscription-health-widget")).not.toBeInTheDocument();
+    });
+
+    it("shows simulate_charge readout when enabled", async () => {
+      mockSimulateCharge.mockResolvedValue("SubscriptionPaused");
+      render(
+        <SubscriptionCard
+          subscription={createMockSubscription({ active: true })}
+          userKey={mockUserKey}
+          onSign={mockOnSign}
+          onRefresh={mockOnRefresh}
+          showSimulateCharge
+        />
+      );
+      await waitFor(() => {
+        expect(screen.getByTestId("simulate-charge-readout")).toHaveTextContent(/paused/i);
+      });
     });
   });
 

--- a/frontend/src/__tests__/SubscriptionHealthWidget.test.tsx
+++ b/frontend/src/__tests__/SubscriptionHealthWidget.test.tsx
@@ -1,0 +1,116 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import SubscriptionHealthWidget from "../components/SubscriptionHealthWidget";
+import type { ChargeSimResult, SubscriptionHealth } from "../stellar";
+
+const mockGetSubscriptionHealth = vi.fn();
+const mockSimulateCharge = vi.fn();
+
+vi.mock("../stellar", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../stellar")>();
+  return {
+    ...actual,
+    getSubscriptionHealth: (...args: unknown[]) => mockGetSubscriptionHealth(...args),
+    simulateCharge: (...args: unknown[]) => mockSimulateCharge(...args),
+  };
+});
+
+const HEALTHY: SubscriptionHealth = {
+  active: true,
+  charge_due: false,
+  within_grace: false,
+  has_sufficient_allowance: true,
+  is_paused: false,
+  trial_active: false,
+  daily_limit_set: false,
+};
+
+describe("SubscriptionHealthWidget", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSubscriptionHealth.mockResolvedValue(HEALTHY);
+    mockSimulateCharge.mockResolvedValue("WouldSucceed" satisfies ChargeSimResult);
+  });
+
+  it("shows a loading skeleton while health is fetching", () => {
+    mockGetSubscriptionHealth.mockReturnValue(new Promise(() => {}));
+    render(<SubscriptionHealthWidget userKey="GUSER" />);
+    expect(screen.getByTestId("subscription-health-loading")).toBeInTheDocument();
+  });
+
+  it("renders Good status for a healthy subscription", async () => {
+    render(<SubscriptionHealthWidget userKey="GUSER" />);
+    await waitFor(() => {
+      expect(screen.getByTestId("subscription-health-status")).toHaveTextContent("Good");
+    });
+    expect(screen.queryByTestId("subscription-health-issues")).not.toBeInTheDocument();
+  });
+
+  it("renders Needs Attention when allowance is insufficient", async () => {
+    mockGetSubscriptionHealth.mockResolvedValue({
+      ...HEALTHY,
+      has_sufficient_allowance: false,
+    });
+    render(<SubscriptionHealthWidget userKey="GUSER" />);
+    await waitFor(() => {
+      expect(screen.getByTestId("subscription-health-status")).toHaveTextContent("Needs Attention");
+    });
+    expect(screen.getByText(/Token allowance is insufficient/)).toBeInTheDocument();
+  });
+
+  it("renders paused state", async () => {
+    mockGetSubscriptionHealth.mockResolvedValue({ ...HEALTHY, is_paused: true });
+    render(<SubscriptionHealthWidget userKey="GUSER" />);
+    await waitFor(() => {
+      expect(screen.getByText(/Subscription is currently paused/)).toBeInTheDocument();
+    });
+  });
+
+  it("renders grace period state", async () => {
+    mockGetSubscriptionHealth.mockResolvedValue({ ...HEALTHY, within_grace: true });
+    render(<SubscriptionHealthWidget userKey="GUSER" />);
+    await waitFor(() => {
+      expect(screen.getByText(/Subscription is in its grace period/)).toBeInTheDocument();
+    });
+  });
+
+  it("shows simulate_charge readout when enabled", async () => {
+    mockSimulateCharge.mockResolvedValue("InsufficientAllowance" satisfies ChargeSimResult);
+    render(<SubscriptionHealthWidget userKey="GUSER" showSimulateCharge />);
+    await waitFor(() => {
+      expect(screen.getByTestId("simulate-charge-readout")).toHaveTextContent(
+        "Allowance is too low for the next charge"
+      );
+    });
+    expect(screen.getByTestId("simulate-charge-readout")).toHaveAttribute(
+      "data-sim-result",
+      "InsufficientAllowance"
+    );
+  });
+
+  it("does not fetch simulate_charge unless requested", async () => {
+    render(<SubscriptionHealthWidget userKey="GUSER" />);
+    await waitFor(() => {
+      expect(screen.getByTestId("subscription-health-status")).toBeInTheDocument();
+    });
+    expect(mockSimulateCharge).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("simulate-charge-readout")).not.toBeInTheDocument();
+  });
+
+  it("shows unavailable message when health fails to load", async () => {
+    mockGetSubscriptionHealth.mockResolvedValue(null);
+    render(<SubscriptionHealthWidget userKey="GUSER" />);
+    await waitFor(() => {
+      expect(screen.getByTestId("subscription-health-unavailable")).toBeInTheDocument();
+    });
+  });
+
+  it("notifies parent when health loads", async () => {
+    const onHealthChange = vi.fn();
+    render(<SubscriptionHealthWidget userKey="GUSER" onHealthChange={onHealthChange} />);
+    await waitFor(() => {
+      expect(onHealthChange).toHaveBeenCalledWith(HEALTHY);
+    });
+  });
+});

--- a/frontend/src/__tests__/stellar.test.ts
+++ b/frontend/src/__tests__/stellar.test.ts
@@ -15,7 +15,20 @@ vi.mock("@stellar/stellar-sdk/rpc", () => {
 });
 
 // Import the implementation AFTER the mock block is securely established
-import { fetchEvents, getChargeHistory, server } from "../stellar";
+import {
+  chargeSimBlocksPay,
+  chargeSimIsRisky,
+  decodeChargeSimResult,
+  fetchEvents,
+  getChargeHistory,
+  isSubscriptionHealthy,
+  normalizeSubscriptionHealth,
+  payBlockedReason,
+  payWarningReason,
+  server,
+  subscriptionHasWarnings,
+  subscriptionHealthBlocksPay,
+} from "../stellar";
 
 const getEventsMock = server.getEvents as ReturnType<typeof vi.fn>;
 
@@ -529,5 +542,71 @@ describe("rpcCache — dedupedCall deduplication & TTL", () => {
     const result = await dedupedCall("test:reject", fn);
     expect(callCount).toBe(2);
     expect(result).toBe("ok");
+  });
+});
+
+describe("subscription health helpers", () => {
+  const healthy = {
+    active: true,
+    charge_due: false,
+    within_grace: false,
+    has_sufficient_allowance: true,
+    is_paused: false,
+    trial_active: false,
+    daily_limit_set: false,
+  };
+
+  it("treats a fully healthy subscription as healthy", () => {
+    expect(isSubscriptionHealthy(healthy)).toBe(true);
+    expect(subscriptionHasWarnings(healthy)).toBe(false);
+    expect(subscriptionHealthBlocksPay(healthy)).toBe(false);
+    expect(payBlockedReason(healthy, "WouldSucceed")).toBeNull();
+    expect(payWarningReason(healthy, "WouldSucceed")).toBeNull();
+  });
+
+  it("flags paused and inactive as blocking pay", () => {
+    expect(subscriptionHealthBlocksPay({ ...healthy, is_paused: true })).toBe(true);
+    expect(subscriptionHealthBlocksPay({ ...healthy, active: false })).toBe(true);
+    expect(chargeSimBlocksPay("SubscriptionPaused")).toBe(true);
+    expect(chargeSimBlocksPay("WouldSucceed")).toBe(false);
+  });
+
+  it("warns on insufficient allowance and grace without blocking pay", () => {
+    expect(subscriptionHealthBlocksPay({ ...healthy, has_sufficient_allowance: false })).toBe(
+      false
+    );
+    expect(payWarningReason({ ...healthy, has_sufficient_allowance: false }, null)).toMatch(
+      /allowance is insufficient/i
+    );
+    expect(payWarningReason({ ...healthy, within_grace: true }, null)).toMatch(/grace period/i);
+    expect(chargeSimIsRisky("InsufficientAllowance")).toBe(true);
+    expect(chargeSimIsRisky("NotDue")).toBe(false);
+  });
+
+  it("decodes ChargeSimResult from a symbol or vec-wrapped symbol", () => {
+    const asSymbol = nativeToScVal("WouldSucceed", { type: "symbol" });
+    expect(decodeChargeSimResult(asSymbol)).toBe("WouldSucceed");
+
+    const asVec = nativeToScVal(["GracePeriodElapsed"], { type: "symbol" });
+    expect(decodeChargeSimResult(asVec)).toBe("GracePeriodElapsed");
+
+    expect(decodeChargeSimResult(nativeToScVal("NotAVariant", { type: "symbol" }))).toBeNull();
+  });
+
+  it("normalizes partial health maps onto contract fields", () => {
+    expect(
+      normalizeSubscriptionHealth({
+        has_sufficient_allowance: true,
+        is_paused: true,
+      })
+    ).toEqual({
+      active: false,
+      charge_due: false,
+      within_grace: false,
+      has_sufficient_allowance: true,
+      is_paused: true,
+      trial_active: false,
+      daily_limit_set: false,
+    });
   });
 });

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -1,5 +1,13 @@
 import React, { useState, useRef, useCallback, lazy, Suspense } from "react";
-import { buildPayPerUseTx } from "../stellar";
+import {
+  buildPayPerUseTx,
+  ChargeSimResult,
+  chargeSimBlocksPay,
+  payBlockedReason,
+  payWarningReason,
+  subscriptionHealthBlocksPay,
+  SubscriptionHealth,
+} from "../stellar";
 import { friendlyError } from "../utils/errors";
 import SubscriptionCard from "./SubscriptionCard";
 import SubscriptionCardSkeleton from "./Skeleton";
@@ -49,6 +57,8 @@ export default function Dashboard({
   const { status: rpcStatus, latencyMs: rpcLatency, error: rpcError } = useRpcHealth();
   const { isMobile } = useResponsive();
   const ppuTx = useTransaction();
+  const [subHealth, setSubHealth] = useState<SubscriptionHealth | null>(null);
+  const [simResult, setSimResult] = useState<ChargeSimResult | null>(null);
   const [showDailyLimit, setShowDailyLimit] = useState(false);
   const [showIncreaseAllowance, setShowIncreaseAllowance] = useState(false);
   const [allowanceRefresh, setAllowanceRefresh] = useState(0);
@@ -138,6 +148,9 @@ export default function Dashboard({
             onSign={onSign}
             onRefresh={refresh}
             onCancelled={onCancelled}
+            showSimulateCharge={sub.active}
+            onHealthChange={setSubHealth}
+            onSimulateResult={setSimResult}
           />
 
           {sub.active && (
@@ -209,6 +222,9 @@ export default function Dashboard({
                 onPay={handlePayPerUse}
                 loading={ppuPending}
                 isPaused={isPaused}
+                disabled={subscriptionHealthBlocksPay(subHealth) || chargeSimBlocksPay(simResult)}
+                disabledReason={payBlockedReason(subHealth, simResult) ?? undefined}
+                warningReason={payWarningReason(subHealth, simResult) ?? undefined}
               />
               {ppuPending && (
                 <p className="status-text status-text--pending">Confirming payment…</p>
@@ -217,7 +233,9 @@ export default function Dashboard({
                 error={ppuTx.error}
                 onIncreaseAllowance={() => setShowIncreaseAllowance(true)}
                 onViewDailyLimit={() => setShowDailyLimit(true)}
-                dailyLimit={sub.amount} // We don't have exactly the daily limit fetched, but could be fetched or omitted.
+                dailyLimit={sub.amount}
+                health={subHealth}
+                simulateResult={simResult}
               />
               <ReferralPanel publicKey={userKey} />
             </>

--- a/frontend/src/components/ErrorRecovery.tsx
+++ b/frontend/src/components/ErrorRecovery.tsx
@@ -1,11 +1,36 @@
 import React from "react";
 import { friendlyError } from "../utils/errors";
+import {
+  CHARGE_SIM_LABELS,
+  ChargeSimResult,
+  chargeSimIsRisky,
+  payBlockedReason,
+  payWarningReason,
+  SubscriptionHealth,
+  subscriptionHasWarnings,
+} from "../stellar";
 
 interface ErrorRecoveryProps {
   error: string | null;
   onIncreaseAllowance?: () => void;
   onViewDailyLimit?: () => void;
   dailyLimit?: string;
+  health?: SubscriptionHealth | null;
+  simulateResult?: ChargeSimResult | null;
+}
+
+function healthGuidanceMessage(
+  health: SubscriptionHealth | null | undefined,
+  simulateResult: ChargeSimResult | null | undefined
+): string | null {
+  const blocked = payBlockedReason(health ?? null, simulateResult ?? null);
+  if (blocked) return blocked;
+  const warning = payWarningReason(health ?? null, simulateResult ?? null);
+  if (warning) return warning;
+  if (simulateResult && chargeSimIsRisky(simulateResult)) {
+    return CHARGE_SIM_LABELS[simulateResult];
+  }
+  return null;
 }
 
 export default function ErrorRecovery({
@@ -13,16 +38,43 @@ export default function ErrorRecovery({
   onIncreaseAllowance,
   onViewDailyLimit,
   dailyLimit,
+  health,
+  simulateResult,
 }: ErrorRecoveryProps) {
-  if (!error) return null;
+  const healthMessage = healthGuidanceMessage(health, simulateResult);
+  if (!error && !healthMessage) return null;
 
-  const raw = error.toLowerCase();
+  const raw = (error ?? "").toLowerCase();
+  const allowanceIssue =
+    raw.includes("insufficientallowance") ||
+    raw.includes("insufficient allowance") ||
+    (health != null && !health.has_sufficient_allowance) ||
+    simulateResult === "InsufficientAllowance";
+  const pausedIssue =
+    raw.includes("subscriptionpaused") ||
+    raw.includes("subscription is paused") ||
+    health?.is_paused === true ||
+    simulateResult === "SubscriptionPaused";
+  const graceIssue =
+    raw.includes("graceperiodelapsed") ||
+    raw.includes("grace period") ||
+    health?.within_grace === true ||
+    simulateResult === "GracePeriodElapsed";
+  const dailyLimitIssue =
+    raw.includes("dailylimitexceeded") || raw.includes("daily limit exceeded");
+  const merchantFrozen = raw.includes("merchantfrozen") || raw.includes("merchant is frozen");
+  const contractPaused =
+    raw.includes("contractpaused") ||
+    raw.includes("contract is paused") ||
+    simulateResult === "ContractPaused";
 
-  let message = friendlyError(error);
+  let message = error ? friendlyError(error) : (healthMessage as string);
   let action: React.ReactNode = null;
 
-  if (raw.includes("insufficientallowance") || raw.includes("insufficient allowance")) {
-    message = "Your token allowance is too low to complete this charge.";
+  if (allowanceIssue) {
+    message = error
+      ? "Your token allowance is too low to complete this charge."
+      : (healthMessage as string);
     if (onIncreaseAllowance) {
       action = (
         <button className="btn-primary" onClick={onIncreaseAllowance}>
@@ -30,7 +82,7 @@ export default function ErrorRecovery({
         </button>
       );
     }
-  } else if (raw.includes("dailylimitexceeded") || raw.includes("daily limit exceeded")) {
+  } else if (dailyLimitIssue) {
     message = `You have exceeded your daily spending limit${dailyLimit ? ` of ${dailyLimit}` : ""}. It resets in 24 hours.`;
     if (onViewDailyLimit) {
       action = (
@@ -39,12 +91,19 @@ export default function ErrorRecovery({
         </button>
       );
     }
-  } else if (raw.includes("merchantfrozen") || raw.includes("merchant is frozen")) {
+  } else if (pausedIssue) {
+    message = error
+      ? "Subscription is paused. Resume it before paying or charging."
+      : (healthMessage as string);
+  } else if (graceIssue) {
+    message = error
+      ? "The grace period for this subscription has elapsed or is active. Recurring charges may fail."
+      : (healthMessage as string);
+  } else if (merchantFrozen) {
     message = "Merchant is suspended. Contact support.";
-  } else if (raw.includes("contractpaused") || raw.includes("contract is paused")) {
+  } else if (contractPaused) {
     message = "Protocol is paused for maintenance. Try again later.";
-  } else if (message === error) {
-    // Unknown error
+  } else if (error && message === error) {
     message = `Contract Error: ${error}`;
     action = (
       <a
@@ -59,10 +118,20 @@ export default function ErrorRecovery({
     );
   }
 
+  const isProactive = !error && !!healthMessage;
+  const showBecauseUnhealthy =
+    isProactive &&
+    ((health != null && subscriptionHasWarnings(health)) ||
+      chargeSimIsRisky(simulateResult ?? null));
+
+  if (!error && !showBecauseUnhealthy && !healthMessage) return null;
+
   return (
     <div
       className="network-warning"
       role="alert"
+      data-testid="error-recovery"
+      data-proactive={isProactive ? "true" : "false"}
       style={{
         background: "var(--color-danger-bg)",
         color: "var(--color-danger-text)",

--- a/frontend/src/components/PayPerUseForm.tsx
+++ b/frontend/src/components/PayPerUseForm.tsx
@@ -8,6 +8,9 @@ interface PayPerUseFormProps {
   onPay: (amount: bigint) => Promise<void>;
   loading: boolean;
   isPaused?: boolean;
+  disabled?: boolean;
+  disabledReason?: string;
+  warningReason?: string;
 }
 
 function validate(raw: string): { stroops: bigint | null; error: string | null } {
@@ -30,7 +33,7 @@ function validate(raw: string): { stroops: bigint | null; error: string | null }
 }
 
 const PayPerUseForm = forwardRef<HTMLInputElement, PayPerUseFormProps>(
-  ({ onPay, loading, isPaused = false }, ref) => {
+  ({ onPay, loading, isPaused = false, disabled = false, disabledReason, warningReason }, ref) => {
     const [amount, setAmount] = useState("");
     const [error, setError] = useState<string | null>(null);
     const [lastValue, setLastValue] = useState(amount);
@@ -64,14 +67,22 @@ const PayPerUseForm = forwardRef<HTMLInputElement, PayPerUseFormProps>(
       return validateStroopAmount(amount, CONTRACT_LIMITS.MAX_PAY_PER_USE_AMOUNT);
     }, [amount]);
 
+    const payDisabled = loading || isPaused || disabled;
+
     async function handleSubmit() {
-      if (!validationResult.valid) return;
+      if (!validationResult.valid || payDisabled) return;
       const stroops = BigInt(Math.round(parseFloat(amount) * 10_000_000));
       await onPay(stroops);
       setAmount("");
       setError(null);
       setConvertedStroops(null);
     }
+
+    const payAriaLabel = disabled
+      ? "Pay now (unavailable — subscription is unhealthy)"
+      : isPaused
+        ? "Pay now (unavailable during maintenance)"
+        : undefined;
 
     return (
       <div className="card">
@@ -87,7 +98,7 @@ const PayPerUseForm = forwardRef<HTMLInputElement, PayPerUseFormProps>(
               value={amount}
               onChange={(e) => setAmount(e.target.value)}
               onBlur={handleBlur}
-              disabled={loading || isPaused}
+              disabled={payDisabled}
               style={{ width: "100%" }}
             />
             {error && <span className="text-error">{error}</span>}
@@ -97,13 +108,23 @@ const PayPerUseForm = forwardRef<HTMLInputElement, PayPerUseFormProps>(
           </div>
           <button
             onClick={handleSubmit}
-            disabled={!validationResult.valid || loading || isPaused}
+            disabled={!validationResult.valid || payDisabled}
             className="btn-primary ppu-card__pay-btn"
-            aria-label={isPaused ? "Pay now (unavailable during maintenance)" : undefined}
+            aria-label={payAriaLabel}
           >
             {loading ? <Spinner size="sm" /> : "Pay now"}
           </button>
         </div>
+        {disabled && disabledReason && (
+          <p className="text-error" data-testid="ppu-blocked-reason" role="status">
+            {disabledReason}
+          </p>
+        )}
+        {!disabled && warningReason && (
+          <p className="text-sm text-muted" data-testid="ppu-warning-reason" role="status">
+            {warningReason}
+          </p>
+        )}
         {validationResult.error && <span className="text-error">{validationResult.error}</span>}
       </div>
     );

--- a/frontend/src/components/SubscriptionCard.tsx
+++ b/frontend/src/components/SubscriptionCard.tsx
@@ -23,7 +23,15 @@ import ErrorRecovery from "./ErrorRecovery";
 import SubscriptionHealthWidget from "./SubscriptionHealthWidget";
 import { Subscription } from "../types";
 import { BILLING_INTERVALS } from "../constants";
-import { getAllowance, getTrialEnd, buildCancelTx } from "../stellar";
+import {
+  ChargeSimResult,
+  getAllowance,
+  getTrialEnd,
+  buildCancelTx,
+  isSubscriptionHealthy,
+  subscriptionHasWarnings,
+  SubscriptionHealth,
+} from "../stellar";
 import { useSubscriptionSync } from "../hooks/useSubscriptionSync";
 import { usePauseResume } from "../hooks/usePauseResume";
 import { useRegisterShortcuts } from "../context/ShortcutRegistry";
@@ -41,6 +49,9 @@ interface SubscriptionCardProps {
   onSign: (xdr: string) => Promise<string>;
   onRefresh: () => void;
   onCancelled?: () => void;
+  showSimulateCharge?: boolean;
+  onHealthChange?: (health: SubscriptionHealth | null) => void;
+  onSimulateResult?: (result: ChargeSimResult | null) => void;
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -194,6 +205,9 @@ export default function SubscriptionCard({
   onSign,
   onRefresh,
   onCancelled,
+  showSimulateCharge = false,
+  onHealthChange,
+  onSimulateResult,
 }: SubscriptionCardProps) {
   const { merchant, amount, interval, last_charged, active, paused } = subscription;
   const { mutate } = useSubscriptionSync(userKey);
@@ -321,6 +335,16 @@ export default function SubscriptionCard({
 
   const isInTrial = trialEndTimestamp !== null && trialEndTimestamp > Math.floor(Date.now() / 1000);
 
+  const [subHealth, setSubHealth] = useState<SubscriptionHealth | null>(null);
+
+  const handleHealthChange = (next: SubscriptionHealth | null) => {
+    setSubHealth(next);
+    onHealthChange?.(next);
+  };
+
+  const healthUnhealthy = subHealth != null && subscriptionHasWarnings(subHealth);
+  const healthBlocksActions = subHealth != null && !isSubscriptionHealthy(subHealth);
+
   return (
     <div className={`card${isMobile ? " card--mobile" : ""}`}>
       <div className="subscription-card__header">
@@ -378,16 +402,34 @@ export default function SubscriptionCard({
         </div>
       </div>
 
+      {active && healthUnhealthy && (
+        <p
+          className="text-sm"
+          data-testid="health-action-warning"
+          role="status"
+          style={{ color: "var(--color-danger-text)", marginBottom: "var(--space-3)" }}
+        >
+          {healthBlocksActions
+            ? "Subscription is unhealthy. Pause and cancel remain available; pay and charge may fail."
+            : "Subscription needs attention before the next charge."}
+        </p>
+      )}
+
       <div className="subscription-card__actions">
         {active && !paused && (
           <>
-            <button onClick={() => setShowPauseConfirm(true)} className="btn-secondary pause-btn">
+            <button
+              onClick={() => setShowPauseConfirm(true)}
+              className="btn-secondary pause-btn"
+              title={healthUnhealthy ? "Subscription needs attention" : undefined}
+            >
               Pause
             </button>
             <button
               onClick={() => setShowCancelConfirm(true)}
               className="btn-danger cancel-btn"
               aria-label="Cancel subscription"
+              title={healthUnhealthy ? "Subscription needs attention" : undefined}
             >
               Cancel
             </button>
@@ -473,8 +515,15 @@ export default function SubscriptionCard({
         />
       )}
 
-      {/* Subscription Health Widget */}
-      <SubscriptionHealthWidget userKey={userKey} />
+      {/* Subscription Health Widget — only for active subscriptions */}
+      {active && (
+        <SubscriptionHealthWidget
+          userKey={userKey}
+          showSimulateCharge={showSimulateCharge}
+          onHealthChange={handleHealthChange}
+          onSimulateResult={onSimulateResult}
+        />
+      )}
 
       {(derivedPauseStatus || cancelStatus) && (
         <p
@@ -494,6 +543,12 @@ export default function SubscriptionCard({
         <ErrorRecovery
           error={
             derivedPauseStatus.startsWith("Error") ? pauseTx.error || resumeTx.error : cancelStatus
+          }
+          health={subHealth}
+          onIncreaseAllowance={
+            subHealth && !subHealth.has_sufficient_allowance
+              ? () => setShowAllowanceModal(true)
+              : undefined
           }
         />
       )}

--- a/frontend/src/components/SubscriptionHealthWidget.tsx
+++ b/frontend/src/components/SubscriptionHealthWidget.tsx
@@ -1,14 +1,38 @@
-import React, { useEffect, useState } from "react";
-import { getSubscriptionHealth, SubscriptionHealth } from "../stellar";
+import React, { useEffect, useRef, useState } from "react";
+import {
+  CHARGE_SIM_LABELS,
+  ChargeSimResult,
+  getSubscriptionHealth,
+  isSubscriptionHealthy,
+  simulateCharge,
+  subscriptionHasWarnings,
+  SubscriptionHealth,
+} from "../stellar";
 
 interface SubscriptionHealthWidgetProps {
   userKey: string;
+  /** When true, also dry-run `simulate_charge` and show the outcome. */
+  showSimulateCharge?: boolean;
+  onHealthChange?: (health: SubscriptionHealth | null) => void;
+  onSimulateResult?: (result: ChargeSimResult | null) => void;
 }
 
-export default function SubscriptionHealthWidget({ userKey }: SubscriptionHealthWidgetProps) {
+export default function SubscriptionHealthWidget({
+  userKey,
+  showSimulateCharge = false,
+  onHealthChange,
+  onSimulateResult,
+}: SubscriptionHealthWidgetProps) {
   const [health, setHealth] = useState<SubscriptionHealth | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
+  const [simResult, setSimResult] = useState<ChargeSimResult | null>(null);
+  const [simLoading, setSimLoading] = useState(false);
+
+  const onHealthChangeRef = useRef(onHealthChange);
+  onHealthChangeRef.current = onHealthChange;
+  const onSimulateResultRef = useRef(onSimulateResult);
+  onSimulateResultRef.current = onSimulateResult;
 
   useEffect(() => {
     let mounted = true;
@@ -19,25 +43,68 @@ export default function SubscriptionHealthWidget({ userKey }: SubscriptionHealth
         if (mounted) {
           setHealth(data);
           setError(!data);
+          onHealthChangeRef.current?.(data);
         }
       } catch {
-        if (mounted) setError(true);
+        if (mounted) {
+          setError(true);
+          setHealth(null);
+          onHealthChangeRef.current?.(null);
+        }
       } finally {
         if (mounted) setLoading(false);
       }
     };
 
     fetchHealth();
-    const intervalId = setInterval(fetchHealth, 30000); // Poll every 30s
+    const intervalId = setInterval(fetchHealth, 30000);
     return () => {
       mounted = false;
       clearInterval(intervalId);
     };
   }, [userKey]);
 
+  useEffect(() => {
+    if (!showSimulateCharge) {
+      setSimResult(null);
+      onSimulateResultRef.current?.(null);
+      return;
+    }
+
+    let mounted = true;
+    const fetchSim = async () => {
+      try {
+        setSimLoading(true);
+        const result = await simulateCharge(userKey);
+        if (mounted) {
+          setSimResult(result);
+          onSimulateResultRef.current?.(result);
+        }
+      } catch {
+        if (mounted) {
+          setSimResult(null);
+          onSimulateResultRef.current?.(null);
+        }
+      } finally {
+        if (mounted) setSimLoading(false);
+      }
+    };
+
+    fetchSim();
+    const intervalId = setInterval(fetchSim, 30000);
+    return () => {
+      mounted = false;
+      clearInterval(intervalId);
+    };
+  }, [userKey, showSimulateCharge]);
+
   if (loading && !health) {
     return (
-      <div className="card" style={{ padding: "var(--space-3)", marginBottom: "var(--space-4)" }}>
+      <div
+        className="card"
+        data-testid="subscription-health-loading"
+        style={{ padding: "var(--space-3)", marginBottom: "var(--space-4)" }}
+      >
         <div style={{ display: "flex", gap: "var(--space-2)" }}>
           <div
             className="skeleton-block"
@@ -49,13 +116,29 @@ export default function SubscriptionHealthWidget({ userKey }: SubscriptionHealth
     );
   }
 
-  if (error || !health) return null;
+  if (error || !health) {
+    return (
+      <div
+        className="card"
+        data-testid="subscription-health-unavailable"
+        style={{ padding: "var(--space-3)", marginBottom: "var(--space-4)" }}
+      >
+        <p style={{ margin: 0, fontSize: "0.875rem", color: "var(--color-text-muted)" }}>
+          Unable to load subscription health.
+        </p>
+      </div>
+    );
+  }
 
-  const isHealthy = health.charged_up && health.allowance_ok && !health.paused;
+  const healthy = isSubscriptionHealthy(health);
+  const needsAttention = subscriptionHasWarnings(health);
+  const simRisky = simResult && simResult !== "WouldSucceed" && simResult !== "NotDue";
 
   return (
     <div
-      className={`card ${isHealthy ? "status-active" : "status-danger"}`}
+      className={`card ${healthy && !needsAttention ? "status-active" : "status-danger"}`}
+      data-testid="subscription-health-widget"
+      data-healthy={healthy && !needsAttention ? "true" : "false"}
       style={{
         padding: "var(--space-3)",
         marginBottom: "var(--space-4)",
@@ -65,12 +148,15 @@ export default function SubscriptionHealthWidget({ userKey }: SubscriptionHealth
       }}
     >
       <div style={{ display: "flex", alignItems: "center", gap: "var(--space-2)" }}>
-        <span style={{ fontSize: "1.2rem" }}>{isHealthy ? "✅" : "⚠️"}</span>
-        <h4 style={{ margin: 0 }}>Subscription Health: {isHealthy ? "Good" : "Needs Attention"}</h4>
+        <span style={{ fontSize: "1.2rem" }}>{healthy && !needsAttention ? "✅" : "⚠️"}</span>
+        <h4 style={{ margin: 0 }} data-testid="subscription-health-status">
+          Subscription Health: {healthy && !needsAttention ? "Good" : "Needs Attention"}
+        </h4>
       </div>
 
-      {!isHealthy && (
+      {needsAttention && (
         <ul
+          data-testid="subscription-health-issues"
           style={{
             margin: 0,
             paddingLeft: "var(--space-5)",
@@ -78,16 +164,40 @@ export default function SubscriptionHealthWidget({ userKey }: SubscriptionHealth
             color: "var(--color-text-muted)",
           }}
         >
-          {!health.charged_up && <li>Balance is too low for the next charge.</li>}
-          {!health.allowance_ok && <li>Token allowance is insufficient.</li>}
-          {health.paused && <li>Subscription is currently paused.</li>}
+          {!health.active && <li>Subscription is inactive.</li>}
+          {!health.has_sufficient_allowance && <li>Token allowance is insufficient.</li>}
+          {health.is_paused && <li>Subscription is currently paused.</li>}
+          {health.within_grace && <li>Subscription is in its grace period.</li>}
           {health.charge_due && <li>A payment is currently due.</li>}
         </ul>
       )}
 
-      {health.trial_active && isHealthy && (
+      {health.trial_active && healthy && !needsAttention && (
         <p style={{ margin: 0, fontSize: "0.875rem", color: "var(--color-text-muted)" }}>
           Currently in trial period.
+        </p>
+      )}
+
+      {showSimulateCharge && simLoading && !simResult && (
+        <p
+          data-testid="simulate-charge-loading"
+          style={{ margin: 0, fontSize: "0.875rem", color: "var(--color-text-muted)" }}
+        >
+          Checking next charge…
+        </p>
+      )}
+
+      {showSimulateCharge && simResult && (
+        <p
+          data-testid="simulate-charge-readout"
+          data-sim-result={simResult}
+          style={{
+            margin: 0,
+            fontSize: "0.875rem",
+            color: simRisky ? "var(--color-danger-text)" : "var(--color-text-muted)",
+          }}
+        >
+          Charge simulation: {CHARGE_SIM_LABELS[simResult]}
         </p>
       )}
     </div>

--- a/frontend/src/stellar.ts
+++ b/frontend/src/stellar.ts
@@ -410,12 +410,141 @@ export async function getSubscriptionMetadata(user: string): Promise<string | nu
   }
 }
 
+/** Mirrors contract `SubscriptionHealth` from `get_subscription_health`. */
 export interface SubscriptionHealth {
-  charged_up: boolean;
-  allowance_ok: boolean;
-  trial_active: boolean;
-  paused: boolean;
+  active: boolean;
   charge_due: boolean;
+  within_grace: boolean;
+  has_sufficient_allowance: boolean;
+  is_paused: boolean;
+  trial_active: boolean;
+  daily_limit_set: boolean;
+}
+
+export const CHARGE_SIM_RESULTS = [
+  "WouldSucceed",
+  "NotDue",
+  "Inactive",
+  "InsufficientAllowance",
+  "GracePeriodElapsed",
+  "ContractPaused",
+  "SubscriptionPaused",
+] as const;
+
+export type ChargeSimResult = (typeof CHARGE_SIM_RESULTS)[number];
+
+export const CHARGE_SIM_LABELS: Record<ChargeSimResult, string> = {
+  WouldSucceed: "Next charge would succeed",
+  NotDue: "Next charge is not due yet",
+  Inactive: "No active subscription to charge",
+  InsufficientAllowance: "Allowance is too low for the next charge",
+  GracePeriodElapsed: "Grace period has elapsed — recurring charge would fail",
+  ContractPaused: "Protocol is paused",
+  SubscriptionPaused: "Subscription is paused — charge would fail",
+};
+
+export function normalizeSubscriptionHealth(
+  raw: Partial<SubscriptionHealth> | null | undefined
+): SubscriptionHealth | null {
+  if (!raw) return null;
+  return {
+    active: !!raw.active,
+    charge_due: !!raw.charge_due,
+    within_grace: !!raw.within_grace,
+    has_sufficient_allowance: !!raw.has_sufficient_allowance,
+    is_paused: !!raw.is_paused,
+    trial_active: !!raw.trial_active,
+    daily_limit_set: !!raw.daily_limit_set,
+  };
+}
+
+export function isSubscriptionHealthy(health: SubscriptionHealth): boolean {
+  return health.active && health.has_sufficient_allowance && !health.is_paused;
+}
+
+export function subscriptionHasWarnings(health: SubscriptionHealth): boolean {
+  return !isSubscriptionHealthy(health) || health.within_grace || health.charge_due;
+}
+
+/** States that would make pay-per-use fail on-chain. */
+export function subscriptionHealthBlocksPay(health: SubscriptionHealth | null): boolean {
+  if (!health) return false;
+  return !health.active || health.is_paused;
+}
+
+export function chargeSimIsRisky(result: ChargeSimResult | null): boolean {
+  return (
+    result === "InsufficientAllowance" ||
+    result === "GracePeriodElapsed" ||
+    result === "ContractPaused" ||
+    result === "SubscriptionPaused" ||
+    result === "Inactive"
+  );
+}
+
+export function chargeSimBlocksPay(result: ChargeSimResult | null): boolean {
+  return result === "ContractPaused" || result === "SubscriptionPaused" || result === "Inactive";
+}
+
+export function payBlockedReason(
+  health: SubscriptionHealth | null,
+  sim: ChargeSimResult | null
+): string | null {
+  if (health?.is_paused || sim === "SubscriptionPaused") {
+    return "Pay-per-use is unavailable while the subscription is paused. Resume first.";
+  }
+  if ((health && !health.active) || sim === "Inactive") {
+    return "Pay-per-use requires an active subscription.";
+  }
+  if (sim === "ContractPaused") {
+    return "Pay-per-use is unavailable while the protocol is paused.";
+  }
+  return null;
+}
+
+export function payWarningReason(
+  health: SubscriptionHealth | null,
+  sim: ChargeSimResult | null
+): string | null {
+  if (payBlockedReason(health, sim)) return null;
+  if ((health && !health.has_sufficient_allowance) || sim === "InsufficientAllowance") {
+    return "Token allowance is insufficient. Increase allowance before paying or the charge may fail.";
+  }
+  if (health?.within_grace) {
+    return "Subscription is in its grace period. Recurring charge is overdue.";
+  }
+  if (sim === "GracePeriodElapsed") {
+    return "Grace period has elapsed. Recurring charge would fail until the subscription is repaired.";
+  }
+  if (health?.charge_due) {
+    return "A recurring charge is currently due.";
+  }
+  return null;
+}
+
+/** Decode a unit `ChargeSimResult` enum (symbol or vec-wrapped symbol). */
+export function decodeChargeSimResult(
+  retval: xdr.ScVal | null | undefined
+): ChargeSimResult | null {
+  if (!retval) return null;
+  try {
+    const type = retval.switch().name;
+    let name: string | null = null;
+    if (type === "scvSymbol") {
+      name = retval.sym().toString();
+    } else if (type === "scvVec") {
+      const vec = retval.vec() ?? [];
+      if (vec.length > 0 && vec[0].switch().name === "scvSymbol") {
+        name = vec[0].sym().toString();
+      }
+    }
+    if (name && (CHARGE_SIM_RESULTS as readonly string[]).includes(name)) {
+      return name as ChargeSimResult;
+    }
+    return null;
+  } catch {
+    return null;
+  }
 }
 
 export function getSubscriptionHealth(user: string): Promise<SubscriptionHealth | null> {
@@ -438,13 +567,43 @@ export function getSubscriptionHealth(user: string): Promise<SubscriptionHealth 
       const retval = (result as { result?: { retval?: xdr.ScVal } }).result?.retval;
       if (!retval || retval.switch().name === "scvVoid") return null;
 
-      return ScValDecoder.decodeStruct(retval, {
-        charged_up: ScValDecoder.decodeBool,
-        allowance_ok: ScValDecoder.decodeBool,
-        trial_active: ScValDecoder.decodeBool,
-        paused: ScValDecoder.decodeBool,
-        charge_due: ScValDecoder.decodeBool,
-      });
+      return normalizeSubscriptionHealth(
+        ScValDecoder.decodeStruct(retval, {
+          active: ScValDecoder.decodeBool,
+          charge_due: ScValDecoder.decodeBool,
+          within_grace: ScValDecoder.decodeBool,
+          has_sufficient_allowance: ScValDecoder.decodeBool,
+          is_paused: ScValDecoder.decodeBool,
+          trial_active: ScValDecoder.decodeBool,
+          daily_limit_set: ScValDecoder.decodeBool,
+        })
+      );
+    } catch {
+      return null;
+    }
+  });
+}
+
+/** Dry-run of on-chain `simulate_charge` — no storage writes or transfers. */
+export function simulateCharge(user: string): Promise<ChargeSimResult | null> {
+  return dedupedCall(`simulateCharge:${user}`, async () => {
+    try {
+      const contract = new Contract(CONTRACT_ID);
+      const account = await server.getAccount(user);
+
+      const tx = new TransactionBuilder(account, {
+        fee: BASE_FEE,
+        networkPassphrase: NETWORK_PASSPHRASE,
+      })
+        .addOperation(contract.call("simulate_charge", addressVal(user)))
+        .setTimeout(30)
+        .build();
+
+      const result = await server.simulateTransaction(tx);
+      if ("error" in result) throw new Error((result as { error: string }).error);
+
+      const retval = (result as { result?: { retval?: xdr.ScVal } }).result?.retval;
+      return decodeChargeSimResult(retval);
     } catch {
       return null;
     }


### PR DESCRIPTION
## Summary
- Align `get_subscription_health` with the on-chain `SubscriptionHealth` fields and add a `simulate_charge` wrapper so the dashboard can dry-run the next recurring charge.
- Surface health (allowance, grace, pause, charge-due) on active subscriptions, warn or disable pay-per-use when those states are risky, and show ErrorRecovery tips (including Increase Allowance) from the detected state.
- Preserve existing pay/pause/cancel behavior for healthy subscriptions.

Closes #844

## Tests
- Vitest: SubscriptionCard, Dashboard, SubscriptionHealthWidget, ErrorRecovery, and stellar helper suites (125 passing).
- `npx tsc --noEmit` and `npm run build` in `frontend`.
- `npm run lint` (no errors).

## Test plan
- [ ] Open an active healthy subscription: health widget shows Good, simulate_charge readout is non-blocking, pay-per-use stays enabled.
- [ ] Paused subscription: pay-per-use is disabled with a resume hint; pause/cancel remain available.
- [ ] Insufficient allowance / grace: health lists the issue, pay-per-use shows a warning, ErrorRecovery offers Increase Allowance.
- [ ] Loading and RPC-failure health states render without breaking the rest of the card.


Made with [Cursor](https://cursor.com)