### PR TITLE
spec: Add fee bounds validation bugfix spec

### DIFF
--- a/.kiro/specs/fee-bounds-validation/.config.kiro
+++ b/.kiro/specs/fee-bounds-validation/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "41600ee0-92ff-4ffd-8652-3c1504d17275", "workflowType": "requirements-first", "specType": "bugfix"}

--- a/.kiro/specs/fee-bounds-validation/bugfix.md
+++ b/.kiro/specs/fee-bounds-validation/bugfix.md
@@ -1,0 +1,55 @@
+# Bugfix Requirements: Fee Bounds Validation
+
+## Introduction
+
+The PayFlow protocol currently lacks governance guardrails for fee proposals. While `set_fee_bounds` is intended to establish MinFeeBps and MaxFeeBps constraints, the `propose_fee` function does not validate proposals against these bounds, allowing admins to bypass governance controls and propose arbitrary fee values. This bugfix ensures that `propose_fee` rejects out-of-bounds proposals with a typed error before storing the pending fee, while preserving all other contract behavior.
+
+## Bug Analysis
+
+### Current Behavior (Defect)
+
+1.1 WHEN an admin proposes a fee with bps < MinFeeBps (when bounds are set) THEN the system accepts the proposal without validation and stores it as a pending fee
+
+1.2 WHEN an admin proposes a fee with bps > MaxFeeBps (when bounds are set) THEN the system accepts the proposal without validation and stores it as a pending fee
+
+1.3 WHEN MinFeeBps is equal to MaxFeeBps THEN the system accepts any proposal matching that value, but also accepts proposals outside this exact value without rejection
+
+1.4 WHEN MinFeeBps and MaxFeeBps bounds have been set to specific values (e.g., 50 and 200) THEN a proposal of bps = 25 (below minimum) is stored as pending without error
+
+1.5 WHEN MinFeeBps and MaxFeeBps bounds have been set to specific values (e.g., 50 and 200) THEN a proposal of bps = 250 (above maximum) is stored as pending without error
+
+### Expected Behavior (Correct)
+
+2.1 WHEN an admin proposes a fee with bps < MinFeeBps (when bounds are set) THEN the system SHALL reject the proposal with a typed ContractError (OutOfBoundsFee or similar) and NOT store the pending fee
+
+2.2 WHEN an admin proposes a fee with bps > MaxFeeBps (when bounds are set) THEN the system SHALL reject the proposal with a typed ContractError (OutOfBoundsFee or similar) and NOT store the pending fee
+
+2.3 WHEN MinFeeBps is equal to MaxFeeBps THEN the system SHALL accept only proposals matching that exact value and reject all others with a typed error
+
+2.4 WHEN MinFeeBps and MaxFeeBps bounds have been set to specific values (e.g., 50 and 200) THEN a proposal of bps = 50 (at minimum boundary) SHALL succeed and be stored as pending
+
+2.5 WHEN MinFeeBps and MaxFeeBps bounds have been set to specific values (e.g., 50 and 200) THEN a proposal of bps = 200 (at maximum boundary) SHALL succeed and be stored as pending
+
+2.6 WHEN MinFeeBps and MaxFeeBps bounds have been set to specific values (e.g., 50 and 200) THEN a proposal of bps = 125 (between min and max) SHALL succeed and be stored as pending
+
+2.7 WHEN an admin proposes a fee with bps < MinFeeBps THEN the system SHALL return a typed ContractError (not a panic)
+
+2.8 WHEN an admin proposes a fee with bps > MaxFeeBps THEN the system SHALL return a typed ContractError (not a panic)
+
+### Unchanged Behavior (Regression Prevention)
+
+3.1 WHEN bps > 10_000 is proposed (absolute maximum) THEN the system SHALL CONTINUE TO reject with InvalidFeeBps error regardless of bounds settings
+
+3.2 WHEN bounds are unset (defaults: MinFeeBps=0, MaxFeeBps=10_000) THEN the system SHALL CONTINUE TO accept any proposal with 0 <= bps <= 10_000
+
+3.3 WHEN a valid pending fee exists and commit_fee is called THEN the system SHALL CONTINUE TO successfully commit the fee without changes
+
+3.4 WHEN get_fee is called THEN the system SHALL CONTINUE TO return the committed fee (collector, bps) or None if unset
+
+3.5 WHEN a non-admin calls propose_fee THEN the system SHALL CONTINUE TO reject with admin authorization error
+
+3.6 WHEN propose_fee is called with a self-collector (user == collector) THEN the system SHALL CONTINUE TO reject (if this validation exists in current code)
+
+3.7 WHEN charging a subscription with a committed fee THEN the system SHALL CONTINUE TO calculate and deduct fees correctly
+
+3.8 WHEN paying per use with a committed fee THEN the system SHALL CONTINUE TO calculate and deduct fees correctly

