### PR TITLE
feat(frontend): add merchant revenue withdraw flow

### DIFF
--- a/frontend/src/__tests__/MerchantDashboard.test.tsx
+++ b/frontend/src/__tests__/MerchantDashboard.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -46,6 +46,38 @@ const SAMPLE_SUBSCRIBER = {
   lastCharged: NOW - 2592000,
   nextChargeAt: NOW + 2592000, // future → active
 };
+
+interface MockTxState {
+  status: "idle" | "pending" | "success" | "failed";
+  submit: (fn: () => Promise<string>) => Promise<string>;
+  error: string | null;
+  hash: string | null;
+}
+
+const idleTx = (): MockTxState => ({
+  status: "idle",
+  submit: vi.fn(async (fn) => fn()),
+  error: null,
+  hash: null,
+});
+
+// MerchantDashboard calls useTransaction() twice: first for the batch-charge
+// flow, then for the withdraw flow. Hooks are called in the same order on
+// every render, so alternating by call count lets tests control each
+// instance independently.
+function mockUseTransaction(overrides: {
+  batch?: Partial<MockTxState>;
+  withdraw?: Partial<MockTxState>;
+}) {
+  const batchState: MockTxState = { ...idleTx(), ...overrides.batch };
+  const withdrawState: MockTxState = { ...idleTx(), ...overrides.withdraw };
+  let call = 0;
+  vi.mocked(useTransaction).mockImplementation(() => {
+    call += 1;
+    return call % 2 === 1 ? batchState : withdrawState;
+  });
+  return { batchState, withdrawState };
+}
 
 describe("MerchantDashboard", () => {
   beforeEach(() => {
@@ -154,5 +186,111 @@ describe("MerchantDashboard", () => {
     expect(screen.getByText("Charged")).toBeTruthy();
     expect(stellar.simulateBatchCharge).toHaveBeenCalled();
     expect(stellar.buildBatchChargeTx).toHaveBeenCalled();
+  });
+
+  // ── Withdraw revenue ────────────────────────────────────────────────────
+
+  it("disables the withdraw button when revenue is zero", async () => {
+    vi.mocked(stellar.getMerchantSubscribers).mockResolvedValue([]);
+    vi.mocked(stellar.getMerchantRevenue).mockResolvedValue(0n);
+    mockUseTransaction({});
+
+    render(<MerchantDashboard merchantKey="GMERCHANT" onSign={vi.fn()} refreshTrigger={0} />);
+
+    const button = await screen.findByTestId("withdraw-revenue-button");
+    expect(button).toBeDisabled();
+  });
+
+  it("enables the withdraw button when revenue is positive", async () => {
+    vi.mocked(stellar.getMerchantSubscribers).mockResolvedValue([]);
+    vi.mocked(stellar.getMerchantRevenue).mockResolvedValue(50000000n);
+    mockUseTransaction({});
+
+    render(<MerchantDashboard merchantKey="GMERCHANT" onSign={vi.fn()} refreshTrigger={0} />);
+
+    const button = await screen.findByTestId("withdraw-revenue-button");
+    await waitFor(() => expect(button).not.toBeDisabled());
+  });
+
+  it("opens a confirmation showing the amount, and cancel closes it without building a tx", async () => {
+    vi.mocked(stellar.getMerchantSubscribers).mockResolvedValue([]);
+    vi.mocked(stellar.getMerchantRevenue).mockResolvedValue(50000000n);
+    mockUseTransaction({});
+    const user = userEvent.setup();
+
+    render(<MerchantDashboard merchantKey="GMERCHANT" onSign={vi.fn()} refreshTrigger={0} />);
+
+    const withdrawButton = await screen.findByTestId("withdraw-revenue-button");
+    await waitFor(() => expect(withdrawButton).not.toBeDisabled());
+    await user.click(withdrawButton);
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toBeTruthy();
+    expect(within(dialog).getByText(/5\.0000000 XLM/)).toBeTruthy();
+
+    await user.click(screen.getByTestId("withdraw-cancel-button"));
+
+    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(stellar.buildWithdrawMerchantRevenueTx).not.toHaveBeenCalled();
+  });
+
+  it("confirming withdraws, signs, shows success, and refreshes revenue", async () => {
+    vi.mocked(stellar.getMerchantSubscribers).mockResolvedValue([]);
+    vi.mocked(stellar.getMerchantRevenue).mockResolvedValue(50000000n);
+    vi.mocked(stellar.buildWithdrawMerchantRevenueTx).mockResolvedValue("withdraw-xdr");
+    const onSign = vi.fn().mockResolvedValue("tx-hash");
+    const mockSubmit = vi.fn(async (fn) => {
+      await fn();
+      return "tx-hash";
+    });
+    mockUseTransaction({ withdraw: { status: "success", submit: mockSubmit } });
+    const user = userEvent.setup();
+
+    render(<MerchantDashboard merchantKey="GMERCHANT" onSign={onSign} refreshTrigger={0} />);
+
+    const withdrawButton = await screen.findByTestId("withdraw-revenue-button");
+    await waitFor(() => expect(withdrawButton).not.toBeDisabled());
+    await user.click(withdrawButton);
+    await user.click(screen.getByTestId("withdraw-confirm-button"));
+
+    await waitFor(() => expect(screen.getByText(/Revenue withdrawn successfully!/i)).toBeTruthy());
+
+    expect(stellar.buildWithdrawMerchantRevenueTx).toHaveBeenCalledWith("GMERCHANT");
+    expect(onSign).toHaveBeenCalledWith("withdraw-xdr");
+    expect(mockSubmit).toHaveBeenCalled();
+    // Initial mount fetches revenue once; a successful withdraw triggers a refresh.
+    await waitFor(() =>
+      expect(vi.mocked(stellar.getMerchantRevenue).mock.calls.length).toBeGreaterThanOrEqual(2)
+    );
+  });
+
+  it("surfaces a friendly message and does not silently succeed on ZeroBalanceAvailable", async () => {
+    vi.mocked(stellar.getMerchantSubscribers).mockResolvedValue([]);
+    vi.mocked(stellar.getMerchantRevenue).mockResolvedValue(50000000n);
+    vi.mocked(stellar.buildWithdrawMerchantRevenueTx).mockResolvedValue("withdraw-xdr");
+    const onSign = vi.fn().mockResolvedValue("tx-hash");
+    const failingSubmit = vi
+      .fn()
+      .mockRejectedValue(new Error("ContractError(#21): ZeroBalanceAvailable"));
+    mockUseTransaction({
+      withdraw: {
+        status: "failed",
+        submit: failingSubmit,
+        error: "ContractError(#21): ZeroBalanceAvailable",
+      },
+    });
+    const user = userEvent.setup();
+
+    render(<MerchantDashboard merchantKey="GMERCHANT" onSign={onSign} refreshTrigger={0} />);
+
+    const withdrawButton = await screen.findByTestId("withdraw-revenue-button");
+    await waitFor(() => expect(withdrawButton).not.toBeDisabled());
+    await user.click(withdrawButton);
+    await user.click(screen.getByTestId("withdraw-confirm-button"));
+
+    await waitFor(() =>
+      expect(screen.getByText(/You have no withdrawable revenue yet\./i)).toBeTruthy()
+    );
+    expect(screen.queryByText(/Revenue withdrawn successfully!/i)).toBeNull();
   });
 });

--- a/frontend/src/components/ConfirmModal.tsx
+++ b/frontend/src/components/ConfirmModal.tsx
@@ -5,9 +5,17 @@ interface Props {
   message: string;
   onConfirm: () => void;
   onCancel: () => void;
+  confirmTestId?: string;
+  cancelTestId?: string;
 }
 
-export default function ConfirmModal({ message, onConfirm, onCancel }: Props) {
+export default function ConfirmModal({
+  message,
+  onConfirm,
+  onCancel,
+  confirmTestId,
+  cancelTestId,
+}: Props) {
   const modalRef = useRef<HTMLDivElement>(null);
 
   useFocusTrap(modalRef, true, onCancel);
@@ -24,10 +32,10 @@ export default function ConfirmModal({ message, onConfirm, onCancel }: Props) {
       >
         <p id="confirm-modal-message">{message}</p>
         <div className="modal-actions">
-          <button className="btn-secondary" onClick={onCancel}>
+          <button className="btn-secondary" onClick={onCancel} data-testid={cancelTestId}>
             Cancel
           </button>
-          <button className="btn-danger" onClick={onConfirm}>
+          <button className="btn-danger" onClick={onConfirm} data-testid={confirmTestId}>
             Confirm
           </button>
         </div>

--- a/frontend/src/components/MerchantDashboard.tsx
+++ b/frontend/src/components/MerchantDashboard.tsx
@@ -3,6 +3,7 @@ import {
   getMerchantSubscribers,
   type MerchantSubscriber,
   buildBatchChargeTx,
+  buildWithdrawMerchantRevenueTx,
   simulateBatchCharge,
   type BatchChargeOutcome,
   getMerchantRevenue,
@@ -20,6 +21,7 @@ import EventFeed from "./EventFeed";
 import SubscriptionExport from "./SubscriptionExport";
 import { MerchantSubscriberSkeleton } from "./Skeleton";
 import ErrorRecovery from "./ErrorRecovery";
+import ConfirmModal from "./ConfirmModal";
 
 const SUBSCRIBER_ROW_HEIGHT = 72;
 const SUBSCRIBER_LIST_HEIGHT = 400;
@@ -49,6 +51,8 @@ export default function MerchantDashboard({
   const [error, setError] = useState<string | null>(null);
 
   const tx = useTransaction();
+  const withdrawTx = useTransaction();
+  const [showWithdrawConfirm, setShowWithdrawConfirm] = useState(false);
   const { isMobile } = useResponsive();
   const { displayCurrentAmount } = useAmountDisplay();
   const [outcomes, setOutcomes] = useState<Record<string, BatchChargeOutcome>>({});
@@ -116,6 +120,21 @@ export default function MerchantDashboard({
     }
   };
 
+  const handleWithdraw = async () => {
+    setShowWithdrawConfirm(false);
+
+    try {
+      await withdrawTx.submit(async () => {
+        return await onSign(await buildWithdrawMerchantRevenueTx(merchantKey));
+      });
+
+      // Success — refresh so revenue reflects the new (zero) balance
+      await refresh();
+    } catch (e) {
+      console.error("Withdraw failed:", e);
+    }
+  };
+
   if (loading) {
     return (
       <div className="dashboard">
@@ -156,6 +175,19 @@ export default function MerchantDashboard({
         <div className="card">
           <span className="text-sm text-muted block mb-1">Total Revenue</span>
           <span className="text-2xl font-bold">{displayCurrentAmount(revenue)}</span>
+          <button
+            className="btn-primary w-full mt-2"
+            data-testid="withdraw-revenue-button"
+            onClick={() => setShowWithdrawConfirm(true)}
+            disabled={revenue <= 0n || withdrawTx.status === "pending"}
+          >
+            {withdrawTx.status === "pending" ? "Withdrawing..." : "Withdraw Revenue"}
+          </button>
+          {withdrawTx.status === "success" && (
+            <p className="text-sm text-center mt-2" style={{ color: "var(--color-success)" }}>
+              Revenue withdrawn successfully!
+            </p>
+          )}
         </div>
         <div className="card">
           <span className="text-sm text-muted block mb-2">Last 7 Days Revenue</span>
@@ -166,6 +198,18 @@ export default function MerchantDashboard({
       {error && <ErrorRecovery error={error} />}
 
       {tx.error && <ErrorRecovery error={tx.error} />}
+
+      {withdrawTx.error && <ErrorRecovery error={withdrawTx.error} />}
+
+      {showWithdrawConfirm && (
+        <ConfirmModal
+          message={`Withdraw ${displayCurrentAmount(revenue)} to your wallet? This transfers your full accrued revenue balance and cannot be undone.`}
+          onConfirm={handleWithdraw}
+          onCancel={() => setShowWithdrawConfirm(false)}
+          confirmTestId="withdraw-confirm-button"
+          cancelTestId="withdraw-cancel-button"
+        />
+      )}
 
       {subscribers.length === 0 ? (
         <div className="card">

--- a/frontend/src/stellar.ts
+++ b/frontend/src/stellar.ts
@@ -781,6 +781,10 @@ export function getMerchantRevenue(merchant: string): Promise<bigint> {
   });
 }
 
+export async function buildWithdrawMerchantRevenueTx(merchant: string): Promise<string> {
+  return buildTx(merchant, "withdraw_merchant_revenue", [addressVal(merchant)]);
+}
+
 export async function getBalance(
   publicKey: string,
   fields?: { asset_type?: string }

--- a/frontend/src/utils/errors.ts
+++ b/frontend/src/utils/errors.ts
@@ -13,6 +13,8 @@ export const CONTRACT_ERRORS: Record<string, string> = {
     "Your subscription data has been archived by the Stellar network. Use Restore to recover it.",
   "-32700":
     "Your subscription data has been archived by the Stellar network. Use Restore to recover it.",
+  "#21": "You have no withdrawable revenue yet.",
+  zerobalanceavailable: "You have no withdrawable revenue yet.",
 };
 
 export function friendlyError(raw: string): string {


### PR DESCRIPTION
## Summary
- Adds `buildWithdrawMerchantRevenueTx(merchant)` to `stellar.ts`, wrapping the on-chain `withdraw_merchant_revenue` call.
- Adds a "Withdraw Revenue" button to the Total Revenue card in `MerchantDashboard`, disabled when accrued revenue is zero or a withdrawal is already pending.
- Clicking it opens a `ConfirmModal` showing the exact amount to be withdrawn before submitting; on success the dashboard refreshes so revenue reflects the new (zero) balance.
- Adds a friendly error mapping for the `ZeroBalanceAvailable` contract error, surfaced via the existing `ErrorRecovery` component on failure.
- `ConfirmModal` gained optional `confirmTestId`/`cancelTestId` props (backward compatible) so its buttons are targetable in tests.

Closes #865

## Acceptance criteria
- [x] Shows the withdrawable amount
- [x] Confirm before submit
- [x] Handles ZeroBalanceAvailable
- [x] Tests included

## Test plan
- `npm run lint` — 0 errors
- `npm run build` — succeeds
- `npx vitest run` — all tests pass, including 5 new tests in `MerchantDashboard.test.tsx` covering disabled/enabled states, confirm/cancel, success + refresh, and the ZeroBalanceAvailable failure path