### PR TITLE
spec: Add global volume check ordering bugfix spec

### DIFF
--- a/.kiro/specs/global-volume-check-ordering/.config.kiro
+++ b/.kiro/specs/global-volume-check-ordering/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "41600ee0-92ff-4ffd-8652-3c1504d17275", "workflowType": "requirements-first", "specType": "bugfix"}

--- a/.kiro/specs/global-volume-check-ordering/bugfix.md
+++ b/.kiro/specs/global-volume-check-ordering/bugfix.md
@@ -1,0 +1,45 @@
+# Bugfix Requirements: Global Volume Check Ordering
+
+## Introduction
+
+The PayFlow contract performs hourly volume capacity checks via `check_and_update_global_volume()` to enforce the `GLOBAL_MAX_VOLUME_PER_HOUR` (50 trillion stroops) limit. Currently, this check runs **AFTER** token transfers in both `charge()` and `pay_per_use()` paths. When the cap is breached, a panic occurs after transfers have already been initiated, violating fail-closed expectations. The fix reorders checks to run **BEFORE** any token transfers, ensuring atomic fail-closed behavior and alignment between simulate/execute paths.
+
+## Bug Analysis
+
+### Current Behavior (Defect)
+
+1.1 WHEN attempting a charge that would exceed the hourly volume cap THEN the system transfers tokens to the merchant before checking the cap, then panics after transfer attempt, resulting in inconsistent state and violated fail-closed expectations
+
+1.2 WHEN attempting a pay-per-use transaction that would exceed the hourly volume cap THEN the system transfers tokens (and protocol fees to the fee collector if applicable) before checking the cap, then panics, leaving partial transfers in-flight
+
+1.3 WHEN the volume cap is breached in `charge()` path THEN the `execute_charge()` function is called even though the transaction fails, causing additional state mutations after cap panic
+
+1.4 WHEN operating at or near the exact hourly capacity THEN transfer attempts may partially commit before cap check rejects them, creating race conditions between cap enforcement and token movement
+
+### Expected Behavior (Correct)
+
+2.1 WHEN attempting a charge that would exceed the hourly volume cap THEN the system SHALL check capacity and reject before any token transfer is initiated, transferring zero tokens and panicking with `GlobalVolumeExceeded`
+
+2.2 WHEN attempting a pay-per-use transaction that would exceed the hourly volume cap THEN the system SHALL check capacity and reject before any token transfer (merchant or fee transfer) is initiated, transferring zero tokens and panicking with `GlobalVolumeExceeded`
+
+2.3 WHEN a charge would exceed the cap THEN the system SHALL NOT call `execute_charge()` and SHALL NOT mutate subscription state, allowing the transaction to fail atomically before any state changes
+
+2.4 WHEN the accumulated volume plus the requested amount exactly equals the cap THEN the system SHALL permit the charge and update volume, accepting it at the boundary
+
+2.5 WHEN the accumulated volume plus the requested amount exceeds the cap by one stroops THEN the system SHALL reject the charge before any transfer and panic with `GlobalVolumeExceeded`
+
+### Unchanged Behavior (Regression Prevention)
+
+3.1 WHEN a charge is within capacity THEN the system SHALL CONTINUE TO transfer the full subscription amount to the merchant and record it in revenue tracking
+
+3.2 WHEN a pay-per-use with protocol fees is within capacity THEN the system SHALL CONTINUE TO transfer fees to the fee collector and the remaining amount to the merchant as before
+
+3.3 WHEN the hourly window boundary is crossed (current_time >= window_start + HOUR_IN_SECONDS) THEN the system SHALL CONTINUE TO reset accumulated_volume to zero and start a new window
+
+3.4 WHEN multiple charges are attempted within the same hour THEN the system SHALL CONTINUE TO accumulate volumes correctly, rejecting only when the cumulative total exceeds the cap
+
+3.5 WHEN a subscription is charged successfully THEN the system SHALL CONTINUE TO update `last_charged`, record charge history, emit events, and maintain all existing side effects
+
+3.6 WHEN a pay-per-use is successful THEN the system SHALL CONTINUE TO record spending limits, merchant revenue, daily limits, and emit events as before
+
+3.7 WHEN the contract is paused THEN the system SHALL CONTINUE TO reject all charge and pay-per-use attempts before any cap check or transfer