--- a/.kiro/specs/fee-bounds-validation/design.md
+++ b/.kiro/specs/fee-bounds-validation/design.md
@@ -1,0 +1,242 @@
+# Fee Bounds Validation Bugfix Design
+
+## Overview
+
+The PayFlow protocol currently allows admins to bypass fee governance controls by proposing fee values outside established bounds. The `propose_fee` function accepts any bps value between 0 and 10,000 without validating against MinFeeBps and MaxFeeBps constraints. This design implements bounds validation in `propose_fee` to reject out-of-bounds proposals with a typed error before storing the pending fee. The fix is minimal and targeted, preserving all existing fee calculation, commit, and charge logic.
+
+## Glossary
+
+- **Bug_Condition (C)**: A fee proposal is made where `bps` is outside the established bounds (bps < MinFeeBps OR bps > MaxFeeBps)
+- **Property (P)**: When the bug condition holds, the proposal is rejected with a typed `OutOfBoundsFee` error and no pending fee is stored
+- **Preservation**: Existing behavior for in-bounds proposals, unset bounds, absolute maximum validation (bps > 10_000), fee calculation, and commitment logic remains unchanged
+- **propose_fee**: Function in `contract/src/fee.rs` that stores a pending fee proposal in temporary storage for later commitment
+- **MinFeeBps**: The lower bound for allowed fee proposals, stored in instance storage (defaults to 0 if unset)
+- **MaxFeeBps**: The upper bound for allowed fee proposals, stored in instance storage (defaults to 10_000 if unset)
+- **Pending fee**: A proposed fee collector address and bps value stored in temporary storage, not yet active until committed
+
+## Bug Details
+
+### Bug Condition
+
+The bug manifests when an admin calls `propose_fee` with a bps value that falls outside the established MinFeeBps and MaxFeeBps bounds. The `propose_fee` function accepts and stores the out-of-bounds proposal without validation, allowing governance controls to be bypassed. The function only checks if `bps > 10_000` (absolute maximum), but does not validate against the configured bounds.
+
+**Formal Specification:**
+```
+FUNCTION isBugCondition(input)
+  INPUT: input.bps (u32), MinFeeBps (u32), MaxFeeBps (u32)
+  OUTPUT: boolean
+  
+  RETURN (input.bps < MinFeeBps OR input.bps > MaxFeeBps)
+         AND input.bps <= 10_000
+         AND (MinFeeBps OR MaxFeeBps has been set via set_fee_bounds)
+END FUNCTION
+```
+
+### Examples
+
+1. **Below-minimum proposal**: MinFeeBps=50, MaxFeeBps=200, admin proposes bps=25
+   - Current behavior: Proposal accepted, stored as pending fee
+   - Expected behavior: Proposal rejected with OutOfBoundsFee error
+
+2. **Above-maximum proposal**: MinFeeBps=50, MaxFeeBps=200, admin proposes bps=250
+   - Current behavior: Proposal accepted, stored as pending fee
+   - Expected behavior: Proposal rejected with OutOfBoundsFee error
+
+3. **Exact boundary (minimum)**: MinFeeBps=50, MaxFeeBps=200, admin proposes bps=50
+   - Current behavior: Proposal accepted
+   - Expected behavior: Proposal accepted (boundary is inclusive)
+
+4. **Exact boundary (maximum)**: MinFeeBps=50, MaxFeeBps=200, admin proposes bps=200
+   - Current behavior: Proposal accepted
+   - Expected behavior: Proposal accepted (boundary is inclusive)
+
+5. **Within bounds**: MinFeeBps=50, MaxFeeBps=200, admin proposes bps=125
+   - Current behavior: Proposal accepted
+   - Expected behavior: Proposal accepted
+
+6. **Unset bounds (default)**: No bounds set, admin proposes bps=500
+   - Current behavior: Proposal accepted
+   - Expected behavior: Proposal accepted (defaults: MinFeeBps=0, MaxFeeBps=10_000)
+
+7. **Exceeds absolute maximum**: MinFeeBps=0, MaxFeeBps=10_000, admin proposes bps=10_001
+   - Current behavior: Rejected with InvalidFeeBps
+   - Expected behavior: Rejected with InvalidFeeBps (existing validation preserved)
+
+## Expected Behavior
+
+### Preservation Requirements
+
+**Unchanged Behaviors:**
+- Proposals with bps > 10_000 continue to be rejected with InvalidFeeBps error
+- When bounds are unset, defaults (MinFeeBps=0, MaxFeeBps=10_000) apply
+- Valid pending fees continue to be committed successfully via commit_fee
+- Fee calculation during charge and pay_per_use continues to work correctly
+- Non-admin callers continue to be rejected with admin authorization error
+- get_fee continues to return the committed fee (collector, bps) or None if unset
+
+**Scope:**
+All inputs that do NOT involve out-of-bounds proposals (relative to MinFeeBps and MaxFeeBps) should be completely unaffected by this fix. This includes:
+- In-bounds proposals that pass validation
+- Commitment of valid pending fees
+- Fee calculations during payments
+- Admin authorization checks
+- Absolute maximum validation (bps > 10_000)
+
+## Hypothesized Root Cause
+
+Based on the bug description and requirements, the most likely issues are:
+
+1. **Missing Bounds Validation**: The `propose_fee` function only validates against the absolute maximum (10_000) but does not fetch or validate against MinFeeBps and MaxFeeBps storage keys
+
+2. **No Access to Bounds Storage**: Helper functions to retrieve MinFeeBps and MaxFeeBps from instance storage may not exist, requiring new functions to be added
+
+3. **Missing Error Variant**: The `ContractError` enum may not have an `OutOfBoundsFee` variant to represent bounds violations
+
+4. **Validation Placement**: The bounds check needs to be placed after admin authorization but before storing the pending fee to ensure no partial state changes
+
+## Correctness Properties
+
+Property 1: Bug Condition - Fee Proposal Bounds Validation
+
+_For any_ fee proposal where the bps is outside the established bounds (bps < MinFeeBps OR bps > MaxFeeBps), and bps <= 10_000, the fixed propose_fee function SHALL reject the proposal with a typed OutOfBoundsFee error and NOT store the pending fee.
+
+**Validates: Requirements 2.1, 2.2, 2.3, 2.7, 2.8**
+
+Property 2: Preservation - Valid Proposal Acceptance and Unset Bounds Handling
+
+_For any_ fee proposal where the bps is within bounds (MinFeeBps <= bps <= MaxFeeBps), OR when bounds are unset (defaults apply: 0 <= bps <= 10_000), the fixed propose_fee function SHALL succeed, store the pending fee, and preserve all existing behavior including absolute maximum validation and admin authorization.
+
+**Validates: Requirements 3.1, 3.2, 3.3, 3.4, 3.5**
+
+## Fix Implementation
+
+### Changes Required
+
+Assuming our root cause analysis is correct:
+
+**File 1: `contract/src/errors.rs`**
+
+**Change Category 1 - Add OutOfBoundsFee Error Variant**:
+- Add new `OutOfBoundsFee` variant to the `ContractError` enum
+- Error code should be assigned from the next available slot
+- Error message: "Fee proposal is outside the configured bounds"
+
+**File 2: `contract/src/lib.rs`**
+
+**Change Category 2 - Add Storage Keys for Bounds**:
+- Add `MinFeeBps` to the `DataKey` enum (instance storage)
+- Add `MaxFeeBps` to the `DataKey` enum (instance storage)
+
+**File 3: `contract/src/fee.rs`**
+
+**Change Category 3 - Add Helper Functions for Bounds**:
+- Add `get_min_fee_bps(env: &Env) -> u32` function that retrieves MinFeeBps from instance storage, defaults to 0 if unset
+- Add `get_max_fee_bps(env: &Env) -> u32` function that retrieves MaxFeeBps from instance storage, defaults to 10_000 if unset
+
+**Change Category 4 - Implement Bounds Validation in propose_fee**:
+- After admin authorization check, retrieve MinFeeBps and MaxFeeBps
+- Validate: `bps >= MinFeeBps AND bps <= MaxFeeBps`
+- If validation fails, panic with `ContractError::OutOfBoundsFee` (before storing pending fee)
+- Preserve existing `bps > 10_000` check (order: bounds check after admin auth, before other operations)
+
+**Change Category 5 - Optional: Add Setter Functions**:
+- Add `set_fee_bounds(env: &Env, min_bps: u32, max_bps: u32)` function to allow admin to configure bounds
+- Requires admin authorization
+- Add corresponding events: `publish_fee_bounds_set(env, min_bps, max_bps)`
+- Store in instance storage at `DataKey::MinFeeBps` and `DataKey::MaxFeeBps`
+
+**File 4: `contract/src/lib.rs` (FlowPayClient interface)**
+
+**Change Category 6 - Add Contract Methods**:
+- Add `set_fee_bounds(min_bps: u32, max_bps: u32)` as a public contract method
+- Add `get_fee_bounds() -> (u32, u32)` as a public contract method to retrieve current bounds
+
+## Testing Strategy
+
+### Validation Approach
+
+The testing strategy follows a two-phase approach: first, surface counterexamples that demonstrate the bug on unfixed code, then verify the fix works correctly and preserves existing behavior.
+
+### Exploratory Bug Condition Checking
+
+**Goal**: Surface counterexamples that demonstrate the bug BEFORE implementing the fix. Confirm or refute the root cause analysis. If we refute, we will need to re-hypothesize.
+
+**Test Plan**: Write tests that set fee bounds, then attempt to propose fees both inside and outside those bounds. Run these tests on the UNFIXED code to observe that out-of-bounds proposals are currently accepted. Observe failures to demonstrate the bug exists.
+
+**Test Cases**:
+1. **Below-Minimum Test**: Set bounds (50, 200), propose bps=25, observe that it's accepted on unfixed code (will fail on unfixed code - this is the bug)
+2. **Above-Maximum Test**: Set bounds (50, 200), propose bps=250, observe that it's accepted on unfixed code (will fail on unfixed code - this is the bug)
+3. **Exact Min Boundary Test**: Set bounds (50, 200), propose bps=50, observe acceptance (should pass on unfixed code)
+4. **Exact Max Boundary Test**: Set bounds (50, 200), propose bps=200, observe acceptance (should pass on unfixed code)
+5. **In-Range Test**: Set bounds (50, 200), propose bps=125, observe acceptance (should pass on unfixed code)
+
+**Expected Counterexamples**:
+- Out-of-bounds proposals (bps < min or bps > max) are accepted when they should be rejected
+- No error is returned for out-of-bounds proposals
+- The buggy behavior allows governance controls to be bypassed
+
+### Fix Checking
+
+**Goal**: Verify that for all inputs where the bug condition holds, the fixed function produces the expected behavior.
+
+**Pseudocode:**
+```
+FOR ALL (min_bps, max_bps, proposed_bps) WHERE isBugCondition(proposed_bps) DO
+  result := propose_fee_fixed(min_bps, max_bps, proposed_bps)
+  ASSERT result == OutOfBoundsFee error
+  ASSERT NO pending fee was stored
+END FOR
+```
+
+### Preservation Checking
+
+**Goal**: Verify that for all inputs where the bug condition does NOT hold, the fixed function produces the same result as the original function.
+
+**Pseudocode:**
+```
+FOR ALL (min_bps, max_bps, proposed_bps) WHERE NOT isBugCondition(proposed_bps) DO
+  ASSERT propose_fee_original(min_bps, max_bps, proposed_bps) 
+         == propose_fee_fixed(min_bps, max_bps, proposed_bps)
+END FOR
+```
+
+**Testing Approach**: Property-based testing is recommended for preservation checking because:
+- It generates many combinations of bounds and proposal values automatically
+- It catches edge cases (exact boundaries, unset bounds, default values) that manual tests might miss
+- It provides strong guarantees that in-bounds behavior is unchanged for all valid inputs
+
+**Test Plan**: Observe behavior on UNFIXED code for in-bounds proposals, then write property-based tests to verify this continues after the fix.
+
+**Test Cases**:
+1. **In-Bounds Acceptance**: Verify that proposals within bounds (MinFeeBps <= bps <= MaxFeeBps) continue to succeed and store pending fee
+2. **Unset Bounds Defaulting**: Verify that when bounds are unset, defaults (0, 10_000) apply and in-range proposals succeed
+3. **Absolute Maximum Validation**: Verify that bps > 10_000 continues to be rejected with InvalidFeeBps regardless of bounds
+4. **Admin Authorization Preservation**: Verify that non-admin calls continue to be rejected
+5. **Commitment Preservation**: Verify that valid pending fees can still be committed via commit_fee
+6. **Fee Calculation Preservation**: Verify that committed fees are still applied correctly to charges and pay_per_use
+
+### Unit Tests
+
+- Test bounds retrieval (get_min_fee_bps, get_max_fee_bps) with unset values returning defaults
+- Test out-of-bounds proposal rejection for each bound violation case
+- Test in-bounds proposal acceptance for boundary and mid-range values
+- Test that absolute maximum validation (bps > 10_000) still works
+- Test that InvalidFeeBps error is returned for bps > 10_000, not OutOfBoundsFee
+- Test set_fee_bounds function (if implemented) to verify bounds are stored correctly
+
+### Property-Based Tests
+
+- Generate random bounds (min_bps, max_bps) where min_bps <= max_bps <= 10_000
+- Generate random proposal values across the full range [0, 10_001]
+- Verify that proposals are accepted iff they fall within the bounds
+- Verify that out-of-bounds rejections produce OutOfBoundsFee error
+- Verify that in-bounds proposals produce the same behavior as original code
+- Test with unset bounds to ensure defaults apply correctly
+
+### Integration Tests
+
+- Test the full fee governance flow: set bounds → propose valid fee → commit → verify fee is active
+- Test the full fee governance flow with rejection: set bounds → propose invalid fee → verify rejection → verify no state change
+- Test that after rejecting an out-of-bounds proposal, the next valid proposal can be accepted
+- Test boundary cases: min=max (exact value only), min=0 (any value up to max), max=10_000 (any value from min)
+- Test that existing pending fees work correctly after bounds are set

