### PR TITLE
docs: document batch_charge failure semantics (resolves #901)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -247,3 +247,27 @@ cargo test bench --features bench -- --nocapture
 ```
 
 The benchmark file prints CPU and memory costs at runtime and compares them against budget thresholds. If a change increases cost intentionally, update both the printed baseline comment and the threshold constant together.
+
+
+#### `batch_charge` failure semantics
+
+`batch_charge(users)` processes each address independently and returns a `Vec<ChargeResult>`.  
+**However**, if the underlying token transfer (`transfer_from`) fails due to an **insufficient allowance** or **insufficient balance**, or if the **token address is invalid**, the contract **panics and aborts the entire batch** – **no** `ChargeResult` is produced for any user.
+
+This means the contract **does not** currently tolerate per‑user allowance failures (see issue #XXX). The only safe way to avoid a batch‑wide panic is to **pre‑check** each user’s allowance and balance before submitting the batch.
+
+| Scenario | Behaviour | Outcome |
+|----------|-----------|---------|
+| User not due (`interval` not elapsed) | Returns | `ChargeResult::Skipped` |
+| Subscription paused | Returns | `ChargeResult::Paused` |
+| Grace period elapsed | Returns | `ChargeResult::GracePeriodElapsed` |
+| No subscription | Returns | `ChargeResult::NoSubscription` |
+| Inactive subscription | Returns | `ChargeResult::Inactive` |
+| Insufficient allowance (gross amount) | **Panics** | Whole batch aborts |
+| Insufficient balance | **Panics** | Whole batch aborts |
+| Token address is not a valid SAC contract | **Panics** | Whole batch aborts |
+
+> ** Important**  
+> Until the allowance‑tolerance issue is fixed (see #001), integrators **must** run `simulate_charge` or `get_batch_charge_estimate` on each candidate user and verify allowance/balance before calling `batch_charge`. The keeper script uses `check-allowances.ts` and `simulate` to guard against these panics.
+
+See [`docs/KEEPER.md`](./KEEPER.md) for operational precheck steps.

--- a/docs/KEEPER.md
+++ b/docs/KEEPER.md
@@ -45,6 +45,11 @@ The keeper must page through the full subscriber index using `get_subscriber_ind
 
 ---
 
+
+>  **Panic warning**  
+> While `batch_charge` returns a `ChargeResult` for normal skips, it **panics** (aborts the entire batch) if any user’s token allowance or balance is insufficient to cover the **gross** subscription amount (including protocol fees). The same happens if the token address is invalid.  
+> Therefore, before calling `batch_charge`, always run `simulate_charge` (or `get_batch_charge_estimate`) on the candidate list, and use `check-allowances.ts` to verify that each user has enough allowance. See [`docs/ARCHITECTURE.md`](./ARCHITECTURE.md#batch_charge-failure-semantics) for the full failure‑modes table.
+
 ## Running the Reference Keeper
 
 ### Prerequisites


### PR DESCRIPTION
Closes #901

What was done:
- Added failure modes table to ARCHITECTURE.md
- Added panic warning and precheck recommendations to KEEPER.md
- Both documents now accurately describe current batch_charge behavior

Why:
- Prevents integrators from assuming full non-abort behavior
- Provides clear precheck guidance (simulate_charge, check-allowances.ts)