### PR TITLE
feat(frontend): add guided transfer_subscription UI with danger checklist

### DIFF
--- a/frontend/src/__tests__/SubscriptionCard.test.tsx
+++ b/frontend/src/__tests__/SubscriptionCard.test.tsx
@@ -30,6 +30,15 @@ vi.mock("../components/IncreaseAllowanceModal", () => ({
   ),
 }));
 
+// Mock TransferSubscriptionModal so we can assert it opens, in isolation from its own logic
+vi.mock("../components/TransferSubscriptionModal", () => ({
+  default: ({ onClose }: { onClose: () => void }) => (
+    <div data-testid="transfer-subscription-modal">
+      <button onClick={onClose}>Close Modal</button>
+    </div>
+  ),
+}));
+
 // Mock the stellar module — getAllowance and getTrialEnd are used by SubscriptionCard
 const mockGetAllowance = vi.fn();
 const mockGetTrialEnd = vi.fn();
@@ -801,6 +810,59 @@ describe("SubscriptionCard", () => {
         />
       );
       expect(screen.queryAllByRole("button", { name: /cancel subscription/i })).toHaveLength(0);
+    });
+  });
+
+  describe("Transfer subscription", () => {
+    it("renders the transfer trigger button for an active subscription", () => {
+      render(
+        <SubscriptionCard
+          subscription={createMockSubscription({ active: true, paused: false })}
+          userKey={mockUserKey}
+          onSign={mockOnSign}
+          onRefresh={mockOnRefresh}
+        />
+      );
+      expect(screen.getByTestId("transfer-subscription-button")).toBeInTheDocument();
+    });
+
+    it("renders the transfer trigger button when the subscription is paused", () => {
+      render(
+        <SubscriptionCard
+          subscription={createMockSubscription({ active: true, paused: true })}
+          userKey={mockUserKey}
+          onSign={mockOnSign}
+          onRefresh={mockOnRefresh}
+        />
+      );
+      expect(screen.getByTestId("transfer-subscription-button")).toBeInTheDocument();
+    });
+
+    it("does not render the transfer trigger button when subscription is inactive", () => {
+      render(
+        <SubscriptionCard
+          subscription={createMockSubscription({ active: false })}
+          userKey={mockUserKey}
+          onSign={mockOnSign}
+          onRefresh={mockOnRefresh}
+        />
+      );
+      expect(screen.queryByTestId("transfer-subscription-button")).not.toBeInTheDocument();
+    });
+
+    it("opens TransferSubscriptionModal when the transfer button is clicked", async () => {
+      render(
+        <SubscriptionCard
+          subscription={createMockSubscription({ active: true, paused: false })}
+          userKey={mockUserKey}
+          onSign={mockOnSign}
+          onRefresh={mockOnRefresh}
+        />
+      );
+
+      expect(screen.queryByTestId("transfer-subscription-modal")).not.toBeInTheDocument();
+      await userEvent.click(screen.getByTestId("transfer-subscription-button"));
+      expect(screen.getByTestId("transfer-subscription-modal")).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/__tests__/TransferSubscriptionModal.test.tsx
+++ b/frontend/src/__tests__/TransferSubscriptionModal.test.tsx
@@ -1,0 +1,136 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import TransferSubscriptionModal from "../components/TransferSubscriptionModal";
+
+// Deterministic valid Stellar Ed25519 public keys (verified via StrKey.isValidEd25519PublicKey)
+const USER_KEY = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+const TARGET_KEY = "GCXO7NWYDZJGGZZIZK3VJLMY276XKV5ZOONULFCRUBCCOCVX5F5M36CR";
+
+const mockBuildTransferSubscriptionTx = vi.fn();
+vi.mock("../stellar", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../stellar")>();
+  return {
+    ...actual,
+    buildTransferSubscriptionTx: (...args: unknown[]) => mockBuildTransferSubscriptionTx(...args),
+  };
+});
+
+// Mock AddressBook so selection can be exercised without localStorage/dialog internals.
+vi.mock("../components/AddressBook", () => ({
+  default: ({ onSelect }: { onSelect: (address: string) => void; onClose: () => void }) => (
+    <div data-testid="mock-address-book">
+      <button onClick={() => onSelect(TARGET_KEY)}>Pick Target</button>
+    </div>
+  ),
+}));
+
+describe("TransferSubscriptionModal", () => {
+  const mockOnSign = vi.fn();
+  const mockOnClose = vi.fn();
+  const mockOnSuccess = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockBuildTransferSubscriptionTx.mockResolvedValue("transfer-xdr");
+    mockOnSign.mockResolvedValue("tx-hash");
+  });
+
+  function renderModal() {
+    return render(
+      <TransferSubscriptionModal
+        userKey={USER_KEY}
+        onSign={mockOnSign}
+        onClose={mockOnClose}
+        onSuccess={mockOnSuccess}
+      />
+    );
+  }
+
+  it("renders with an empty address and all checklist items unchecked, confirm disabled", () => {
+    renderModal();
+
+    expect(screen.getByTestId("transfer-address-input")).toHaveValue("");
+    expect(screen.getByTestId("transfer-checklist-item-0")).not.toBeChecked();
+    expect(screen.getByTestId("transfer-checklist-item-1")).not.toBeChecked();
+    expect(screen.getByTestId("transfer-checklist-item-2")).not.toBeChecked();
+    expect(screen.getByTestId("transfer-confirm-button")).toBeDisabled();
+  });
+
+  it("shows a validation error for an invalid address and keeps confirm disabled", async () => {
+    renderModal();
+
+    await userEvent.type(screen.getByTestId("transfer-address-input"), "not-a-valid-address");
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(/valid stellar address/i);
+    expect(screen.getByTestId("transfer-confirm-button")).toBeDisabled();
+  });
+
+  it("keeps confirm disabled when the address equals the caller's own address", async () => {
+    renderModal();
+
+    await userEvent.type(screen.getByTestId("transfer-address-input"), USER_KEY);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(/own address/i);
+    expect(screen.getByTestId("transfer-confirm-button")).toBeDisabled();
+  });
+
+  it("keeps confirm disabled when address is valid but not all checklist items are checked", async () => {
+    renderModal();
+
+    await userEvent.type(screen.getByTestId("transfer-address-input"), TARGET_KEY);
+    await userEvent.click(screen.getByTestId("transfer-checklist-item-0"));
+    await userEvent.click(screen.getByTestId("transfer-checklist-item-1"));
+
+    expect(screen.getByTestId("transfer-confirm-button")).toBeDisabled();
+  });
+
+  it("enables confirm once address is valid, not self, and all checklist items are checked, then submits", async () => {
+    renderModal();
+
+    await userEvent.type(screen.getByTestId("transfer-address-input"), TARGET_KEY);
+    await userEvent.click(screen.getByTestId("transfer-checklist-item-0"));
+    await userEvent.click(screen.getByTestId("transfer-checklist-item-1"));
+    await userEvent.click(screen.getByTestId("transfer-checklist-item-2"));
+
+    expect(screen.getByTestId("transfer-confirm-button")).toBeEnabled();
+
+    await userEvent.click(screen.getByTestId("transfer-confirm-button"));
+
+    await waitFor(() => {
+      expect(mockOnSuccess).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockBuildTransferSubscriptionTx).toHaveBeenCalledWith(USER_KEY, TARGET_KEY);
+    expect(mockOnSign).toHaveBeenCalledWith("transfer-xdr");
+  });
+
+  it("shows a friendly error and does not call onSuccess when the build/sign call is rejected", async () => {
+    mockBuildTransferSubscriptionTx.mockRejectedValue(new Error("no subscription found"));
+
+    renderModal();
+
+    await userEvent.type(screen.getByTestId("transfer-address-input"), TARGET_KEY);
+    await userEvent.click(screen.getByTestId("transfer-checklist-item-0"));
+    await userEvent.click(screen.getByTestId("transfer-checklist-item-1"));
+    await userEvent.click(screen.getByTestId("transfer-checklist-item-2"));
+
+    await userEvent.click(screen.getByTestId("transfer-confirm-button"));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(/no subscription found/i);
+    expect(mockOnSuccess).not.toHaveBeenCalled();
+  });
+
+  it("populates the address input when an address is selected via the address book", async () => {
+    renderModal();
+
+    await userEvent.click(screen.getByTestId("transfer-address-book-button"));
+    expect(screen.getByTestId("mock-address-book")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByText("Pick Target"));
+
+    expect(screen.getByTestId("transfer-address-input")).toHaveValue(TARGET_KEY);
+  });
+});

--- a/frontend/src/components/SubscriptionCard.tsx
+++ b/frontend/src/components/SubscriptionCard.tsx
@@ -19,6 +19,7 @@ import React, { useEffect, useState } from "react";
 import CopyButton from "./CopyButton";
 import NextChargeCountdown from "./NextChargeCountdown";
 import IncreaseAllowanceModal from "./IncreaseAllowanceModal";
+import TransferSubscriptionModal from "./TransferSubscriptionModal";
 import ErrorRecovery from "./ErrorRecovery";
 import SubscriptionHealthWidget from "./SubscriptionHealthWidget";
 import { Subscription } from "../types";
@@ -231,6 +232,9 @@ export default function SubscriptionCard({
   const [allowanceLoading, setAllowanceLoading] = useState(true);
   const [showAllowanceModal, setShowAllowanceModal] = useState(false);
 
+  // ── Transfer subscription state ────────────────────────────────────────────
+  const [showTransferModal, setShowTransferModal] = useState(false);
+
   const amountBigInt = BigInt(amount);
   const health = computeAllowanceHealth(allowance, amountBigInt);
 
@@ -433,6 +437,14 @@ export default function SubscriptionCard({
             >
               Cancel
             </button>
+            <button
+              onClick={() => setShowTransferModal(true)}
+              className="btn-secondary transfer-btn"
+              aria-label="Transfer subscription ownership"
+              data-testid="transfer-subscription-button"
+            >
+              Transfer
+            </button>
           </>
         )}
         {active && paused && (
@@ -450,6 +462,14 @@ export default function SubscriptionCard({
               aria-label="Cancel subscription"
             >
               Cancel
+            </button>
+            <button
+              onClick={() => setShowTransferModal(true)}
+              className="btn-secondary transfer-btn"
+              aria-label="Transfer subscription ownership"
+              data-testid="transfer-subscription-button"
+            >
+              Transfer
             </button>
           </>
         )}
@@ -512,6 +532,20 @@ export default function SubscriptionCard({
               .finally(() => setAllowanceLoading(false));
           }}
           announce={() => {}}
+        />
+      )}
+
+      {/* Transfer subscription modal — guided ownership transfer */}
+      {showTransferModal && (
+        <TransferSubscriptionModal
+          userKey={userKey}
+          onSign={onSign}
+          onClose={() => setShowTransferModal(false)}
+          onSuccess={() => {
+            setShowTransferModal(false);
+            addToast("Subscription transferred successfully.", "success");
+            onRefresh();
+          }}
         />
       )}
 

--- a/frontend/src/components/TransferSubscriptionModal.tsx
+++ b/frontend/src/components/TransferSubscriptionModal.tsx
@@ -1,0 +1,164 @@
+import React, { useMemo, useRef, useState } from "react";
+import { StrKey } from "@stellar/stellar-sdk";
+import { buildTransferSubscriptionTx } from "../stellar";
+import { friendlyError } from "../utils/errors";
+import { useFocusTrap } from "../hooks/useFocusTrap";
+import AddressBook from "./AddressBook";
+
+interface Props {
+  userKey: string;
+  onSign: (xdr: string) => Promise<string>;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+const CHECKLIST_ITEMS = [
+  "I have verified this address is correct and does not already have an active subscription.",
+  "I understand the recipient must also authorize this transfer in their own wallet.",
+  "I understand this action is irreversible and cannot be undone.",
+] as const;
+
+export default function TransferSubscriptionModal({ userKey, onSign, onClose, onSuccess }: Props) {
+  const [targetAddress, setTargetAddress] = useState("");
+  const [showAddressBook, setShowAddressBook] = useState(false);
+  const [checklist, setChecklist] = useState<boolean[]>(CHECKLIST_ITEMS.map(() => false));
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  useFocusTrap(modalRef, true, onClose);
+
+  const trimmedTarget = targetAddress.trim();
+  const trimmedSelf = userKey.trim();
+  const isValidFormat = trimmedTarget.length > 0 && StrKey.isValidEd25519PublicKey(trimmedTarget);
+  const isSelf = trimmedTarget.length > 0 && trimmedTarget === trimmedSelf;
+
+  const addressError = useMemo(() => {
+    if (trimmedTarget.length === 0) return null;
+    if (!isValidFormat) return "Enter a valid Stellar address.";
+    if (isSelf) return "You cannot transfer a subscription to your own address.";
+    return null;
+  }, [trimmedTarget, isValidFormat, isSelf]);
+
+  const allChecked = checklist.every(Boolean);
+  const canConfirm = isValidFormat && !isSelf && allChecked && !submitting;
+
+  const toggleChecklistItem = (index: number) => {
+    setChecklist((prev) => prev.map((checked, i) => (i === index ? !checked : checked)));
+  };
+
+  const handleConfirm = async () => {
+    if (!canConfirm) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const xdr = await buildTransferSubscriptionTx(userKey, trimmedTarget);
+      await onSign(xdr);
+      onSuccess();
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : String(e);
+      setError(friendlyError(message));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div
+        ref={modalRef}
+        className="modal-card card"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="transfer-subscription-title"
+      >
+        <h3 id="transfer-subscription-title">Transfer Subscription Ownership</h3>
+        <p>
+          Move this subscription to a different Stellar address. Both you and the recipient must
+          authorize the transfer in your wallets.
+        </p>
+
+        <label className="form-group">
+          <span className="form-label">Target address</span>
+          <input
+            type="text"
+            placeholder="G… (Stellar address)"
+            value={targetAddress}
+            onChange={(e) => setTargetAddress(e.target.value)}
+            disabled={submitting}
+            data-testid="transfer-address-input"
+            aria-invalid={addressError ? true : undefined}
+          />
+        </label>
+        <button
+          type="button"
+          className="btn-secondary btn-sm"
+          onClick={() => setShowAddressBook(true)}
+          disabled={submitting}
+          data-testid="transfer-address-book-button"
+        >
+          Choose from Address Book
+        </button>
+        {addressError && (
+          <p className="text-error" role="alert">
+            {addressError}
+          </p>
+        )}
+
+        <fieldset className="form-group">
+          <legend className="form-label">Before you continue, confirm the following</legend>
+          {CHECKLIST_ITEMS.map((item, index) => (
+            <label key={item} className="checklist-item">
+              <input
+                type="checkbox"
+                checked={checklist[index]}
+                onChange={() => toggleChecklistItem(index)}
+                disabled={submitting}
+                data-testid={`transfer-checklist-item-${index}`}
+              />
+              {item}
+            </label>
+          ))}
+        </fieldset>
+
+        <p className="text-sm text-muted">
+          Warning: transferring ownership is irreversible. Once confirmed, this subscription can no
+          longer be managed from your wallet.
+        </p>
+
+        {error && (
+          <p className="text-error" role="alert">
+            {error}
+          </p>
+        )}
+
+        <div className="modal-actions">
+          <button
+            className="btn-secondary"
+            onClick={onClose}
+            disabled={submitting}
+            data-testid="transfer-cancel-button"
+          >
+            Cancel
+          </button>
+          <button
+            className="btn-danger"
+            onClick={handleConfirm}
+            disabled={!canConfirm}
+            data-testid="transfer-confirm-button"
+          >
+            {submitting ? "Transferring…" : "Confirm Transfer"}
+          </button>
+        </div>
+      </div>
+
+      {showAddressBook && (
+        <AddressBook
+          onSelect={(address) => setTargetAddress(address)}
+          onClose={() => setShowAddressBook(false)}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/stellar.ts
+++ b/frontend/src/stellar.ts
@@ -147,6 +147,10 @@ export async function buildResumeTx(user: string): Promise<string> {
   return buildTx(user, "resume", [addressVal(user)]);
 }
 
+export async function buildTransferSubscriptionTx(user: string, newUser: string): Promise<string> {
+  return buildTx(user, "transfer_subscription", [addressVal(user), addressVal(newUser)]);
+}
+
 export async function buildSetDailyLimitTx(user: string, amount: bigint): Promise<string> {
   return buildTx(user, "set_daily_limit", [
     addressVal(user),

--- a/frontend/src/utils/errors.ts
+++ b/frontend/src/utils/errors.ts
@@ -13,6 +13,7 @@ export const CONTRACT_ERRORS: Record<string, string> = {
     "Your subscription data has been archived by the Stellar network. Use Restore to recover it.",
   "-32700":
     "Your subscription data has been archived by the Stellar network. Use Restore to recover it.",
+  "#24": "That address already has an active subscription.",
 };
 
 export function friendlyError(raw: string): string {


### PR DESCRIPTION
## Summary
- Adds `buildTransferSubscriptionTx(user, newUser)` to `stellar.ts`, wrapping the on-chain `transfer_subscription` call.
- Adds a new `TransferSubscriptionModal` reachable from a "Transfer" button on active subscriptions in `SubscriptionCard`: lets the user pick a target from the existing `AddressBook` or type an address, validates it (well-formed, not the caller's own address), and requires a 3-item danger checklist to be acknowledged (target verified/no existing subscription, recipient must co-authorize, action is irreversible) before the confirm button enables.
- On success, refreshes the subscription view via the existing `onRefresh` callback and shows a success toast; on failure, surfaces a friendly error (including a new mapping for the `SubscriptionAlreadyActive` contract error).

Closes #866

## Acceptance criteria
- [x] Validates target address
- [x] Warns about irreversibility
- [x] Success refreshes subscription state
- [x] Tests included

## Test plan
- `npm run lint` — 0 errors
- `npm run build` — succeeds
- `npx vitest run` — all tests pass, including new `TransferSubscriptionModal.test.tsx` (7 tests) and additional `SubscriptionCard.test.tsx` coverage for the new Transfer button