### PR TITLE
feat: optionally filter grace-lapsed batch queries and assert fee conservation properties

### DIFF
--- a/contract/src/fee.rs
+++ b/contract/src/fee.rs
@@ -99,6 +99,12 @@ pub fn clear_fee(env: &Env) {
 /// `amount * bps` is the one multiplication in the fee path that can leave
 /// i128 range for amounts near the economic caps, so it is checked and fails
 /// closed with `ArithmeticOverflow` instead of wrapping or string-panicking.
+///
+/// ### Rounding Rule
+/// Integer division in Rust rounds toward zero (truncation). Since the product of `amount`
+/// and `bps` is positive, the calculated fee is rounded down (truncated). The remaining
+/// net amount is calculated as `net = amount - fee`, which ensures exact conservation:
+/// `fee + net == amount` for all possible inputs, with no dust lost.
 pub fn calculate_fee_amount(env: &Env, amount: i128, bps: u32) -> i128 {
     if bps == 0 || amount <= 0 {
         return 0;
@@ -228,4 +234,51 @@ pub fn transfer_pay_per_use(
     token_client.transfer_from(&env.current_contract_address(), user, recipient, &net);
 
     fee_amount
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_fee_conservation_properties() {
+        let env = Env::default();
+        // Test combinations of amount and bps
+        let amounts = [
+            0, 1, 2, 9, 10, 99, 100, 101, 1000, 10000, 1234567, 10_000_000,
+        ];
+        let bps_values = [
+            0, 1, 5, 10, 50, 100, 500, 1000, 5000, 9999, 10000,
+        ];
+
+        for &amount in amounts.iter() {
+            for &bps in bps_values.iter() {
+                let fee = calculate_fee_amount(&env, amount, bps);
+                let net = amount - fee;
+
+                // 1. Assert conservation
+                assert_eq!(
+                    fee + net,
+                    amount,
+                    "Conservation failed for amount={} and bps={}",
+                    amount,
+                    bps
+                );
+
+                // 2. Assert non-negative parts
+                assert!(fee >= 0, "Fee is negative: {} for amount={}, bps={}", fee, amount, bps);
+                assert!(net >= 0, "Net is negative: {} for amount={}, bps={}", net, amount, bps);
+
+                // 3. Assert fee limits
+                if bps == 0 {
+                    assert_eq!(fee, 0);
+                } else if bps == 10000 {
+                    assert_eq!(fee, amount);
+                    assert_eq!(net, 0);
+                } else {
+                    assert!(fee <= amount);
+                }
+            }
+        }
+    }
 }

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -1423,8 +1423,14 @@ impl FlowPay {
 
     /// Returns a list of subscriber addresses that are currently due for charging.
     /// Reads from the `SubscriberIndex` starting from `offset` up to `offset + limit`.
-    /// Capped at 50 per call.
-    pub fn get_next_charge_batch(env: Env, offset: u64, limit: u32) -> Vec<Address> {
+    /// Capped at 50 per call. Optionally filters out grace-lapsed subscriptions when
+    /// `exclude_lapsed` is `Some(true)` or `None`.
+    pub fn get_next_charge_batch(
+        env: Env,
+        offset: u64,
+        limit: u32,
+        exclude_lapsed: Option<bool>,
+    ) -> Vec<Address> {
         if limit > 50 {
             env.panic_with_error(ContractError::BatchTooLarge);
         }
@@ -1433,13 +1439,23 @@ impl FlowPay {
         if offset >= size || limit == 0 {
             return result;
         }
+        let exclude = exclude_lapsed.unwrap_or(true);
         let mut i = offset;
         let end = (offset + limit as u64).min(size);
         while i < end {
             if !subscription_count::is_subscriber_index_removed(&env, i) {
                 if let Some(addr) = env.storage().persistent().get::<DataKey, Address>(&DataKey::SubscriberIndex(i)) {
-                    if Self::is_charge_due(env.clone(), addr.clone()) {
-                        result.push_back(addr);
+                    if let Some(sub) = storage::get_subscription(&env, &addr) {
+                        if let Some(next) = charge_exec::compute_next_charge_at(&sub) {
+                            let now = env.ledger().timestamp();
+                            if now >= next {
+                                let grace = grace::get_grace_period(&env);
+                                let lapsed = grace > 0 && now > next + grace;
+                                if !exclude || !lapsed {
+                                    result.push_back(addr);
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/contract/src/test.rs
+++ b/contract/src/test.rs
@@ -9055,10 +9055,10 @@ fn test_get_next_charge_batch_empty_and_bounds() {
     let (env, contract_id, _, _, _) = setup();
     let client = FlowPayClient::new(&env, &contract_id);
 
-    let batch = client.get_next_charge_batch(&0, &10);
+    let batch = client.get_next_charge_batch(&0, &10, &None);
     assert_eq!(batch.len(), 0);
 
-    let batch_oob = client.get_next_charge_batch(&5, &10);
+    let batch_oob = client.get_next_charge_batch(&5, &10, &None);
     assert_eq!(batch_oob.len(), 0);
 }
 
@@ -9086,7 +9086,7 @@ fn test_get_next_charge_batch_filtering() {
 
     client.subscribe(&user_not_due, &merchant, &1_0000000, &interval, &token_addr, &None, &None);
 
-    let batch = client.get_next_charge_batch(&0, &10);
+    let batch = client.get_next_charge_batch(&0, &10, &None);
     assert_eq!(batch.len(), 1);
     assert_eq!(batch.get(0).unwrap(), user_due);
 }
@@ -9109,12 +9109,12 @@ fn test_get_next_charge_batch_pagination() {
         l.timestamp += interval + 1;
     });
 
-    let batch1 = client.get_next_charge_batch(&0, &2);
+    let batch1 = client.get_next_charge_batch(&0, &2, &None);
     assert_eq!(batch1.len(), 2);
     assert_eq!(batch1.get(0).unwrap(), user1);
     assert_eq!(batch1.get(1).unwrap(), user2);
 
-    let batch2 = client.get_next_charge_batch(&2, &2);
+    let batch2 = client.get_next_charge_batch(&2, &2, &None);
     assert_eq!(batch2.len(), 1);
     assert_eq!(batch2.get(0).unwrap(), user3);
 }
@@ -9125,7 +9125,58 @@ fn test_get_next_charge_batch_exceeds_limit_panics() {
     let (env, contract_id, _, _, _) = setup();
     let client = FlowPayClient::new(&env, &contract_id);
 
-    client.get_next_charge_batch(&0, &51);
+    client.get_next_charge_batch(&0, &51, &None);
+}
+
+#[test]
+fn test_get_next_charge_batch_exclude_lapsed() {
+    let (env, contract_id, token_addr, user, merchant) = setup();
+    let client = FlowPayClient::new(&env, &contract_id);
+
+    env.as_contract(&contract_id, || {
+        storage::set_admin(&env, &user);
+    });
+    let grace_period: u64 = 86400;
+    client.propose_grace_period(&grace_period);
+    client.commit_grace_period();
+
+    let interval: u64 = 86400;
+    client.subscribe(
+        &user,
+        &merchant,
+        &1_0000000,
+        &interval,
+        &token_addr,
+        &None,
+        &None,
+    );
+
+    // Advance ledger beyond interval, but WITHIN grace period
+    env.ledger().with_mut(|l| {
+        l.timestamp += interval + grace_period - 100;
+    });
+
+    // It should be returned because it's due and not lapsed
+    let batch = client.get_next_charge_batch(&0, &10, &Some(true));
+    assert_eq!(batch.len(), 1);
+    assert_eq!(batch.get(0).unwrap(), user);
+
+    // Advance ledger beyond interval + grace period
+    env.ledger().with_mut(|l| {
+        l.timestamp += 200; // past the grace period
+    });
+
+    // When exclude_lapsed is Some(true) or None, it should NOT be returned
+    let batch_exclude = client.get_next_charge_batch(&0, &10, &Some(true));
+    assert_eq!(batch_exclude.len(), 0);
+
+    let batch_default = client.get_next_charge_batch(&0, &10, &None);
+    assert_eq!(batch_default.len(), 0);
+
+    // When exclude_lapsed is Some(false), it should be returned
+    let batch_include = client.get_next_charge_batch(&0, &10, &Some(false));
+    assert_eq!(batch_include.len(), 1);
+    assert_eq!(batch_include.get(0).unwrap(), user);
 }
 
 #[test]


### PR DESCRIPTION
Closes #830, Closes #831

This PR:
1. Adds optional filtering for grace-lapsed subscriptions in get_next_charge_batch.
2. Documents the fee rounding rule in ee.rs and adds property-style tests for fee conservation.