--- a/.kiro/specs/global-volume-check-ordering/design.md
+++ b/.kiro/specs/global-volume-check-ordering/design.md
@@ -1,0 +1,332 @@
+# Global Volume Check Ordering - Bugfix Design
+
+## Overview
+
+The PayFlow contract's hourly volume capacity check (`GLOBAL_MAX_VOLUME_PER_HOUR = 50 trillion stroops`) currently runs **AFTER** token transfers in both `charge()` and `pay_per_use()` paths. When the cap is exceeded, transfers have already been initiated before rejection occurs, violating fail-closed semantics and creating inconsistent state.
+
+This design reorders volume checks to execute **BEFORE** any token transfers, ensuring:
+- Atomic fail-closed behavior: volume checks succeed before any state mutation
+- Consistency between simulate and execute paths
+- Clear separation: capacity reserve before transfers, window updates only on success
+
+## Glossary
+
+- **Bug_Condition (C)**: Inputs where token transfers occur before global volume capacity is verified
+- **Property (P)**: Correct behavior when cap is enforced: checks occur atomically before transfers
+- **Preservation**: Existing behavior for transactions within capacity and window rollover logic
+- **check_and_update_global_volume**: Helper function in `contract/src/lib.rs` that verifies and updates `GlobalVolumeWindow` state
+- **charge()**: Function in `contract/src/lib.rs` that triggers recurring subscription charges
+- **pay_per_use()**: Function in `contract/src/lib.rs` that executes immediate one-off payments
+- **batch_charge()**: Function accessed via `contract/src/batch.rs` that charges multiple users
+- **GlobalVolumeWindow**: Storage struct tracking `current_window_start` and `accumulated_volume`
+- **GLOBAL_MAX_VOLUME_PER_HOUR**: Constant = 50 trillion stroops, the hourly cap
+- **HOUR_IN_SECONDS**: Constant = 3600, defines window rollover interval
+- **execute_charge()**: Function in `contract/src/charge_exec.rs` that handles post-transfer bookkeeping
+
+## Bug Details
+
+### Bug Condition
+
+The bug manifests when a user attempts a charge or pay-per-use transaction that would exceed the `GLOBAL_MAX_VOLUME_PER_HOUR` cap. The system is either not correctly checking the cap before transfer initiation, or is allowing token movement to begin before enforcing the constraint.
+
+**Formal Specification:**
+
+```
+FUNCTION isBugCondition(input)
+  INPUT: input of type {transaction_type: "charge" | "pay_per_use", amount: i128}
+  OUTPUT: boolean
+  
+  RETURN current_window_accumulated_volume + input.amount > GLOBAL_MAX_VOLUME_PER_HOUR
+         AND window_hour_boundary_not_crossed
+         AND input.amount > 0
+END FUNCTION
+```
+
+### Examples
+
+**Example 1: Over-cap charge (defective behavior)**
+- Current window accumulated volume: 49.5T stroops
+- User attempts charge: 1T stroops
+- Expected: Reject before transfer, return GlobalVolumeExceeded
+- Actual (defective): transfer_from() called, then panic after payment attempt
+
+**Example 2: Over-cap pay-per-use with fee (defective behavior)**
+- Current window accumulated volume: 49.99T stroops
+- User attempts pay-per-use: 0.2T stroops (with 100 bps fee = 0.002T)
+- Expected: Reject before any transfers, return GlobalVolumeExceeded
+- Actual (defective): fee transfer to collector initiated, then merchant transfer initiated, then panic
+
+**Example 3: Exact capacity boundary (edge case)**
+- Current window accumulated volume: 49.99T stroops
+- User attempts charge: 1.01T stroops (total = 50T exactly)
+- Expected: Permit charge, update volume to 50T
+- Actual (edge case at boundary): Should accept, not reject
+
+**Example 4: Over boundary by one stroops (edge case)**
+- Current window accumulated volume: 49.99T stroops
+- User attempts charge: 1.01000001T stroops (total = 50T + 1 stroops)
+- Expected: Reject before transfer
+- Actual (edge case): Should reject
+
+## Expected Behavior
+
+### Preservation Requirements
+
+**Unchanged Behaviors:**
+
+1. Successful charges within capacity shall continue to transfer the full subscription amount to the merchant
+2. Successful pay-per-use with protocol fees shall continue to transfer fees to collector and remaining amount to merchant
+3. Window rollover at `current_time >= window_start + HOUR_IN_SECONDS` shall continue to reset `accumulated_volume` to 0
+4. Multiple charges within the same hour shall continue to accumulate volumes correctly
+5. Charges within capacity shall continue to update subscription state, record charge history, and emit events
+6. Pay-per-use within capacity shall continue to record daily limits, merchant revenue, and emit events
+7. Contract pause shall continue to reject all charges before cap check or transfer
+
+**Scope:**
+
+All transactions where `new_volume <= GLOBAL_MAX_VOLUME_PER_HOUR` should be completely unaffected by this fix. All window rollover calculations, event emission, revenue tracking, and subscription state updates for successful charges shall remain unchanged.
+
+## Hypothesized Root Cause
+
+Based on the bug description, the most likely issues are:
+
+1. **Incorrect Check Placement**: `check_and_update_global_volume()` is currently called in `charge()` at line 367 AFTER `token.transfer_from()` at line 361-365, and in `pay_per_use()` at line 460 AFTER both fee and merchant transfers. The check should execute before any transfer initiation.
+
+2. **Batch Charge Atomicity**: The `batch_charge()` function in `contract/src/batch.rs` calls `charge_exec::execute_charge()` which performs transfers via `fee::transfer_subscription_charge()`. Volume checks are not applied in the batch path at all, creating vulnerability to cap bypass.
+
+3. **Fee Transfer Isolation**: In `pay_per_use()`, the fee transfer happens separately from the merchant transfer. If the fee transfer succeeds but volume check fails, partial state mutation occurs. The volume check must precede both transfers.
+
+4. **Window Rollover Interleaving**: The `check_and_update_global_volume()` function checks the window boundary and resets if needed. If this reset interleaves with transfers, window state may become inconsistent. The entire check-and-update must be atomic before any transfer.
+
+## Correctness Properties
+
+Property 1: Bug Condition - Global Volume Cap Enforcement Before Transfer
+
+_For any_ transaction where the bug condition holds (accumulated volume + amount would exceed GLOBAL_MAX_VOLUME_PER_HOUR), the fixed charge() and pay_per_use() functions SHALL check the capacity constraint and reject the transaction before any token transfer is initiated, transferring zero tokens and panicking with GlobalVolumeExceeded error.
+
+**Validates: Requirements 2.1, 2.2, 2.3**
+
+Property 2: Preservation - Non-Over-Cap Transactions
+
+_For any_ transaction where the bug condition does NOT hold (accumulated volume + amount <= GLOBAL_MAX_VOLUME_PER_HOUR and window boundary not crossed), the fixed code SHALL produce exactly the same result as the original code for transactions within capacity, including token transfers, state updates, event emission, and all side effects.
+
+**Validates: Requirements 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7**
+
+## Fix Implementation
+
+### Changes Required
+
+Assuming our root cause analysis is correct:
+
+**File**: `contract/src/lib.rs`
+
+**Function**: `charge()` (lines 327-379)
+
+**Specific Changes**:
+
+1. **Move volume check before transfer in charge()**:
+   - After grace period validation (line 354), call `check_and_update_global_volume(&env, sub.amount)` 
+   - Move this to line ~355 (immediately after grace period check, before token client instantiation)
+   - This ensures cap verification before `token.transfer_from()` is called
+   - If cap is exceeded, function panics with GlobalVolumeExceeded before line 360
+
+2. **Reorder charge() execution sequence**:
+   - Current: require_active → execute_charge → check_and_update_global_volume
+   - Desired: require_active → grace_check → check_and_update_global_volume → token.transfer_from → execute_charge
+   - Ensure execute_charge is only called when cap check has succeeded
+
+3. **Move volume check before fee transfer in pay_per_use()**:
+   - After spending_limit enforcement (line 439), call `check_and_update_global_volume(&env, amount)`
+   - Move this to line ~440 (immediately after spending_limit check, before token client instantiation)
+   - This ensures cap verification before fee or merchant transfers
+   - Window must be checked and updated atomically before any fee::transfer_* calls
+
+4. **Ensure batch_charge() applies volume checks**:
+   - Currently `batch_charge()` → `charge_exec::precheck_charge()` → `charge_exec::execute_charge()`
+   - Volume checks are completely bypassed in batch path
+   - Modify `charge_exec::execute_charge()` to accept pre-verified capacity or add pre-check in batch loop
+   - Option A: Add volume check before `execute_charge()` call in `batch.rs` (line 42)
+   - Option B: Move volume check into `execute_charge()` as first operation
+   - Recommended: Option A (pre-check in batch loop) to maintain single check location and fail-closed semantics
+
+### Implementation Details
+
+**In `charge()` function:**
+```
+Line 327: pub fn charge(env: Env, user: Address) {
+  ...
+  Line 354: if grace_period > 0 && now > next + grace_period { ... }
+  
+  NEW: Line 355: check_and_update_global_volume(&env, sub.amount);
+  
+  Line 357 (was 355): let token = token::Client::new(...);
+  Line 358-362: token.transfer_from(...);
+  Line 365 (was 367): REMOVE check_and_update_global_volume(&env, sub.amount);
+  ...
+}
+```
+
+**In `pay_per_use()` function:**
+```
+Line 409: pub fn pay_per_use(env: Env, user: Address, amount: i128) {
+  ...
+  Line 439: spending_limit::enforce_limit(&env, &user, amount);
+  
+  NEW: Line 440: check_and_update_global_volume(&env, amount);
+  
+  Line 442 (was 440): let token = token::Client::new(...);
+  Line 444-458: fee and merchant transfers
+  Line 460 (was 460): REMOVE check_and_update_global_volume(&env, amount);
+  ...
+}
+```
+
+**In `batch.rs` function:**
+```
+Line 29: pub fn batch_charge(env: &Env, users: Vec<Address>) -> Vec<ChargeResult> {
+  ...
+  Line 42: for user in users.iter() {
+    NEW: Add volume check before execute_charge:
+      if let Ok(()) = precheck_charge(...) {
+        check_and_update_global_volume(env, sub.amount); // ADD THIS
+        charge_exec::execute_charge(env, &user, &key, &mut sub, now);
+      }
+  ...
+}
+```
+
+## Testing Strategy
+
+### Validation Approach
+
+The testing strategy follows a three-phase approach:
+1. **Exploratory**: Verify the bug exists on unfixed code by demonstrating over-cap attempts transfer tokens
+2. **Fix Checking**: Verify fixed code rejects over-cap attempts before transfer
+3. **Preservation Checking**: Verify fixed code preserves all existing behavior for within-cap transactions
+
+### Exploratory Bug Condition Checking
+
+**Goal**: Surface counterexamples that demonstrate the bug BEFORE implementing the fix. Confirm or refute the root cause analysis. If we refute, we will need to re-hypothesize.
+
+**Test Plan**: Write tests that simulate transactions at or exceeding the hourly volume cap and assert that over-cap transactions fail after observing transfer attempts on unfixed code.
+
+**Test Cases**:
+
+1. **Single Over-Cap Charge Test**: Set accumulated volume to 49.5T, attempt 1T charge
+   - Unfixed code: transfer_from is called (observable via mock), then panics
+   - Expected counterexample: Transfer initiated before cap rejection
+
+2. **Over-Cap Pay-Per-Use with Fee Test**: Set accumulated volume to 49.99T, attempt 0.2T with 100 bps fee
+   - Unfixed code: fee transfer_from called, then merchant transfer_from called, then panics
+   - Expected counterexample: Fee transfer initiated before cap rejection
+
+3. **Exact Boundary Test**: Set accumulated volume to 49T, attempt 1T charge (total = 50T exactly)
+   - Unfixed code: Should accept (currently panics if check runs after transfer)
+   - Expected counterexample: Either accepts (correct) or rejects after transfer (buggy)
+
+4. **Batch Over-Cap Test**: Set accumulated volume to 49.5T, batch charge multiple users where one exceeds cap
+   - Unfixed code: Batch bypasses volume check entirely, all transfers occur
+   - Expected counterexample: No volume check, all users charged regardless of cap
+
+**Expected Counterexamples**:
+- Token transfers occur via transfer_from before GlobalVolumeExceeded panic
+- Batch charges bypass volume checks entirely
+- Possible causes: Volume check placement after transfers, missing checks in batch path
+
+### Fix Checking
+
+**Goal**: Verify that for all inputs where the bug condition holds, the fixed function produces the expected behavior (rejects before transfer).
+
+**Pseudocode:**
+```
+FOR ALL input WHERE isBugCondition(input) DO
+  result := charge_fixed(input) OR pay_per_use_fixed(input)
+  ASSERT result == GlobalVolumeExceeded
+  ASSERT no token.transfer_from was called
+  ASSERT window.accumulated_volume unchanged
+END FOR
+```
+
+### Preservation Checking
+
+**Goal**: Verify that for all inputs where the bug condition does NOT hold, the fixed function produces the same result as the original function.
+
+**Pseudocode:**
+```
+FOR ALL input WHERE NOT isBugCondition(input) DO
+  original_result := charge_original(input) OR pay_per_use_original(input)
+  fixed_result := charge_fixed(input) OR pay_per_use_fixed(input)
+  ASSERT original_result == fixed_result
+  ASSERT token transfers identical
+  ASSERT window.accumulated_volume identical
+END FOR
+```
+
+**Testing Approach**: Property-based testing is recommended for preservation checking because:
+- It generates many test cases automatically across valid transaction space
+- It catches edge cases near boundaries that manual tests might miss
+- It provides strong guarantees that behavior is unchanged for all non-buggy inputs
+- It can randomize window states and transaction amounts to verify consistency
+
+**Test Plan**: 
+1. Generate random initial window states (various accumulated volumes and window timestamps)
+2. Generate random valid transactions (amounts within cap)
+3. Run both original and fixed implementations
+4. Assert identical outcomes for transfers, state, and events
+5. Run on multiple window rollover scenarios
+
+**Test Cases**:
+
+1. **Within-Cap Charge Preservation**: 
+   - Verify charges below cap continue to transfer exact subscription amounts
+   - Verify last_charged, history, and revenue tracking unchanged
+
+2. **Within-Cap Pay-Per-Use Preservation**: 
+   - Verify pay-per-use below cap continues to transfer fees and merchant amounts correctly
+   - Verify spending limits recorded unchanged
+
+3. **Window Rollover Preservation**: 
+   - Cross window boundary and verify new hour resets accumulated_volume
+   - Multiple transactions spanning boundary all handled correctly
+
+4. **Batch Charge Preservation**: 
+   - Multiple users charged within cap all succeed
+   - Individual failures within batch still recorded correctly
+   - Volume accumulates correctly across batch
+
+5. **Fee Transfer Preservation**: 
+   - Protocol fees calculated and transferred correctly for within-cap pay-per-use
+   - Net amounts to merchant correct
+
+6. **Exact Boundary Acceptance**: 
+   - Transaction bringing accumulated volume to exactly GLOBAL_MAX_VOLUME_PER_HOUR accepts
+   - Transaction bringing it to exactly + 1 stroops rejects
+
+### Unit Tests
+
+- Test volume check with initial window (new hour, volume = 0)
+- Test volume check near window boundary (crossing HOUR_IN_SECONDS)
+- Test volume window reset on hour boundary crossing
+- Test overflow prevention when accumulated_volume + amount overflows
+- Test charge succeeds and persists volume update
+- Test pay-per-use succeeds and persists volume update
+- Test batch processes users and accumulates volumes correctly
+- Test each over-cap scenario rejects without state mutation
+
+### Property-Based Tests
+
+- **Property 1**: For random within-cap transactions, fixed and original implementations produce identical results
+- **Property 2**: For over-cap transactions, fixed implementation rejects before any transfer
+- **Property 3**: Window rollover correctly resets volume across random timestamps
+- **Property 4**: Volume accumulates correctly across sequences of transactions
+- **Property 5**: Batch operations respect accumulated volume across multiple users
+- **Property 6**: Exact capacity boundary (accumulated + amount == cap) accepts; (accumulated + amount > cap) rejects
+
+### Integration Tests
+
+- Full transaction flow: subscribe → charge (within cap) → verify revenue recorded
+- Full transaction flow: pay-per-use (within cap) → verify daily limits and merchant revenue
+- Multiple sequential charges accumulating volume within hour
+- Multiple charges crossing hour boundary with volume reset
+- Batch charge with mixed results (some skip, some charged, all within cap)
+- Batch charge with over-cap user in batch (verify rejection before transfer)

