### PR TITLE
feat(frontend): orchestrate notification priority between pause banner and toasts

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,12 +3,15 @@ import { useWallet, AVAILABLE_WALLETS } from "./hooks/useWallet";
 import { useAccessibility } from "./hooks/useAccessibility";
 import { useNetworkCheck } from "./hooks/useNetworkCheck";
 import { useAdmin } from "./hooks/useAdmin";
+import { useContractPaused } from "./hooks/useContractPaused";
+import { useToast } from "./hooks/useToast";
 import SubscribeForm from "./components/SubscribeForm";
 import Dashboard from "./components/Dashboard";
 import MerchantDashboard from "./components/MerchantDashboard";
 import WalletSelectModal from "./components/WalletSelectModal";
 import WalletBar from "./components/WalletBar";
 import TabBar from "./components/TabBar";
+import ContractPauseBanner from "./components/ContractPauseBanner";
 import AdminDashboard from "./pages/AdminDashboard";
 import type { WalletAdapter } from "./services/wallets/WalletAdapter";
 
@@ -20,6 +23,13 @@ export default function App() {
   const { announcement, announce } = useAccessibility();
   const { networkMatch, walletNetwork } = useNetworkCheck();
   const { isAdmin } = useAdmin(publicKey);
+  const { isPaused } = useContractPaused();
+  // Dashboard/SubscribeForm/MerchantDashboard/admin panels each keep their own
+  // useToast() instance (and their own tests mock them independently), so
+  // centralizing every toast call site into one shared instance is out of
+  // scope here. This App-level instance exists solely to drive the header's
+  // NotificationCenter (issue #864).
+  const { notifications, unreadCount, markAllRead, clearNotifications } = useToast();
   const [tab, setTab] = useState<Tab>("dashboard");
   const [refresh, setRefresh] = useState(0);
   const [showWalletModal, setShowWalletModal] = useState(false);
@@ -36,6 +46,10 @@ export default function App() {
 
   return (
     <div style={{ maxWidth: 480, margin: "60px auto", padding: "0 16px" }}>
+      {/* Contract pause banner — rendered first so it takes precedence over
+          everything else, including toasts (see index.css stacking rules). */}
+      <ContractPauseBanner paused={isPaused} />
+
       {/* ARIA live region for screen reader announcements */}
       <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
         {announcement}
@@ -88,6 +102,10 @@ export default function App() {
             publicKey={publicKey}
             activeAdapter={activeAdapter}
             onDisconnect={disconnect}
+            notifications={notifications}
+            unreadCount={unreadCount}
+            onMarkAllRead={markAllRead}
+            onClearNotifications={clearNotifications}
           />
 
           {/* Tab navigation — admin tab only visible to contract admin */}
@@ -111,6 +129,7 @@ export default function App() {
                 onSign={signAndSubmit}
                 refreshTrigger={refresh}
                 announce={announce}
+                isPaused={isPaused}
               />
             )}
             {tab === "merchant" && (
@@ -118,6 +137,7 @@ export default function App() {
                 merchantKey={publicKey}
                 onSign={signAndSubmit}
                 refreshTrigger={refresh}
+                isPaused={isPaused}
               />
             )}
             {tab === "admin" && isAdmin && (

--- a/frontend/src/__tests__/App.notificationOrchestration.test.tsx
+++ b/frontend/src/__tests__/App.notificationOrchestration.test.tsx
@@ -1,0 +1,183 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import NotificationCenter from "../components/NotificationCenter";
+import type { Notification } from "../hooks/useToast";
+
+// Mock Stellar BEFORE importing App — useNetworkCheck imports NETWORK_PASSPHRASE
+// from here at module load time, so the real @stellar/stellar-sdk must not load.
+vi.mock("../stellar", () => ({
+  NETWORK_PASSPHRASE: "Test SDF Network ; September 2015",
+  RPC_URL: "https://soroban-testnet.stellar.org",
+  CONTRACT_ID: "",
+  TOKEN_CONTRACT_ID: "",
+  server: { sendTransaction: vi.fn() },
+  getContractAdmin: vi.fn().mockResolvedValue(null),
+}));
+
+// Mock useWallet so wallet-connected state is controllable per test.
+vi.mock("../hooks/useWallet", () => ({
+  AVAILABLE_WALLETS: [],
+  useWallet: vi.fn(() => ({
+    publicKey: null,
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    signAndSubmit: vi.fn(),
+    error: null,
+    connecting: false,
+    ready: true,
+    activeAdapter: null,
+  })),
+}));
+
+// Mock useAdmin — irrelevant to notification/pause orchestration.
+vi.mock("../hooks/useAdmin", () => ({
+  useAdmin: vi.fn(() => ({
+    isAdmin: false,
+    adminAddress: null,
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+  })),
+}));
+
+// Mock useContractPaused — the single source of truth this test suite exercises.
+vi.mock("../hooks/useContractPaused", () => ({
+  useContractPaused: vi.fn(() => ({ isPaused: false, loading: false })),
+}));
+
+// Mock heavy child components so this suite stays focused on App-level wiring.
+vi.mock("../components/SubscribeForm", () => ({
+  default: () => <div data-testid="subscribe-form" />,
+}));
+vi.mock("../pages/AdminDashboard", () => ({
+  default: () => <div data-testid="admin-dashboard" />,
+}));
+vi.mock("../components/Dashboard", () => ({
+  default: (props: { isPaused?: boolean }) => (
+    <div data-testid="dashboard" data-is-paused={String(props.isPaused)} />
+  ),
+}));
+vi.mock("../components/MerchantDashboard", () => ({
+  default: (props: { isPaused?: boolean }) => (
+    <div data-testid="merchant-dashboard" data-is-paused={String(props.isPaused)} />
+  ),
+}));
+
+// WalletBar renders NotificationCenter internally in the real app; mock it
+// down to that same wiring so we can verify App -> WalletBar -> NotificationCenter
+// prop flow without pulling in WalletBar's heavier deps (balance/network badges).
+vi.mock("../components/WalletBar", () => {
+  return {
+    default: (props: {
+      publicKey: string;
+      onDisconnect: () => void;
+      notifications?: Notification[];
+      unreadCount?: number;
+      onMarkAllRead?: () => void;
+      onClearNotifications?: () => void;
+    }) => {
+      return (
+        <div data-testid="wallet-bar">
+          <span>{props.publicKey}</span>
+          <NotificationCenter
+            notifications={props.notifications ?? []}
+            unreadCount={props.unreadCount ?? 0}
+            onMarkAllRead={props.onMarkAllRead ?? (() => {})}
+            onClearAll={props.onClearNotifications ?? (() => {})}
+          />
+          <button onClick={props.onDisconnect}>Disconnect</button>
+        </div>
+      );
+    },
+  };
+});
+
+import App from "../App";
+import { useWallet } from "../hooks/useWallet";
+import { useContractPaused } from "../hooks/useContractPaused";
+
+function mockWallet(publicKey: string | null) {
+  (useWallet as ReturnType<typeof vi.fn>).mockReturnValue({
+    publicKey,
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    signAndSubmit: vi.fn(),
+    error: null,
+    connecting: false,
+    ready: true,
+    activeAdapter: publicKey ? { id: "freighter", name: "Freighter", icon: "🚢" } : null,
+  });
+}
+
+function mockPaused(isPaused: boolean) {
+  (useContractPaused as ReturnType<typeof vi.fn>).mockReturnValue({ isPaused, loading: false });
+}
+
+describe("App — notification priority orchestration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockWallet(null);
+    mockPaused(false);
+  });
+
+  it("renders the contract pause banner when the contract is paused", () => {
+    mockPaused(true);
+    render(<App />);
+    const banner = screen.getByTestId("contract-pause-banner");
+    expect(banner).toBeInTheDocument();
+    expect(banner).toHaveAttribute("role", "alert");
+  });
+
+  it("does not render the contract pause banner when the contract is not paused", () => {
+    mockPaused(false);
+    render(<App />);
+    expect(screen.queryByTestId("contract-pause-banner")).not.toBeInTheDocument();
+  });
+
+  it("renders the pause banner before any other app content in the DOM", () => {
+    mockPaused(true);
+    mockWallet("GABCDEF1234567890");
+    render(<App />);
+    const banner = screen.getByTestId("contract-pause-banner");
+    const walletBar = screen.getByTestId("wallet-bar");
+    // compareDocumentPosition: banner precedes walletBar in document order.
+    const position = banner.compareDocumentPosition(walletBar);
+    expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it("threads isPaused=true down to Dashboard", () => {
+    mockPaused(true);
+    mockWallet("GABCDEF1234567890");
+    render(<App />);
+    expect(screen.getByTestId("dashboard")).toHaveAttribute("data-is-paused", "true");
+  });
+
+  it("threads isPaused=false down to Dashboard", () => {
+    mockPaused(false);
+    mockWallet("GABCDEF1234567890");
+    render(<App />);
+    expect(screen.getByTestId("dashboard")).toHaveAttribute("data-is-paused", "false");
+  });
+
+  it("threads isPaused down to MerchantDashboard", () => {
+    mockPaused(true);
+    mockWallet("GABCDEF1234567890");
+    render(<App />);
+    // Dashboard is the default tab; switch to Merchant to render MerchantDashboard.
+    fireEvent.click(screen.getByRole("tab", { name: "Merchant" }));
+    expect(screen.getByTestId("merchant-dashboard")).toHaveAttribute("data-is-paused", "true");
+  });
+
+  it("mounts NotificationCenter (bell trigger) once a wallet is connected", () => {
+    mockWallet("GABCDEF1234567890");
+    render(<App />);
+    expect(screen.getByTestId("notification-bell")).toBeInTheDocument();
+  });
+
+  it("does not render NotificationCenter before a wallet is connected", () => {
+    mockWallet(null);
+    render(<App />);
+    expect(screen.queryByTestId("notification-bell")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/notificationPriority.test.ts
+++ b/frontend/src/__tests__/notificationPriority.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { shouldShowToastWhilePaused } from "../utils/notificationPriority";
+
+describe("shouldShowToastWhilePaused", () => {
+  it("allows info toasts when not paused", () => {
+    expect(shouldShowToastWhilePaused("info", false)).toBe(true);
+  });
+
+  it("allows success toasts when not paused", () => {
+    expect(shouldShowToastWhilePaused("success", false)).toBe(true);
+  });
+
+  it("allows error toasts when not paused", () => {
+    expect(shouldShowToastWhilePaused("error", false)).toBe(true);
+  });
+
+  it("suppresses info toasts while paused", () => {
+    expect(shouldShowToastWhilePaused("info", true)).toBe(false);
+  });
+
+  it("allows success toasts while paused", () => {
+    expect(shouldShowToastWhilePaused("success", true)).toBe(true);
+  });
+
+  it("allows error toasts while paused", () => {
+    expect(shouldShowToastWhilePaused("error", true)).toBe(true);
+  });
+});

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -243,7 +243,7 @@ export default function Dashboard({
         </>
       )}
 
-      <ToastContainer toasts={toasts} onRemove={removeToast} />
+      <ToastContainer toasts={toasts} onRemove={removeToast} isPaused={isPaused} />
 
       {showDailyLimit && sub?.active && (
         <DailyLimitModal

--- a/frontend/src/components/Toast.tsx
+++ b/frontend/src/components/Toast.tsx
@@ -1,17 +1,21 @@
 import type { Toast } from "../hooks/useToast";
 import { explorerTxUrl } from "../stellar";
 import { formatAddress } from "../utils/format";
+import { shouldShowToastWhilePaused } from "../utils/notificationPriority";
 
 interface Props {
   toasts: Toast[];
   onRemove: (id: number) => void;
+  /** When true, suppresses informational toasts so they don't compete with the contract pause banner. */
+  isPaused?: boolean;
 }
 
-export default function ToastContainer({ toasts, onRemove }: Props) {
-  if (!toasts.length) return null;
+export default function ToastContainer({ toasts, onRemove, isPaused = false }: Props) {
+  const visibleToasts = toasts.filter((t) => shouldShowToastWhilePaused(t.variant, isPaused));
+  if (!visibleToasts.length) return null;
   return (
     <div className="toast-container">
-      {toasts.map((t) => (
+      {visibleToasts.map((t) => (
         <div key={t.id} className={`toast toast--${t.variant} fade-in`}>
           <span>
             {t.message}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -634,6 +634,14 @@ input::placeholder {
   border-radius: var(--radius-md);
   font-size: var(--text-sm);
   font-weight: var(--font-medium);
+  margin-bottom: var(--space-4);
+  /* Notification priority (issue #864): the pause banner is the single
+     source of truth for maintenance state and must never be visually
+     obscured by toasts. It sticks to the top of the viewport and sits
+     above the toast container's stacking context (see .toast-container). */
+  position: sticky;
+  top: 0;
+  z-index: 300;
 }
 
 .contract-pause-banner__icon {
@@ -643,6 +651,24 @@ input::placeholder {
 
 .contract-pause-banner__message {
   flex: 1;
+}
+
+/* ─────────────────────────────────────────────────────────────────────────────
+   Toast Container (notification priority — issue #864)
+   Fixed to a corner so toasts never push page content around; kept below the
+   contract pause banner's z-index so the banner is always on top when both
+   are visible at once.
+   ───────────────────────────────────────────────────────────────────────────── */
+
+.toast-container {
+  position: fixed;
+  top: var(--space-4);
+  right: var(--space-4);
+  z-index: 150;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  max-width: min(360px, calc(100vw - var(--space-8)));
 }
 
 .merchant-row {

--- a/frontend/src/utils/notificationPriority.ts
+++ b/frontend/src/utils/notificationPriority.ts
@@ -1,0 +1,16 @@
+import type { ToastVariant } from "../hooks/useToast";
+
+/**
+ * Decides whether a toast should be shown while the contract is paused.
+ *
+ * The contract pause banner (role="alert") is the single source of truth for
+ * maintenance state and must take visual precedence over transient toasts.
+ * Informational toasts add nothing the banner hasn't already said, so they
+ * are suppressed while paused. Success/error toasts reflect the direct
+ * consequences of the user's own actions and are always shown regardless of
+ * pause state.
+ */
+export function shouldShowToastWhilePaused(variant: ToastVariant, isPaused: boolean): boolean {
+  if (!isPaused) return true;
+  return variant !== "info";
+}


### PR DESCRIPTION
## Summary
Wires three previously-unconnected pieces into the app shell:
- `useContractPaused()` is now called in `App.tsx` as the single source of truth for maintenance state, and `isPaused` is threaded down to `Dashboard` and `MerchantDashboard` (both already accepted the prop but never received a real value).
- `ContractPauseBanner` is now rendered — first, before anything else in the app shell — so it's always the first thing seen and DOM-precedes the toast layer.
- `NotificationCenter` is now actually reachable: `App.tsx` owns a `useToast()` instance feeding it through `WalletBar` (which already accepted the notification props but never received them).
- Added a pure, directly-tested helper `shouldShowToastWhilePaused(variant, isPaused)`: while the contract is paused, informational toasts are suppressed so they don't compete with the banner; success/error toasts (direct consequences of the user's own actions) always show. Wired into `ToastContainer`.
- `index.css`: gave the pause banner a higher stacking context (`position: sticky; z-index: 300`) than the toast container (`position: fixed; z-index: 150`), so the banner is never visually obscured by toasts.

Note: per-component `useToast()` instances (Dashboard, SubscribeForm, admin panels, etc.) were left as-is rather than fully centralized — several have existing tests that mock `useToast` independently, and rerouting all of them through props was riskier than this issue's scope warranted. The App-level `useToast()` instance exists specifically to drive `NotificationCenter`; documented inline in `App.tsx`.

Closes #864

## Acceptance criteria
- [x] Pause banner takes precedence visually
- [x] Toasts do not hide critical banners
- [x] Tests for priority

## Test plan
- `npm run lint` — 0 errors
- `npm run build` — succeeds
- `npx vitest run` — all tests pass, including new `notificationPriority.test.ts` (6 tests, all variant × isPaused combinations) and `App.notificationOrchestration.test.tsx` (8 tests covering banner visibility, DOM precedence, isPaused propagation, and NotificationCenter mounting)