--- a/.kiro/specs/fee-bounds-validation/tasks.md
+++ b/.kiro/specs/fee-bounds-validation/tasks.md
@@ -1,0 +1,186 @@
+# Implementation Plan: Fee Bounds Validation
+
+## Phase 1: Exploration - Demonstrate the Bug
+
+- [ ] 1. Write bug condition exploration test
+  - **Property 1: Bug Condition** - Fee Proposal Bounds Validation
+  - **CRITICAL**: This test MUST FAIL on unfixed code - failure confirms the bug exists
+  - **DO NOT attempt to fix the test or the code when it fails**
+  - **NOTE**: This test encodes the expected behavior - it will validate the fix when it passes after implementation
+  - **GOAL**: Surface counterexamples that demonstrate the bug exists (out-of-bounds proposals are accepted when they should be rejected)
+  - **Scoped PBT Approach**: For deterministic bugs, scope the property to concrete failing case(s) to ensure reproducibility
+  - Test that when bounds are set (e.g., MinFeeBps=50, MaxFeeBps=200), proposals outside these bounds (bps < 50 or bps > 200) are rejected with OutOfBoundsFee error (not accepted as currently happens)
+  - Test implementation details from Bug Condition in design: `(bps < MinFeeBps OR bps > MaxFeeBps) AND bps <= 10_000 AND bounds set`
+  - The test assertions should match the Expected Behavior Properties from design: "rejected with OutOfBoundsFee and NO pending fee stored"
+  - Run test on UNFIXED code
+  - **EXPECTED OUTCOME**: Test FAILS (this is correct - it proves the bug exists)
+  - Document counterexamples found to understand root cause (e.g., "propose_fee(50, 200, 25) currently accepted, should be rejected")
+  - Mark task complete when test is written, run, and failure is documented
+  - _Requirements: 2.1, 2.2, 2.7, 2.8_
+
+## Phase 2: Preservation - Establish Baseline Behavior
+
+- [ ] 2. Write preservation property tests (BEFORE implementing fix)
+  - **Property 2: Preservation** - Valid Fee Proposal Acceptance and In-Bounds Behavior
+  - **IMPORTANT**: Follow observation-first methodology
+  - Observe: When bounds are unset or when bps is within bounds (MinFeeBps <= bps <= MaxFeeBps), current code accepts and stores pending fee
+  - Observe: bps > 10_000 currently rejected with InvalidFeeBps; bps in-range currently accepted
+  - Write property-based tests capturing these observed behavior patterns:
+    - In-bounds proposals succeed: for all (min, max, bps) where min <= bps <= max, proposal succeeds and pending fee is stored
+    - Unset bounds default correctly: when bounds are unset, (0 <= bps <= 10_000) proposals succeed
+    - Absolute maximum validation preserved: bps > 10_000 rejected with InvalidFeeBps
+    - Admin authorization preserved: non-admin calls rejected before any storage changes
+    - Boundary cases work: exact min and exact max values accepted
+  - Property-based testing generates many test cases for stronger guarantees
+  - Run tests on UNFIXED code
+  - **EXPECTED OUTCOME**: Tests PASS (this confirms baseline behavior to preserve)
+  - Mark task complete when tests are written, run, and passing on unfixed code
+  - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5_
+
+## Phase 3: Implementation
+
+- [ ] 3. Fix for Fee Bounds Validation
+
+  - [ ] 3.1 Add OutOfBoundsFee error variant to ContractError enum
+    - Edit `contract/src/errors.rs`
+    - Add new `OutOfBoundsFee` variant to `ContractError` enum with next available error code (approximately 24 or next gap)
+    - Use error message: "Returned when a fee proposal is outside the configured bounds"
+    - Maintain alphabetical or logical ordering of error variants
+    - _Bug_Condition: isBugCondition(input) = (bps < MinFeeBps OR bps > MaxFeeBps) AND bps <= 10_000_
+    - _Expected_Behavior: Reject out-of-bounds proposals with typed OutOfBoundsFee error_
+    - _Preservation: Existing error codes unchanged, InvalidFeeBps still used for bps > 10_000_
+    - _Requirements: 2.1, 2.2, 2.7, 2.8_
+
+  - [ ] 3.2 Add MinFeeBps and MaxFeeBps storage keys to DataKey enum
+    - Edit `contract/src/lib.rs`
+    - Locate the `DataKey` enum (contracttype)
+    - Add `MinFeeBps` variant for instance storage of minimum fee bound (u32)
+    - Add `MaxFeeBps` variant for instance storage of maximum fee bound (u32)
+    - Add entries in comment section with the fee-related keys
+    - _Bug_Condition: Bounds storage keys needed to validate against stored constraints_
+    - _Expected_Behavior: Keys exist and persist fee bounds in instance storage_
+    - _Preservation: Existing DataKey variants unchanged_
+    - _Requirements: 2.1, 2.2, 2.3_
+
+  - [ ] 3.3 Implement get_min_fee_bps() and get_max_fee_bps() helper functions
+    - Edit `contract/src/fee.rs`
+    - Add `get_min_fee_bps(env: &Env) -> u32` function
+      - Retrieve from instance storage at DataKey::MinFeeBps
+      - Default to 0 if unset (allowing any non-negative bps)
+    - Add `get_max_fee_bps(env: &Env) -> u32` function
+      - Retrieve from instance storage at DataKey::MaxFeeBps
+      - Default to 10_000 if unset (preserving absolute maximum)
+    - Place these functions near existing fee helpers (get_fee_bps, get_fee_collector)
+    - _Bug_Condition: Functions needed to retrieve bounds from storage_
+    - _Expected_Behavior: Bounds retrieved with correct defaults_
+    - _Preservation: No impact on other functions_
+    - _Requirements: 2.1, 2.2_
+
+  - [ ] 3.4 Implement bounds validation in propose_fee function
+    - Edit `contract/src/fee.rs` in the `propose_fee` function
+    - Order of validation (critical for correct error reporting):
+      1. Check admin authorization (require_admin - existing)
+      2. Retrieve min_bps and max_bps using new helper functions
+      3. Validate: `bps >= min_bps AND bps <= max_bps`
+      4. If validation fails, panic with ContractError::OutOfBoundsFee (BEFORE storing pending fee)
+      5. Check if bps > 10_000 and panic with InvalidFeeBps (existing check)
+      6. Store pending fee, emit event, extend TTL (existing logic)
+    - Bounds check happens AFTER admin auth but BEFORE storing pending fee
+    - No pending fee is stored when bounds validation fails
+    - _Bug_Condition: isBugCondition(input) = (bps < MinFeeBps OR bps > MaxFeeBps) AND bps <= 10_000_
+    - _Expected_Behavior: expectedBehavior(result) = OutOfBoundsFee error && NO pending fee stored_
+    - _Preservation: In-bounds proposals stored, absolute max validation preserved, admin auth preserved_
+    - _Requirements: 2.1, 2.2, 2.7, 2.8, 3.1, 3.3, 3.5_
+
+  - [ ] 3.5 Add set_fee_bounds() governance function
+    - Edit `contract/src/fee.rs`
+    - Add `set_fee_bounds(env: &Env, min_bps: u32, max_bps: u32)` function
+      - Require admin authorization (admin::require_admin)
+      - Validate that min_bps <= max_bps (panic if invalid)
+      - Validate that max_bps <= 10_000 (panic if exceeds absolute maximum)
+      - Store min_bps at DataKey::MinFeeBps in instance storage
+      - Store max_bps at DataKey::MaxFeeBps in instance storage
+      - Extend TTL for both storage keys
+      - Call `crate::events::publish_fee_bounds_set(env, min_bps, max_bps)` to emit event
+    - _Bug_Condition: Admin must be able to establish bounds_
+    - _Expected_Behavior: Bounds stored securely in instance storage_
+    - _Preservation: No impact on other functions_
+    - _Requirements: 2.1, 2.2, 2.3_
+
+  - [ ] 3.6 Add get_fee_bounds() query function
+    - Edit `contract/src/fee.rs`
+    - Add `get_fee_bounds(env: &Env) -> (u32, u32)` function
+      - Retrieve min_bps and max_bps using helper functions (which provide defaults)
+      - Return tuple (min_bps, max_bps)
+    - _Bug_Condition: Admin needs to verify bounds are set correctly_
+    - _Expected_Behavior: Bounds returned with defaults if unset_
+    - _Preservation: Query-only, no impact on other functions_
+    - _Requirements: 2.3_
+
+  - [ ] 3.7 Add contract interface methods in lib.rs
+    - Edit `contract/src/lib.rs` in the `FlowPayClient` impl block
+    - Add public method `set_fee_bounds(env: Env, min_bps: u32, max_bps: u32)`
+      - Call admin::require_admin(&env)
+      - Call fee::set_fee_bounds(&env, min_bps, max_bps)
+      - Emit event
+    - Add public method `get_fee_bounds(env: Env) -> (u32, u32)`
+      - Call fee::get_fee_bounds(&env)
+      - Return current bounds (with defaults if unset)
+    - Place these near existing fee-related methods (propose_fee, commit_fee, get_fee)
+    - _Bug_Condition: Contract interface needed to set and query bounds_
+    - _Expected_Behavior: Methods available and properly routed to fee module_
+    - _Preservation: Existing fee methods unchanged_
+    - _Requirements: 2.1, 2.2, 2.3_
+
+  - [ ] 3.8 Add fee_bounds_set event to events module
+    - Edit `contract/src/events.rs`
+    - Add `publish_fee_bounds_set(env: &Env, min_bps: u32, max_bps: u32)` function
+      - Emit event with topic: "fee_bounds_set"
+      - Include min_bps and max_bps in event data
+      - Follow existing fee event pattern
+    - _Bug_Condition: Event published when bounds are updated_
+    - _Expected_Behavior: Bounds changes tracked in blockchain history_
+    - _Preservation: Existing events unchanged_
+    - _Requirements: 2.1, 2.2, 2.3_
+
+  - [ ] 3.9 Verify bug condition exploration test now passes
+    - **Property 1: Expected Behavior** - Fee Proposal Bounds Validation
+    - **IMPORTANT**: Re-run the SAME test from task 1 - do NOT write a new test
+    - The test from task 1 encodes the expected behavior
+    - When this test passes, it confirms the expected behavior is satisfied
+    - Run the bug condition exploration test from step 1
+    - **EXPECTED OUTCOME**: Test PASSES (confirms bug is fixed)
+    - Verify that out-of-bounds proposals are now rejected with OutOfBoundsFee error
+    - Verify that no pending fee is stored for out-of-bounds proposals
+    - _Requirements: Expected Behavior Properties: 2.1, 2.2, 2.7, 2.8_
+
+  - [ ] 3.10 Verify preservation tests still pass
+    - **Property 2: Preservation** - Valid Fee Proposal Acceptance and In-Bounds Behavior
+    - **IMPORTANT**: Re-run the SAME tests from task 2 - do NOT write new tests
+    - Run preservation property tests from step 2
+    - **EXPECTED OUTCOME**: Tests PASS (confirms no regressions)
+    - Verify in-bounds proposals still succeed and store pending fee
+    - Verify unset bounds defaults work correctly (0 to 10_000)
+    - Verify absolute maximum validation (bps > 10_000) still rejects with InvalidFeeBps
+    - Verify admin authorization still enforced
+    - Verify boundary cases (exact min and max) still accepted
+    - Confirm all tests still pass after fix (no regressions)
+    - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5_
+
+## Phase 4: Checkpoint & Validation
+
+- [ ] 4. Checkpoint - Ensure all tests pass and code compiles
+  - Run `cargo build --release --target wasm32-unknown-unknown` in contract directory
+    - Verify no compilation errors
+    - Verify no warnings that affect correctness
+  - Run `cargo test` to execute full test suite
+    - Verify all existing tests pass (no regressions)
+    - Verify bug condition test passes (confirms bug is fixed)
+    - Verify preservation tests pass (confirms no regressions)
+  - Verify error codes documented (check docs/ERROR-CODES.md if it exists)
+    - If ERROR-CODES.md exists, add entry for OutOfBoundsFee with code number and description
+  - Ensure all storage keys are properly used (MinFeeBps, MaxFeeBps)
+  - Confirm no panics for non-error conditions
+  - Mark complete when all tests pass and code compiles without errors
+  - _Requirements: 2.1, 2.2, 2.3, 2.7, 2.8, 3.1, 3.2, 3.3, 3.4, 3.5_
+


### PR DESCRIPTION

closes #799 
- Add bugfix requirements document (bugfix.md)
- Add technical design with implementation approach (design.md)
- Add implementation task list with 4 phases (tasks.md)

This spec defines the bugfix for the issue where admins can propose fees outside the configured MinFeeBps/MaxFeeBps bounds, bypassing governance controls.

The implementation will add bounds validation to propose_fee, reject out-of-bounds proposals with a typed OutOfBoundsFee error, and preserve all existing behavior for in-bounds proposals and fee calculations.

Acceptance criteria:
- Out-of-bounds proposals fail with typed error
- Boundary values are accepted
- Commit still works for valid pending fees
- Tests prove set_fee_bounds constrains propose_fee