--- a/.kiro/specs/global-volume-check-ordering/tasks.md
+++ b/.kiro/specs/global-volume-check-ordering/tasks.md
@@ -1,0 +1,186 @@
+# Implementation Plan: Global Volume Check Ordering
+
+## Phase 1: Exploration - Bug Condition Testing (BEFORE FIX)
+
+- [ ] 1. Write bug condition exploration test
+  - **Property 1: Bug Condition** - Over-Cap Volume Rejection Atomicity
+  - **CRITICAL**: This test MUST FAIL on unfixed code - failure confirms the bug exists
+  - **DO NOT attempt to fix the test or the code when it fails**
+  - **NOTE**: This test encodes the expected behavior - it will validate the fix when it passes after implementation
+  - **GOAL**: Surface counterexamples that demonstrate over-cap transactions transfer tokens BEFORE cap rejection
+  - **Scoped PBT Approach**: Scope the property to the concrete failing case of amounts exceeding GLOBAL_MAX_VOLUME_PER_HOUR to ensure reproducibility
+  - Test implementation details from Bug Condition in design:
+    - Set accumulated window volume to known values approaching the 50T cap
+    - Attempt charge/pay_per_use amounts that breach the cap
+    - Assert that GlobalVolumeExceeded is returned WITHOUT any token transfers being executed
+    - Verify accumulated_volume remains unchanged when cap is breached
+  - The test assertions should match the Expected Behavior Properties from design (Requirements 2.1, 2.2, 2.3)
+  - Run test on UNFIXED code
+  - **EXPECTED OUTCOME**: Test FAILS with observable token transfers occurring before cap rejection panic (this is correct - it proves the bug exists)
+  - Document counterexamples found to understand root cause:
+    - Over-cap charge: transfers occur then panic with GlobalVolumeExceeded
+    - Over-cap pay-per-use with fee: fee transfer occurs, merchant transfer occurs, then panic
+    - Batch charges: volume checks bypassed entirely, all transfers succeed regardless of cap
+  - Mark task complete when test is written, run, and failure is documented with counterexamples
+  - _Requirements: 2.1, 2.2, 2.3_
+
+- [ ] 2. Write preservation property tests (BEFORE implementing fix)
+  - **Property 2: Preservation** - Within-Cap Transactions Preserve Existing Behavior
+  - **IMPORTANT**: Follow observation-first methodology
+  - Observe behavior on UNFIXED code for non-buggy inputs (transactions within capacity):
+    - Within-cap charges: transfer full subscription amount to merchant, update last_charged, record history, emit event
+    - Within-cap pay-per-use with fees: transfer fees to collector, transfer net to merchant, record daily limits
+    - Window rollover: crossing HOUR_IN_SECONDS boundary resets accumulated_volume to 0
+    - Batch charges: multiple within-cap users all get charged, volumes accumulate correctly
+  - Write property-based tests capturing observed behavior patterns from Preservation Requirements (Requirements 3.1-3.7):
+    - For any within-cap transaction: transfers succeed with correct amounts
+    - For any within-cap charge: subscription state updates (last_charged), charge history recorded
+    - For any within-cap pay-per-use: merchant revenue and daily spend recorded
+    - For any sequence crossing window boundary: accumulated volume resets correctly
+    - For contract pause: all charges/pay-per-use rejected before cap check
+  - Property-based testing generates many test cases for stronger guarantees
+  - Run tests on UNFIXED code
+  - **EXPECTED OUTCOME**: Tests PASS (this confirms baseline behavior to preserve)
+  - Mark task complete when tests are written, run, and passing on unfixed code
+  - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7_
+
+## Phase 2: Implementation - Fix Global Volume Check Ordering
+
+- [ ] 3. Fix for global volume check ordering
+
+  - [ ] 3.1 Move volume check before token transfer in charge()
+    - In `contract/src/lib.rs`, locate `charge()` function (around line 327)
+    - Find grace period validation at line 354: `if grace_period > 0 && now > next + grace_period`
+    - Immediately after grace period check completes (line 354), add: `check_and_update_global_volume(&env, sub.amount);`
+    - This call must occur BEFORE line 361 where `token.transfer_from()` is called
+    - Then remove the duplicate `check_and_update_global_volume(&env, sub.amount);` call that currently appears at line 367 (after the transfer)
+    - Result: cap enforcement atomically occurs before transfer initiation, failing closed
+    - _Bug_Condition: accumulated_volume + sub.amount > GLOBAL_MAX_VOLUME_PER_HOUR_
+    - _Expected_Behavior: check_and_update_global_volume executes before transfer, GlobalVolumeExceeded panic occurs before token movement_
+    - _Preservation: within-cap charges continue with identical transfer amounts, state updates, and event emission_
+    - _Requirements: 2.1, 2.3, 3.1, 3.5_
+
+  - [ ] 3.2 Move volume check before fee/merchant transfers in pay_per_use()
+    - In `contract/src/lib.rs`, locate `pay_per_use()` function (around line 409)
+    - Find spending limit enforcement at line 439: `spending_limit::enforce_limit(&env, &user, amount);`
+    - Immediately after spending limit check completes (line 439), add: `check_and_update_global_volume(&env, amount);`
+    - This call must occur BEFORE line 444 where first token.transfer_from() is called (fee transfer)
+    - This ensures cap is verified before ANY token movement (fee OR merchant transfer)
+    - Then remove the duplicate `check_and_update_global_volume(&env, amount);` call that currently appears at line 460 (after transfers)
+    - Result: cap enforcement atomically precedes both fee and merchant transfers, failing closed
+    - _Bug_Condition: accumulated_volume + amount > GLOBAL_MAX_VOLUME_PER_HOUR_
+    - _Expected_Behavior: check_and_update_global_volume executes before transfers, GlobalVolumeExceeded panic occurs before fee or merchant transfer_
+    - _Preservation: within-cap pay-per-use continues with identical fee and merchant transfers, daily limits, and event emission_
+    - _Requirements: 2.2, 2.3, 3.2, 3.6_
+
+  - [ ] 3.3 Add volume check in batch_charge() path before execute_charge calls
+    - In `contract/src/batch.rs`, locate `batch_charge()` function (around line 26)
+    - Find the charge loop at line 42: `for user in users.iter()`
+    - Inside the loop where `precheck_charge()` succeeds (after line 40 Ok(()) branch)
+    - Before calling `charge_exec::execute_charge()` at line 41, add: `check_and_update_global_volume(env, sub.amount);`
+    - This ensures batch path also validates capacity before execution, preventing cap bypass
+    - If check fails with GlobalVolumeExceeded panic, the batch terminates (fail-closed for that user and remaining batch)
+    - Result: batch operations respect global volume cap across multiple users
+    - _Bug_Condition: batch path bypasses volume checks entirely, allowing multiple users to charge regardless of cap_
+    - _Expected_Behavior: volume check occurs in batch loop before execute_charge, over-cap users fail with GlobalVolumeExceeded_
+    - _Preservation: within-cap batch users continue to charge successfully with volumes accumulating across batch_
+    - _Requirements: 2.1, 2.2, 3.4_
+
+  - [ ] 3.4 Verify atomicity of window check-and-update with transfer operations
+    - Review `check_and_update_global_volume()` implementation to ensure:
+      - Window boundary check occurs atomically with accumulated_volume read
+      - If window boundary crossed, accumulated_volume is reset to 0 AND new window_start is set in same operation
+      - No interleaving between window boundary detection and volume accumulation is possible
+      - Once volume check passes, the updated window state is persisted before any transfer occurs
+    - Confirm `check_and_update_global_volume()` is called in all three paths (charge, pay_per_use, batch_charge) BEFORE transfers
+    - Verify no code path allows token transfer if `check_and_update_global_volume()` panics
+    - _Preservation: window rollover behavior continues to correctly reset volumes at hour boundaries_
+    - _Requirements: 3.3_
+
+  - [ ] 3.5 Ensure GlobalVolumeExceeded error returns to callers and panics consistently
+    - Verify that when `check_and_update_global_volume()` detects over-cap (accumulated + amount > GLOBAL_MAX_VOLUME_PER_HOUR), it panics with `GlobalVolumeExceeded`
+    - Confirm this panic occurs BEFORE any transfers in charge(), pay_per_use(), and batch_charge() paths
+    - This ensures callers receive the GlobalVolumeExceeded error atomically before any state mutation
+    - _Expected_Behavior: GlobalVolumeExceeded panic prevents transaction from proceeding to transfer stage_
+    - _Requirements: 2.1, 2.2, 2.3_
+
+  - [ ] 3.6 Verify no state mutations occur after over-cap rejection
+    - In charge() path: ensure `execute_charge()` is NOT called if volume check fails (fails before that call)
+    - In pay_per_use() path: ensure merchant revenue, spending limits, and events are NOT recorded if volume check fails
+    - In batch_charge() path: ensure subscription state is NOT updated if volume check fails for a user
+    - Confirm that GlobalVolumeExceeded panic short-circuits the entire transaction before post-transfer bookkeeping
+    - _Expected_Behavior: over-cap rejection atomically prevents all state changes_
+    - _Requirements: 2.3_
+
+## Phase 3: Validation - Verify Fix and Preservation
+
+- [ ] 4. Verify bug condition exploration test now passes
+
+  - [ ] 4.1 Re-run bug condition exploration test from Phase 1
+    - **Property 1: Expected Behavior** - Over-Cap Volume Rejection Atomicity (Fixed)
+    - **IMPORTANT**: Re-run the SAME test from task 1 - do NOT write a new test
+    - The test from task 1 encodes the expected behavior - it should now pass
+    - When this test passes, it confirms the expected behavior is satisfied (cap checks precede transfers)
+    - Run bug condition exploration test from step 1 on FIXED code
+    - **EXPECTED OUTCOME**: Test PASSES (confirms bug is fixed - over-cap transactions now reject before transfer)
+    - Assert: GlobalVolumeExceeded panic occurs without any token.transfer_from being called
+    - Assert: accumulated_volume remains unchanged when cap is breached
+    - Document fix validation: test pass confirms over-cap handling now atomic and fail-closed
+    - _Requirements: 2.1, 2.2, 2.3_
+
+  - [ ] 4.2 Verify no partial transfers on over-cap rejection
+    - For over-cap charge: assert zero tokens transferred to merchant
+    - For over-cap pay-per-use with fee: assert zero tokens to both collector AND merchant
+    - For batch with over-cap user: assert no transfers for that user or remaining batch users after over-cap
+    - Use balance assertions: `token.balance(merchant_before) == token.balance(merchant_after)`
+    - Confirms that GlobalVolumeExceeded rejection is fail-closed with zero state mutation
+    - _Requirements: 2.1, 2.2_
+
+- [ ] 5. Verify preservation tests still pass
+
+  - [ ] 5.1 Re-run preservation property tests from Phase 1
+    - **Property 2: Preservation** - Within-Cap Transactions Preserve Existing Behavior (Fixed)
+    - **IMPORTANT**: Re-run the SAME tests from task 2 - do NOT write new tests
+    - Run preservation property tests from step 2 on FIXED code
+    - **EXPECTED OUTCOME**: Tests PASS (confirms no regressions - within-cap behavior unchanged)
+    - Verify for all within-cap transactions:
+      - Token transfer amounts identical to unfixed code
+      - Merchant revenue recorded identically
+      - Fee transfers (if applicable) occur identically
+      - Subscription state updates (last_charged, history) identical
+      - Events emitted identically
+      - Window rollover behavior unchanged
+      - Batch operations accumulate volumes correctly
+    - Confirm all tests still pass after fix (no regressions)
+    - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7_
+
+  - [ ] 5.2 Verify exact capacity boundary handling
+    - Test transaction bringing accumulated volume to exactly GLOBAL_MAX_VOLUME_PER_HOUR accepts
+    - Test transaction bringing accumulated volume to exactly + 1 stroops rejects before transfer
+    - Assert: 49.99T volume + 1.01T charge (total = 50T exactly) → accepts and transfers
+    - Assert: 49.99T volume + 1.010001T charge (total = 50T + 1 stroops) → rejects before transfer
+    - Confirms boundary arithmetic correct and fail-closed at boundary
+    - _Requirements: 2.4, 2.5_
+
+- [ ] 6. Checkpoint - Ensure all tests pass and build succeeds
+
+  - [ ] 6.1 Run full contract test suite
+    - Execute: `cargo test` in contract directory
+    - Verify: All existing tests pass (no regressions introduced by reordering)
+    - Verify: Bug condition exploration test passes (bug is fixed)
+    - Verify: Preservation tests pass (no behavioral changes to within-cap transactions)
+    - If any test fails, diagnose and confirm fix is correct before proceeding
+    - _Requirements: All requirements validated_
+
+  - [ ] 6.2 Verify contract builds without errors
+    - Execute: `cargo build --release --target wasm32-unknown-unknown` in contract directory
+    - Confirm: No compilation errors or warnings related to volume check reordering
+    - Confirm: WASM binary is generated successfully
+    - _Requirements: Implementation complete and validated_
+
+  - [ ] 6.3 Verify simulate_charge alignment with execute behavior (optional)
+    - If `simulate_charge()` function exists and performs pre-transfer validation:
+      - Verify `simulate_charge()` applies volume checks identically to `charge()`
+      - Confirm simulate and execute paths now aligned: both check volume before reporting success
+      - This ensures callers can rely on simulate results to predict execute outcomes
+    - _Requirements: 2.1 (consistency between paths)_


### PR DESCRIPTION
closes #798 
- Add bugfix requirements document (bugfix.md)
- Add technical design with reordering approach (design.md)
- Add implementation task list with 4 phases (tasks.md)

This spec defines the bugfix for the ordering issue where volume capacity checks run AFTER token transfers in charge() and pay_per_use() paths, causing panics after partial transfers and violating fail-closed expectations.

The fix reorders checks to run BEFORE any token transfers:
- charge(): move check_and_update_global_volume before token.transfer_from
- pay_per_use(): move check before both fee and merchant transfers
- batch_charge(): add volume check in loop before execute_charge calls

Acceptance criteria:
- Over-cap attempts transfer zero tokens (fail-closed)
- Under-cap paths unchanged functionally
- simulate_charge/estimate_pay_per_use consistent with execute
- Boundary tests at exact capacity pass
- Window rollover (HOUR_IN_SECONDS) continues working
- All tests pass with balance assertions proving no transfers on over-cap