### PR TITLE
feat: mainnet safety gate, tx recovery, daily limit UX + security review (#846, #847, #845, #793)

### DIFF
--- a/docs/SECURITY-REVIEW.html
+++ b/docs/SECURITY-REVIEW.html
@@ -1,0 +1,280 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PayFlow Security Review — Top 3 Issues (2026-08-28)</title>
+<meta name="description" content="Point-in-time security review of PayFlow (FlowPay) Soroban contract and frontend — top 3 issues, impact, and mitigations. Not a formal audit.">
+<style>
+  :root {
+    --bg: #0f0f14;
+    --card: #1a1a2e;
+    --border: #2d2d3f;
+    --text: #e2e8f0;
+    --muted: #94a3b8;
+    --subtle: #64748b;
+    --primary: #7c3aed;
+    --danger: #f87171;
+    --warn: #fbbf24;
+    --success: #4ade80;
+    --info: #60a5fa;
+  }
+  * { box-sizing: border-box; }
+  body {
+    font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.6;
+    margin: 0;
+    padding: 0;
+  }
+  header {
+    max-width: 880px;
+    margin: 0 auto;
+    padding: 40px 20px 20px;
+    text-align: center;
+  }
+  header h1 { font-size: 28px; font-weight: 800; margin: 0; color: #a78bfa; }
+  header p { color: var(--muted); margin: 8px 0 0; font-size: 14px; }
+  .badge {
+    display: inline-block;
+    padding: 4px 10px;
+    border-radius: 999px;
+    font-size: 12px;
+    font-weight: 600;
+    margin-top: 10px;
+  }
+  .badge-warn { background: #451a03; color: var(--warn); border: 1px solid #92400e; }
+  .badge-info { background: #1e1b4b; color: #c7d2fe; border: 1px solid #4338ca; }
+  main { max-width: 880px; margin: 0 auto; padding: 20px; display: flex; flex-direction: column; gap: 24px; }
+  .card {
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 24px;
+  }
+  .card h2 { font-size: 18px; margin: 0 0 6px; }
+  .card h3 { font-size: 14px; color: var(--muted); margin: 16px 0 8px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; }
+  .severity { display: inline-flex; align-items: center; gap: 6px; padding: 3px 10px; border-radius: 999px; font-size: 12px; font-weight: 700; }
+  .sev-high { background: #3f1515; color: var(--danger); }
+  .sev-medium { background: #451a03; color: var(--warn); }
+  .sev-low { background: rgba(74,222,128,0.12); color: var(--success); }
+  table { width: 100%; border-collapse: collapse; font-size: 13px; margin: 12px 0; }
+  th, td { border: 1px solid var(--border); padding: 8px 10px; text-align: left; }
+  th { background: #1e1e2e; color: var(--muted); font-weight: 600; }
+  td { color: var(--text); }
+  code, .mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; background: #1e1e2e; padding: 2px 6px; border-radius: 6px; border: 1px solid var(--border); }
+  pre { background: #1e1e2e; border: 1px solid var(--border); border-radius: 8px; padding: 14px; overflow-x: auto; font-size: 12px; color: #cbd5e1; }
+  .grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+  @media (max-width: 640px) { .grid { grid-template-columns: 1fr; } }
+  a { color: var(--info); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  footer { max-width: 880px; margin: 0 auto; padding: 16px 20px 40px; color: var(--subtle); font-size: 12px; text-align: center; }
+  .toc { list-style: none; padding: 0; margin: 8px 0 0; }
+  .toc li { margin: 4px 0; }
+  .callout { border-left: 3px solid var(--warn); padding: 12px 16px; background: rgba(251,191,36,0.06); border-radius: 8px; font-size: 13px; color: var(--muted); }
+  .issue-num { color: var(--primary); font-weight: 800; }
+</style>
+</head>
+<body>
+<header>
+  <h1>⚡ PayFlow Security Review</h1>
+  <p>Point-in-time review — Top 3 security issues found in <strong>PayFlow (FlowPay)</strong> — Soroban contract + React frontend</p>
+  <p>
+    <span class="badge badge-warn">Not a formal audit — Testnet only</span>
+    <span class="badge badge-info" style="margin-left:8px;">Revision: 2026-08-28</span>
+  </p>
+  <p style="margin-top:12px; font-size:12px; color:var(--subtle);">
+    Scope: <code>contract/src/lib.rs</code>, <code>spending_limit.rs</code>, <code>admin.rs</code>, <code>fee.rs</code>, <code>frontend/src/stellar.ts</code>, <code>useWallet.ts</code>/hooks, <code>docs/SECURITY.md</code>. &nbsp;|&nbsp;
+    Disclosure: <a href="mailto:security@payflow.dev">security@payflow.dev</a> &nbsp;|&nbsp;
+    <a href="./SECURITY.md">Threat model</a>
+  </p>
+</header>
+
+<main>
+  <section class="card" aria-labelledby="summary-title">
+    <h2 id="summary-title">Executive Summary</h2>
+    <p style="color:var(--muted); font-size:14px;">
+      This review was performed against the current <code>master</code> without running a full audit toolchain. It surfaces the three most load-bearing risks a reviewer or auditor should validate first. All three are <em>acknowledged</em> in existing docs (<code>docs/SECURITY.md</code>, <code>DAILY-LIMITS.md</code>, <code>SECURITY.md</code>), but require concrete product mitigations before mainnet.
+    </p>
+    <table aria-label="Summary of top 3 issues">
+      <thead><tr><th>#</th><th>Issue</th><th>Severity</th><th>Primary location</th><th>Status</th></tr></thead>
+      <tbody>
+        <tr><td><span class="issue-num">1</span></td><td>Overly broad token allowance without mandatory daily cap</td><td><span class="severity sev-high">High</span></td><td><code>pay_per_use</code> / <code>fee::transfer_*</code> + <code>stellar.ts</code></td><td>Acknowledged — docs warn, UI now adds proactive limit UX</td></tr>
+        <tr><td><span class="issue-num">2</span></td><td>Single admin key with broad powers</td><td><span class="severity sev-high">High</span></td><td><code>admin.rs</code>, <code>lib.rs</code> pause/fee/whitelist</td><td>Acknowledged — two-step transfer + audit roadmap</td></tr>
+        <tr><td><span class="issue-num">3</span></td><td>Storage TTL expiry &amp; keeper liveness (temporary entries + persistent TTL)</td><td><span class="severity sev-medium">Medium</span></td><td><code>spending_limit.rs</code>, <code>storage.rs</code>, <code>DAILY-LIMITS.md</code></td><td>Acknowledged — TTL docs, <code>extend_subscription_ttl</code> / <code>bump_instance_ttl</code> exist</td></tr>
+      </tbody>
+    </table>
+    <div class="callout" role="note">
+      <strong>Method:</strong> Static read of contract entrypoints, auth matrix (<code>docs/SECURITY.md:60-99</code>), storage/TTL notes, and frontend allowance/limit flows. No fuzzing or on-chain exploit was executed. Severity reflects ease of abuse × blast radius if left unmitigated.
+    </div>
+  </section>
+
+  <section class="card" aria-labelledby="issue1-title">
+    <h2 id="issue1-title"><span class="issue-num">#1</span> Overly broad token allowance + pay-per-use drain if daily limit not set</h2>
+    <span class="severity sev-high">Severity: High — user funds at risk</span>
+    <p style="color:var(--muted); font-size:13px;">Location: <code>contract/src/lib.rs:pay_per_use</code>, <code>contract/src/fee.rs:transfer_pay_per_use</code>, <code>contract/src/spending_limit.rs</code>, <code>frontend/src/stellar.ts:getAllowance / buildApproveTx</code>, <code>components/AllowanceDisplay.tsx</code>, <code>components/DailyLimitCard.tsx</code>, <code>DailyLimitModal.tsx</code></p>
+
+    <h3>Description</h3>
+    <p>
+      Subscribing approves the contract to <code>transfer_from</code> the user's SAC token. Recurring <code>charge()</code> is bounded by fixed <code>amount</code>/<code>interval</code>, but <code>pay_per_use</code> and <code>pay_per_use_to</code> pull <em>arbitrary</em> amounts on demand. If a user approves a large allowance (or infinite) and never calls <code>set_daily_limit</code>, a buggy or compromised frontend/merchant integration can repeatedly call <code>pay_per_use</code> until allowance is exhausted. <code>spending_limit::enforce_limit</code> only checks when a limit is present (<code>Some(limit)</code>); otherwise spending is uncapped by that control.
+    </p>
+
+    <h3>Impact</h3>
+    <ul style="color:var(--muted); font-size:14px;">
+      <li>Single compromised merchant or wallet-signed promise can drain allowance without further user prompts.</li>
+      <li>Fees are counted toward the daily limit, but do not reduce net received — UI that only shows “merchant received” misreads budget.</li>
+      <li>Shared pool across <code>pay_per_use</code> and <code>pay_per_use_to</code> means “pay to custom recipient” uses the same budget — easy to miss without UX.</li>
+    </ul>
+
+    <h3>Reproduction (static)</h3>
+    <pre>1. subscribe(user, merchant, amount=5 XLM, interval, token, ...)  — approve 1_000 XLM
+2. (do NOT call set_daily_limit)
+3. pay_per_use(user, 100 XLM)  — succeeds, repeated until allowance gone
+4. get_daily_limit(user) → None, get_daily_spent → 0, DayStart → false — no warning</pre>
+
+    <h3>Recommendation</h3>
+    <ul style="color:var(--muted); font-size:14px;">
+      <li><strong>Product:</strong> Proactively surface <code>limit / spent / remaining</code> + reset timing (<code>day_start</code>) in the pay-per-use flow and block the wallet prompt when <code>amount &gt; remaining</code> (implemented in this PR: <code>PayPerUseForm.tsx:remaining</code>, <code>DailyLimitCard.tsx</code> progress + “resets ~24h after first spend”). Simulate before signing to catch <code>DailyLimitExceeded (code 24)</code>.</li>
+      <li><strong>Allowance hygiene:</strong> Encourage minimal allowances via <code>AllowanceDisplay</code> + <code>IncreaseAllowanceModal</code>; document “approve exactly what you need” in <code>docs/SECURITY.md</code> and the subscribe flow.</li>
+      <li><strong>Defaults:</strong> Consider prompting for a daily limit during <code>subscribe</code> (or defaulting to e.g. 2× subscription amount) — currently opt-in.</li>
+      <li><strong>Docs:</strong> <code>docs/DAILY-LIMITS.md:413-420</code> already lists UX recommendations; enforce them in UI.</li>
+    </ul>
+
+    <h3>Status</h3>
+    <p style="color:var(--muted); font-size:14px;">Acknowledged. This PR (Issues <code>#845</code> / 050) adds <code>getDayStart</code> + <code>getDailyLimitStatus</code> helpers, remaining/progress UI, and pre-wallet validation. Formal audit still required before mainnet (<code>SECURITY.md</code> roadmap).</p>
+  </section>
+
+  <section class="card" aria-labelledby="issue2-title">
+    <h2 id="issue2-title"><span class="issue-num">#2</span> Single admin key with broad, pause/fee/whitelist powers</h2>
+    <span class="severity sev-high">Severity: High — protocol-wide trust</span>
+    <p style="color:var(--muted); font-size:13px;">Location: <code>contract/src/admin.rs</code>, <code>contract/src/lib.rs:freeze_merchant / set_subscription_amount / propose_fee / pause_contract</code>, <code>docs/SECURITY.md:60-99</code> auth matrix</p>
+
+    <h3>Description</h3>
+    <p>
+      The contract admin can freeze merchants, adjust subscription amounts/intervals, set minimum interval, propose/commit fee and grace-period changes, toggle whitelist, pause the whole contract, clear merchant revenue history, upgrade via two-step propose/commit, and batch-pause subscriptions. The auth matrix documents this correctly. Until governance is tightened, the admin key is a single point of compromise. This is <em>by design</em> pre-audit, but the blast radius is high: a compromised admin could pause the protocol, redirect fees, or whitelist a malicious merchant.
+    </p>
+
+    <h3>Impact</h3>
+    <ul style="color:var(--muted); font-size:14px;">
+      <li>Stolen admin key → can pause charges, change fees, or upgrade the contract (upgrade authority review noted in <code>docs/SECURITY.md:122-140</code>).</li>
+      <li>Admin powers are documented as “broad and should be treated as high trust until governance is tightened” — but frontend does not surface this risk to merchants/users.</li>
+    </ul>
+
+    <h3>Reproduction (static)</h3>
+    <pre>// As admin:
+propose_fee(new_collector, 500) → commit_fee()  // fee now 5%
+freeze_merchant(victim, None)                     // blocks new subs
+pause_contract()                                 // all charge/pay_per_use panics
+// All require admin.require_auth(); verify via
+//   contract/src/admin.rs:require_admin</pre>
+
+    <h3>Recommendation</h3>
+    <ul style="color:var(--muted); font-size:14px;">
+      <li><strong>Governance:</strong> Move admin to a multisig or timelock before mainnet; publish the audit-candidate WASM hash and freeze non-essential admin powers post-audit.</li>
+      <li><strong>Two-step:</strong> Keep existing two-step flows (<code>transfer_admin</code>/<code>accept_admin</code>, <code>propose_fee</code>/<code>commit_fee</code>, <code>propose_grace_period</code>/<code>commit_grace_period</code>, <code>propose_upgrade</code>/<code>commit_upgrade</code>) and add UI confirmation (“You are performing an admin action — this is high trust”).</li>
+      <li><strong>Monitoring:</strong> Index <code>fee_proposed / fee_committed / paused</code> events for alerts; keep <code>ContractPauseBanner</code> as the single source of truth (already sticky, z-index 300).</li>
+      <li><strong>Docs:</strong> Tighten <code>docs/SECURITY.md</code> “Admin powers are broad” into a checklist with owners before mainnet.</li>
+    </ul>
+
+    <h3>Status</h3>
+    <p style="color:var(--muted); font-size:14px;">Acknowledged — documented in <code>docs/SECURITY.md:142-148</code> known limitations and audit roadmap. No code change in this PR beyond surfacing the risk; governance hardening is a follow-up.</p>
+  </section>
+
+  <section class="card" aria-labelledby="issue3-title">
+    <h2 id="issue3-title"><span class="issue-num">#3</span> Storage TTL expiry &amp; keeper liveness (temporary + persistent)</h2>
+    <span class="severity sev-medium">Severity: Medium — availability &amp; accounting</span>
+    <p style="color:var(--muted); font-size:13px;">Location: <code>contract/src/spending_limit.rs:LEDGERS_PER_DAY=17_280</code>, <code>contract/src/storage.rs</code>, <code>contract/src/lib.rs:extend_subscription_ttl / bump_instance_ttl</code>, <code>docs/DAILY-LIMITS.md:58-102</code>, <code>docs/SECURITY.md:104-122</code></p>
+
+    <h3>Description</h3>
+    <p>
+      Daily-limit keys (<code>DailyLimit</code>, <code>DailySpent</code>, <code>DayStart</code>) live in <em>temporary</em> storage with TTL ≈ 17,280 ledgers (~24h). <code>DailyLimit</code> can expire after ~1 day of inactivity, silently removing the cap (<code>get_daily_limit → None</code>) while <code>DayStart</code> remains until its own window expires — a confusing mid-transition (<code>docs/DAILY-LIMITS.md:199-204</code>). Separately, subscription entries are in <em>persistent</em> storage but can be archived if TTL is not refreshed; users must call <code>extend_subscription_ttl</code>. The keeper (<code>charge</code>/<code>batch_charge</code>) is an external liveness dependency with no decentralized dispute layer.
+    </p>
+
+    <h3>Impact</h3>
+    <ul style="color:var(--muted); font-size:14px;">
+      <li>User sets a cap, goes inactive for a day, limit expires — next <code>pay_per_use</code> is uncapped until they re-apply.</li>
+      <li>Spend window is ledger-count based, not wall-clock; “resets at midnight” assumptions fail. Testnet ledgers are less regular.</li>
+      <li>If persistent TTL is not bumped, <code>Subscription</code> can be archived (<code>entryExpired / -32700</code>) and reads fail until <code>extend_subscription_ttl</code> / <code>SubscriptionRepairPanel</code>.</li>
+      <li>Keeper downtime → delayed charges; no on-chain retry — users may miss grace windows.</li>
+    </ul>
+
+    <h3>Reproduction (static)</h3>
+    <pre>// From contract/src/test.rs: test_daily_limit_day_start_boundary
+set_daily_limit(user, 10 XLM);
+pay_per_use(user, 4 XLM);          // DayStart created, DailySpent=4
+// Advance 17_281 ledgers
+env.ledger().sequence_number += 17281;
+pay_per_use(user, 8 XLM);          // passes — DayStart expired, spent reset to 8
+get_day_start(user) → None→ fresh window
+
+// Allowance TTL edge:
+set_daily_limit(user, 5 XLM);      // TTL ~1 day from now
+// wait ~1 day inactive, then pay_per_use → limit is None, uncapped</pre>
+
+    <h3>Recommendation</h3>
+    <ul style="color:var(--muted); font-size:14px;">
+      <li><strong>UI:</strong> Show <code>limit / spent / remaining</code> + “resets ~24h after first spend today” + progress bar; warn when a previously known limit becomes <code>None</code> (TTL expiry) and offer to re-apply (done in this PR).</li>
+      <li><strong>Refresh:</strong> Auto-bump persistent TTL on lifecycle mutations (<code>subscribe / charge / pause / resume</code> already do) and expose <code>extend_subscription_ttl</code> / <code>bump_subscription</code> keepers for dormant accounts (already exists).</li>
+      <li><strong>Keeper:</strong> Document liveness SLA; consider <code>batch_extend_subscription_ttl</code> keepers for cold subscribers.</li>
+      <li><strong>Error mapping:</strong> Preserve <code>isArchivedError</code> handling (codes <code>-32700 / entryExpired / archived</code>) and <code>ErrorRecovery</code> restore flow.</li>
+    </ul>
+
+    <h3>Status</h3>
+    <p style="color:var(--muted); font-size:14px;">Acknowledged — TTL design is intentional (temporary = safe to recompute, persistent = less likely evicted). Mitigations are docs + UI + keepers; audit should validate <code>extend_ttl</code> coverage and keeper incentives.</p>
+  </section>
+
+  <section class="card" aria-labelledby="method-title">
+    <h2 id="method-title">Methodology &amp; Non-Goals</h2>
+    <div class="grid">
+      <div>
+        <h3>What was checked</h3>
+        <ul style="color:var(--muted); font-size:13px;">
+          <li>Auth matrix vs <code>lib.rs</code> / <code>admin.rs</code> / <code>migration.rs</code> / <code>upgrade.rs</code></li>
+          <li>Storage keys (<code>DataKey</code>) and TTL strategy</li>
+          <li><code>pay_per_use</code> shared-budget + fee split atomicity</li>
+          <li>Frontend allowance/daily-limit flows</li>
+          <li>Pause banner / toast priority, RPC health, allowlists</li>
+        </ul>
+      </div>
+      <div>
+        <h3>What was NOT checked</h3>
+        <ul style="color:var(--muted); font-size:13px;">
+          <li>Fuzzing / formal verification / full audit</li>
+          <li>Third-party SAC or Freighter internals</li>
+          <li>Off-chain keeper/indexer correctness</li>
+          <li>Economic caps beyond code constants</li>
+        </ul>
+      </div>
+    </div>
+    <h3>How to verify</h3>
+    <pre>cd contract && cargo test daily_limit        # spending_limit suite (9 cases)
+cd frontend && npm run test -- DailyLimit         # limit UX + PayPerUseForm limit
+cd frontend && npm run test -- network            # mainnet gate
+cd frontend && npm run test -- txQueue            # persistence + recovery
+# Open this file directly: docs/SECURITY-REVIEW.html</pre>
+    <p style="color:var(--muted); font-size:13px;">
+      Related: <a href="./DAILY-LIMITS.md">DAILY-LIMITS.md</a> · <a href="./SECURITY.md">SECURITY.md</a> · <a href="../SECURITY.md">Root SECURITY.md</a> · <a href="./ERROR-CODES.md">ERROR-CODES.md</a>
+    </p>
+  </section>
+
+  <section class="card" aria-labelledby="disclosure-title">
+    <h2 id="disclosure-title">Disclosure &amp; Next Steps</h2>
+    <p style="color:var(--muted); font-size:14px;">
+      Found something else? Report privately via <a href="https://github.com/SiLioLabs/PayFlow/security/advisories">GitHub Security Advisories</a> or email <code>security@payflow.dev</code> with subject <code>[FlowPay Security] …</code>. Please include steps to reproduce, impact, and suggested mitigation. We aim to acknowledge within 48h (<code>SECURITY.md</code>).
+    </p>
+    <p style="color:var(--muted); font-size:14px;">
+      Before mainnet: complete <code>docs/security/audit-preparation.md</code> checklist, freeze an audit candidate commit, publish the WASM hash, and engage a Soroban-focused auditor. This HTML is a <em>point-in-time</em> review and does not replace that audit.
+    </p>
+    <p style="font-size:12px; color:var(--subtle); margin-top:12px;">
+      Generated for PR closing <code>#846</code>, <code>#847</code>, <code>#845</code>, and review <code>#793</code>. Source: <code>contract/src/lib.rs</code>, <code>docs/DAILY-LIMITS.md</code>, <code>frontend/src/components/DailyLimitCard.tsx</code>, <code>PayPerUseForm.tsx</code>, <code>services/txQueue.ts</code>.
+    </p>
+  </section>
+</main>
+
+<footer>
+  <p>PayFlow (FlowPay) — Decentralized subscriptions on Stellar · Testnet only · <a href="https://github.com/SiLioLabs/PayFlow">SiLioLabs/PayFlow</a></p>
+  <p style="margin-top:6px;">This document is static HTML with no external dependencies. Print-friendly · Accessible · No JS required.</p>
+</footer>
+</body>
+</html>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import WalletSelectModal from "./components/WalletSelectModal";
 import WalletBar from "./components/WalletBar";
 import TabBar from "./components/TabBar";
 import ContractPauseBanner from "./components/ContractPauseBanner";
+import NetworkBadge from "./components/NetworkBadge";
 import AdminDashboard from "./pages/AdminDashboard";
 import type { WalletAdapter } from "./services/wallets/WalletAdapter";
 
@@ -21,7 +22,8 @@ export default function App() {
   const { publicKey, connect, disconnect, signAndSubmit, error, connecting, activeAdapter } =
     useWallet();
   const { announcement, announce } = useAccessibility();
-  const { networkMatch, walletNetwork } = useNetworkCheck();
+  const { networkMatch, walletNetwork, isMainnet, requiresMainnetConfirm, confirmMainnet } =
+    useNetworkCheck();
   const { isAdmin } = useAdmin(publicKey);
   const { isPaused } = useContractPaused();
   // Dashboard/SubscribeForm/MerchantDashboard/admin panels each keep their own
@@ -55,13 +57,34 @@ export default function App() {
         {announcement}
       </div>
 
-      {/* Header */}
+      {/* Header — NetworkBadge is persistent in shell so users always see Testnet/Mainnet */}
       <div style={{ marginBottom: 32, textAlign: "center" }}>
         <h1 style={{ fontSize: 28, fontWeight: 800, color: "#a78bfa" }}>⚡ FlowPay</h1>
         <p style={{ color: "#64748b", marginTop: 6, fontSize: 14 }}>
           Decentralized recurring payments on Stellar
         </p>
+        <div style={{ marginTop: 10, display: "flex", justifyContent: "center" }}>
+          <NetworkBadge />
+        </div>
       </div>
+
+      {/* Mainnet safety gate — require explicit confirmation once per session when passphrase is mainnet */}
+      {isMainnet && requiresMainnetConfirm && (
+        <div className="card" style={{ background: "#3b1f1f", borderColor: "#7f1d1d", marginBottom: 16 }}>
+          <p style={{ color: "#fbbf24", fontSize: 13, fontWeight: 600 }}>
+            ⚠ Mainnet mode — real funds at risk. Please confirm you intend to use Mainnet before
+            continuing.
+          </p>
+          <button
+            onClick={confirmMainnet}
+            className="btn-primary"
+            style={{ marginTop: 12 }}
+            data-testid="confirm-mainnet-btn"
+          >
+            I understand, continue on Mainnet
+          </button>
+        </div>
+      )}
 
       {/* Network mismatch warning — preserves passphrase/network check from useNetworkCheck */}
       {publicKey && !networkMatch && (

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -70,7 +70,10 @@ export default function App() {
 
       {/* Mainnet safety gate — require explicit confirmation once per session when passphrase is mainnet */}
       {isMainnet && requiresMainnetConfirm && (
-        <div className="card" style={{ background: "#3b1f1f", borderColor: "#7f1d1d", marginBottom: 16 }}>
+        <div
+          className="card"
+          style={{ background: "#3b1f1f", borderColor: "#7f1d1d", marginBottom: 16 }}
+        >
           <p style={{ color: "#fbbf24", fontSize: 13, fontWeight: 600 }}>
             ⚠ Mainnet mode — real funds at risk. Please confirm you intend to use Mainnet before
             continuing.

--- a/frontend/src/__tests__/DailyLimitCard.test.tsx
+++ b/frontend/src/__tests__/DailyLimitCard.test.tsx
@@ -51,7 +51,9 @@ describe("DailyLimitCard", () => {
     // Progress bar
     expect(screen.getByRole("progressbar", { name: /daily limit usage/i })).toBeInTheDocument();
     expect(screen.getByText(/70% used/)).toBeInTheDocument();
-    expect(screen.getByText(/Resets about 24 hours after your first spend today/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Resets about 24 hours after your first spend today/)
+    ).toBeInTheDocument();
   });
 
   it("shows Not set and uncapped hint when no limit", async () => {
@@ -85,7 +87,9 @@ describe("DailyLimitCard", () => {
     });
     const { default: Card4 } = await import("../components/DailyLimitCard");
     render(<Card4 userKey="GABC" refreshTrigger={0} onOpen={vi.fn()} />);
-    await waitFor(() => expect(screen.getByText(/Limit expired but window still active/)).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByText(/Limit expired but window still active/)).toBeInTheDocument()
+    );
   });
 
   it("shows error state when fetch fails", async () => {

--- a/frontend/src/__tests__/DailyLimitCard.test.tsx
+++ b/frontend/src/__tests__/DailyLimitCard.test.tsx
@@ -2,20 +2,6 @@ import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-import DailyLimitCard from "../components/DailyLimitCard";
-
-function mockStellar({ limit, spent, dayStart, error }: { limit?: bigint | null; spent?: bigint; dayStart?: bigint | null; error?: string }) {
-  vi.doMock("../stellar", async () => {
-    const actual = (await vi.importActual("../stellar")) as Record<string, unknown>;
-    return {
-      ...actual,
-      getDailyLimit: vi.fn().mockImplementation(() => (error ? Promise.reject(new Error(error)) : Promise.resolve(limit ?? null))),
-      getDailySpent: vi.fn().mockImplementation(() => (error ? Promise.reject(new Error(error)) : Promise.resolve(spent ?? 0n))),
-      getDayStart: vi.fn().mockImplementation(() => (error ? Promise.reject(new Error(error)) : Promise.resolve(dayStart ?? null))),
-    };
-  });
-}
-
 vi.mock("../hooks/useAmountDisplay", () => ({
   useAmountDisplay: () => ({
     displayCurrentAmount: (v: bigint) => `${Number(v) / 10_000_000} XLM`,

--- a/frontend/src/__tests__/DailyLimitCard.test.tsx
+++ b/frontend/src/__tests__/DailyLimitCard.test.tsx
@@ -1,0 +1,137 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import DailyLimitCard from "../components/DailyLimitCard";
+
+function mockStellar({ limit, spent, dayStart, error }: { limit?: bigint | null; spent?: bigint; dayStart?: bigint | null; error?: string }) {
+  vi.doMock("../stellar", async () => {
+    const actual = (await vi.importActual("../stellar")) as Record<string, unknown>;
+    return {
+      ...actual,
+      getDailyLimit: vi.fn().mockImplementation(() => (error ? Promise.reject(new Error(error)) : Promise.resolve(limit ?? null))),
+      getDailySpent: vi.fn().mockImplementation(() => (error ? Promise.reject(new Error(error)) : Promise.resolve(spent ?? 0n))),
+      getDayStart: vi.fn().mockImplementation(() => (error ? Promise.reject(new Error(error)) : Promise.resolve(dayStart ?? null))),
+    };
+  });
+}
+
+vi.mock("../hooks/useAmountDisplay", () => ({
+  useAmountDisplay: () => ({
+    displayCurrentAmount: (v: bigint) => `${Number(v) / 10_000_000} XLM`,
+    unit: "XLM" as const,
+    setUnit: vi.fn(),
+  }),
+}));
+
+describe("DailyLimitCard", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("shows loading initially", async () => {
+    vi.doMock("../stellar", async () => {
+      const actual = (await vi.importActual("../stellar")) as Record<string, unknown>;
+      return {
+        ...actual,
+        getDailyLimit: vi.fn(() => new Promise(() => {})),
+        getDailySpent: vi.fn(() => new Promise(() => {})),
+        getDayStart: vi.fn(() => new Promise(() => {})),
+      };
+    });
+    const { default: Card } = await import("../components/DailyLimitCard");
+    render(<Card userKey="GABC" refreshTrigger={0} onOpen={vi.fn()} />);
+    expect(screen.getByLabelText(/loading daily spending limit/i)).toBeInTheDocument();
+  });
+
+  it("renders limit/spent/remaining and progress when limit set", async () => {
+    vi.resetModules();
+    vi.doMock("../stellar", async () => {
+      const actual = (await vi.importActual("../stellar")) as Record<string, unknown>;
+      return {
+        ...actual,
+        getDailyLimit: vi.fn().mockResolvedValue(100_000_000n), // 10 XLM
+        getDailySpent: vi.fn().mockResolvedValue(70_000_000n), // 7 XLM
+        getDayStart: vi.fn().mockResolvedValue(123456789n),
+      };
+    });
+    const { default: Card2 } = await import("../components/DailyLimitCard");
+    render(<Card2 userKey="GABC" refreshTrigger={0} onOpen={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText(/Daily Spending/)).toBeInTheDocument());
+    expect(screen.getByText(/Daily limit/)).toBeInTheDocument();
+    expect(screen.getByText(/Today's spend/)).toBeInTheDocument();
+    expect(screen.getByText(/Remaining/)).toBeInTheDocument();
+    // Progress bar
+    expect(screen.getByRole("progressbar", { name: /daily limit usage/i })).toBeInTheDocument();
+    expect(screen.getByText(/70% used/)).toBeInTheDocument();
+    expect(screen.getByText(/Resets about 24 hours after your first spend today/)).toBeInTheDocument();
+  });
+
+  it("shows Not set and uncapped hint when no limit", async () => {
+    vi.resetModules();
+    vi.doMock("../stellar", async () => {
+      const actual = (await vi.importActual("../stellar")) as Record<string, unknown>;
+      return {
+        ...actual,
+        getDailyLimit: vi.fn().mockResolvedValue(null),
+        getDailySpent: vi.fn().mockResolvedValue(0n),
+        getDayStart: vi.fn().mockResolvedValue(null),
+      };
+    });
+    const { default: Card3 } = await import("../components/DailyLimitCard");
+    render(<Card3 userKey="GABC" refreshTrigger={0} onOpen={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText("Not set")).toBeInTheDocument());
+    expect(screen.getByText(/No cap set — pay-per-use is uncapped/)).toBeInTheDocument();
+    expect(screen.getByText(/Inactive/)).toBeInTheDocument();
+  });
+
+  it("shows uncapped-but-window-active warning when limit expired mid-window", async () => {
+    vi.resetModules();
+    vi.doMock("../stellar", async () => {
+      const actual = (await vi.importActual("../stellar")) as Record<string, unknown>;
+      return {
+        ...actual,
+        getDailyLimit: vi.fn().mockResolvedValue(null),
+        getDailySpent: vi.fn().mockResolvedValue(5_000_000n),
+        getDayStart: vi.fn().mockResolvedValue(999n),
+      };
+    });
+    const { default: Card4 } = await import("../components/DailyLimitCard");
+    render(<Card4 userKey="GABC" refreshTrigger={0} onOpen={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText(/Limit expired but window still active/)).toBeInTheDocument());
+  });
+
+  it("shows error state when fetch fails", async () => {
+    vi.resetModules();
+    vi.doMock("../stellar", async () => {
+      const actual = (await vi.importActual("../stellar")) as Record<string, unknown>;
+      return {
+        ...actual,
+        getDailyLimit: vi.fn().mockRejectedValue(new Error("RPC down")),
+        getDailySpent: vi.fn().mockRejectedValue(new Error("RPC down")),
+        getDayStart: vi.fn().mockRejectedValue(new Error("RPC down")),
+      };
+    });
+    const { default: Card5 } = await import("../components/DailyLimitCard");
+    render(<Card5 userKey="GABC" refreshTrigger={0} onOpen={vi.fn()} />);
+    await waitFor(() => expect(screen.getByRole("alert")).toBeInTheDocument());
+    expect(screen.getByText(/Unable to load daily spending data/)).toBeInTheDocument();
+  });
+
+  it("remaining shows Exceeded when spent > limit", async () => {
+    vi.resetModules();
+    vi.doMock("../stellar", async () => {
+      const actual = (await vi.importActual("../stellar")) as Record<string, unknown>;
+      return {
+        ...actual,
+        getDailyLimit: vi.fn().mockResolvedValue(10_000_000n),
+        getDailySpent: vi.fn().mockResolvedValue(15_000_000n),
+        getDayStart: vi.fn().mockResolvedValue(1n),
+      };
+    });
+    const { default: Card6 } = await import("../components/DailyLimitCard");
+    render(<Card6 userKey="GABC" refreshTrigger={0} onOpen={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText("Exceeded")).toBeInTheDocument());
+  });
+});

--- a/frontend/src/__tests__/NetworkBadge.test.tsx
+++ b/frontend/src/__tests__/NetworkBadge.test.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+describe("NetworkBadge", () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it("renders Testnet badge by default", async () => {
+    vi.doMock("../stellar", async () => {
+      const actual = (await vi.importActual("../stellar")) as Record<string, unknown>;
+      return { ...actual, NETWORK_PASSPHRASE: "Test SDF Network ; September 2015" };
+    });
+    const { default: NetworkBadge } = await import("../components/NetworkBadge");
+    render(<NetworkBadge />);
+    const badge = screen.getByTestId("network-badge");
+    expect(badge).toHaveTextContent("Testnet");
+    expect(badge).toHaveClass("badge-testnet");
+    expect(badge).toHaveAttribute("aria-label", "Network: Testnet");
+  });
+
+  it("renders Mainnet badge with mainnet styling", async () => {
+    vi.resetModules();
+    vi.doMock("../stellar", async () => {
+      const actual = (await vi.importActual("../stellar")) as Record<string, unknown>;
+      return { ...actual, NETWORK_PASSPHRASE: "Public Global Stellar Network ; September 2015" };
+    });
+    // Also need to mock utils/network isMainnetPassphrase to align, but badge uses isMainnetPassphrase on NETWORK_PASSPHRASE directly
+    const { default: NetworkBadge2 } = await import("../components/NetworkBadge");
+    render(<NetworkBadge2 />);
+    const badge = screen.getByTestId("network-badge");
+    expect(badge).toHaveTextContent("Mainnet");
+    expect(badge).toHaveClass("badge-mainnet");
+    expect(badge).toHaveAttribute("aria-label", "Network: Mainnet");
+  });
+});

--- a/frontend/src/__tests__/PayPerUseForm.limit.test.tsx
+++ b/frontend/src/__tests__/PayPerUseForm.limit.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import PayPerUseForm from "../components/PayPerUseForm";

--- a/frontend/src/__tests__/PayPerUseForm.limit.test.tsx
+++ b/frontend/src/__tests__/PayPerUseForm.limit.test.tsx
@@ -1,0 +1,121 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import PayPerUseForm from "../components/PayPerUseForm";
+
+vi.mock("../hooks/useAmountDisplay", () => ({
+  useAmountDisplay: () => ({
+    displayCurrentAmount: (v: bigint) => `${Number(v) / 10_000_000} XLM`,
+    unit: "XLM" as const,
+    setUnit: vi.fn(),
+  }),
+}));
+
+describe("PayPerUseForm daily limit UX (Issue 050)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows remaining when limit set and blocks submit when amount > remaining", async () => {
+    const onPay = vi.fn().mockResolvedValue(undefined);
+    render(
+      <PayPerUseForm
+        onPay={onPay}
+        loading={false}
+        dailyLimit={100_000_000n} // 10 XLM
+        dailySpent={70_000_000n} // 7 XLM => remaining 3
+        dayActive={true}
+        isLimitLoading={false}
+      />
+    );
+
+    expect(screen.getByText(/Remaining:/)).toBeInTheDocument();
+    expect(screen.getByText(/Resets about 24 hours/)).toBeInTheDocument();
+
+    const input = screen.getByPlaceholderText(/Amount in XLM/);
+    const button = screen.getByRole("button", { name: /pay now/i });
+
+    // Within limit: 3 XLM should be allowed
+    await userEvent.clear(input);
+    await userEvent.type(input, "3");
+    await waitFor(() => expect(button).not.toBeDisabled());
+    expect(screen.queryByTestId("ppu-limit-error")).not.toBeInTheDocument();
+
+    // Exceeds remaining: 4 XLM > 3 remaining
+    await userEvent.clear(input);
+    await userEvent.type(input, "4");
+    await waitFor(() => expect(button).toBeDisabled());
+    expect(screen.getByTestId("ppu-limit-error")).toHaveTextContent(/Exceeds remaining daily budget/);
+  });
+
+  it("blocks when remaining is 0 (limit reached)", async () => {
+    const onPay = vi.fn().mockResolvedValue(undefined);
+    render(
+      <PayPerUseForm
+        onPay={onPay}
+        loading={false}
+        dailyLimit={50_000_000n}
+        dailySpent={50_000_000n}
+        dayActive={true}
+      />
+    );
+    const input = screen.getByPlaceholderText(/Amount in XLM/);
+    await userEvent.type(input, "1");
+    const button = screen.getByRole("button", { name: /pay now/i });
+    await waitFor(() => expect(button).toBeDisabled());
+    expect(screen.getByTestId("ppu-limit-error")).toHaveTextContent(/Daily limit reached/);
+  });
+
+  it("does not block when no limit (uncapped)", async () => {
+    const onPay = vi.fn().mockResolvedValue(undefined);
+    render(<PayPerUseForm onPay={onPay} loading={false} dailyLimit={null} dailySpent={null} />);
+    const input = screen.getByPlaceholderText(/Amount in XLM/);
+    await userEvent.type(input, "100");
+    const button = screen.getByRole("button", { name: /pay now/i });
+    await waitFor(() => expect(button).not.toBeDisabled());
+    expect(screen.queryByTestId("ppu-limit-error")).not.toBeInTheDocument();
+  });
+
+  it("shows loading when isLimitLoading true", async () => {
+    const onPay = vi.fn();
+    render(<PayPerUseForm onPay={onPay} loading={false} isLimitLoading={true} dailyLimit={100_000_000n} dailySpent={0n} />);
+    expect(screen.getByText(/Loading daily spending limit/)).toBeInTheDocument();
+  });
+
+  it("calls onPay only when not exceeding remaining", async () => {
+    const onPay = vi.fn().mockResolvedValue(undefined);
+    render(
+      <PayPerUseForm
+        onPay={onPay}
+        loading={false}
+        dailyLimit={100_000_000n}
+        dailySpent={0n}
+        dayActive={false}
+      />
+    );
+    const input = screen.getByPlaceholderText(/Amount in XLM/);
+    await userEvent.type(input, "5");
+    await userEvent.click(screen.getByRole("button", { name: /pay now/i }));
+    await waitFor(() => expect(onPay).toHaveBeenCalledWith(50_000_000n));
+  });
+
+  it("prevents onPay when amount exceeds remaining even if button somehow enabled", async () => {
+    const onPay = vi.fn().mockResolvedValue(undefined);
+    render(
+      <PayPerUseForm
+        onPay={onPay}
+        loading={false}
+        dailyLimit={10_000_000n}
+        dailySpent={9_000_000n}
+        dayActive={true}
+      />
+    );
+    const input = screen.getByPlaceholderText(/Amount in XLM/);
+    await userEvent.clear(input);
+    await userEvent.type(input, "2"); // 2 XLM > 1 XLM remaining
+    // Directly try to submit via form logic: button is disabled, but ensure onPay not called
+    await userEvent.click(screen.getByRole("button", { name: /pay now/i }));
+    expect(onPay).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/__tests__/PayPerUseForm.limit.test.tsx
+++ b/frontend/src/__tests__/PayPerUseForm.limit.test.tsx
@@ -46,7 +46,9 @@ describe("PayPerUseForm daily limit UX (Issue 050)", () => {
     await userEvent.clear(input);
     await userEvent.type(input, "4");
     await waitFor(() => expect(button).toBeDisabled());
-    expect(screen.getByTestId("ppu-limit-error")).toHaveTextContent(/Exceeds remaining daily budget/);
+    expect(screen.getByTestId("ppu-limit-error")).toHaveTextContent(
+      /Exceeds remaining daily budget/
+    );
   });
 
   it("blocks when remaining is 0 (limit reached)", async () => {
@@ -79,7 +81,15 @@ describe("PayPerUseForm daily limit UX (Issue 050)", () => {
 
   it("shows loading when isLimitLoading true", async () => {
     const onPay = vi.fn();
-    render(<PayPerUseForm onPay={onPay} loading={false} isLimitLoading={true} dailyLimit={100_000_000n} dailySpent={0n} />);
+    render(
+      <PayPerUseForm
+        onPay={onPay}
+        loading={false}
+        isLimitLoading={true}
+        dailyLimit={100_000_000n}
+        dailySpent={0n}
+      />
+    );
     expect(screen.getByText(/Loading daily spending limit/)).toBeInTheDocument();
   });
 

--- a/frontend/src/__tests__/TxQueuePanel.recovery.test.tsx
+++ b/frontend/src/__tests__/TxQueuePanel.recovery.test.tsx
@@ -55,7 +55,9 @@ describe("TxQueuePanel recovery UX (Issue 052)", () => {
     act(() => {
       txQueue.enqueue("Pay Per Use", retry);
     });
-    await waitFor(() => expect(screen.getByRole("button", { name: /resume pay per use/i })).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /resume pay per use/i })).toBeInTheDocument()
+    );
     await userEvent.click(screen.getByRole("button", { name: /resume pay per use/i }));
     await waitFor(() => expect(retry).toHaveBeenCalledTimes(1));
   });
@@ -77,7 +79,14 @@ describe("TxQueuePanel recovery UX (Issue 052)", () => {
 
   it("pending items survive reload: pre-populated localStorage renders on mount", async () => {
     const persisted = [
-      { id: 42, operation: "Subscribe", hash: null, timestamp: new Date().toISOString(), status: "pending", error: null },
+      {
+        id: 42,
+        operation: "Subscribe",
+        hash: null,
+        timestamp: new Date().toISOString(),
+        status: "pending",
+        error: null,
+      },
     ];
     localStorage.setItem(txQueue.TX_QUEUE_STORAGE_KEY, JSON.stringify(persisted));
     localStorage.setItem(txQueue.TX_PANEL_STORAGE_KEY, "true");

--- a/frontend/src/__tests__/TxQueuePanel.recovery.test.tsx
+++ b/frontend/src/__tests__/TxQueuePanel.recovery.test.tsx
@@ -23,9 +23,8 @@ describe("TxQueuePanel recovery UX (Issue 052)", () => {
   it("shows interrupted pending entry with resume/discard and double-submit warning", async () => {
     render(<TxQueuePanel />);
 
-    let id: number;
     act(() => {
-      id = txQueue.enqueue("Subscribe", vi.fn().mockResolvedValue(undefined));
+      txQueue.enqueue("Subscribe", vi.fn().mockResolvedValue(undefined));
       // keep as pending with no hash (interrupted)
     });
 

--- a/frontend/src/__tests__/TxQueuePanel.recovery.test.tsx
+++ b/frontend/src/__tests__/TxQueuePanel.recovery.test.tsx
@@ -1,0 +1,104 @@
+import React from "react";
+import { render, screen, waitFor, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import TxQueuePanel from "../components/TxQueuePanel";
+import * as txQueue from "../services/txQueue";
+
+vi.mock("../stellar", () => ({
+  explorerTxUrl: (hash: string) => `https://stellar.expert/explorer/testnet/tx/${hash}`,
+}));
+
+vi.mock("../components/CopyButton", () => ({
+  default: ({ text }: { text: string }) => <button data-testid={`copy-${text}`}>Copy</button>,
+}));
+
+describe("TxQueuePanel recovery UX (Issue 052)", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    txQueue._reset();
+  });
+
+  it("shows interrupted pending entry with resume/discard and double-submit warning", async () => {
+    render(<TxQueuePanel />);
+
+    let id: number;
+    act(() => {
+      id = txQueue.enqueue("Subscribe", vi.fn().mockResolvedValue(undefined));
+      // keep as pending with no hash (interrupted)
+    });
+
+    await waitFor(() => expect(screen.getByText("Subscribe")).toBeInTheDocument());
+    expect(screen.getByText("Pending")).toBeInTheDocument();
+    expect(screen.getByText(/Interrupted — wallet closed/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /resume subscribe/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /discard subscribe/i })).toBeInTheDocument();
+    expect(screen.getByText(/Double-submit risk/)).toBeInTheDocument();
+  });
+
+  it("discard removes the entry", async () => {
+    render(<TxQueuePanel />);
+    act(() => {
+      txQueue.enqueue("Subscribe");
+    });
+    await waitFor(() => expect(screen.getByText("Subscribe")).toBeInTheDocument());
+    await userEvent.click(screen.getByRole("button", { name: /discard subscribe/i }));
+    await waitFor(() => {
+      expect(screen.queryByText("Subscribe")).not.toBeInTheDocument();
+    });
+    expect(txQueue.getEntries()).toHaveLength(0);
+  });
+
+  it("retry on interrupted entry calls retry callback and warns about simulation", async () => {
+    const retry = vi.fn().mockResolvedValue(undefined);
+    render(<TxQueuePanel />);
+    act(() => {
+      txQueue.enqueue("Pay Per Use", retry);
+    });
+    await waitFor(() => expect(screen.getByRole("button", { name: /resume pay per use/i })).toBeInTheDocument());
+    await userEvent.click(screen.getByRole("button", { name: /resume pay per use/i }));
+    await waitFor(() => expect(retry).toHaveBeenCalledTimes(1));
+  });
+
+  it("failed entry shows discard and retry, and explains risk after reload", async () => {
+    render(<TxQueuePanel />);
+    const retry = vi.fn().mockResolvedValue(undefined);
+    let id: number;
+    act(() => {
+      id = txQueue.enqueue("Subscribe", retry);
+      txQueue.markFailed(id, "Freighter closed");
+    });
+    await waitFor(() => expect(screen.getByText("Failed")).toBeInTheDocument());
+    expect(screen.getByRole("button", { name: /retry subscribe/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /discard subscribe/i })).toBeInTheDocument();
+    // Persistence hint
+    expect(screen.getByText(/Pending items survive reload/)).toBeInTheDocument();
+  });
+
+  it("pending items survive reload: pre-populated localStorage renders on mount", async () => {
+    const persisted = [
+      { id: 42, operation: "Subscribe", hash: null, timestamp: new Date().toISOString(), status: "pending", error: null },
+    ];
+    localStorage.setItem(txQueue.TX_QUEUE_STORAGE_KEY, JSON.stringify(persisted));
+    localStorage.setItem(txQueue.TX_PANEL_STORAGE_KEY, "true");
+    txQueue._rehydrate();
+    render(<TxQueuePanel />);
+    await waitFor(() => expect(screen.getByText("Subscribe")).toBeInTheDocument());
+    expect(screen.getByText("Pending")).toBeInTheDocument();
+  });
+
+  it("clear all removes all persisted entries", async () => {
+    render(<TxQueuePanel />);
+    act(() => {
+      txQueue.enqueue("Subscribe");
+      txQueue.enqueue("Cancel");
+    });
+    await waitFor(() => expect(screen.getByText("Clear all")).toBeInTheDocument());
+    await userEvent.click(screen.getByRole("button", { name: /clear all transactions/i }));
+    await waitFor(() => {
+      // Panel disappears when empty
+      expect(screen.queryByRole("region", { name: /transaction queue/i })).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/__tests__/network.test.ts
+++ b/frontend/src/__tests__/network.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
   isMainnetPassphrase,
-  isMainnetNetwork,
   MAINNET_CONFIRM_KEY,
   isMainnetConfirmed,
   setMainnetConfirmed,

--- a/frontend/src/__tests__/network.test.ts
+++ b/frontend/src/__tests__/network.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  isMainnetPassphrase,
+  isMainnetNetwork,
+  MAINNET_CONFIRM_KEY,
+  isMainnetConfirmed,
+  setMainnetConfirmed,
+  clearMainnetConfirmed,
+  ensureMainnetConfirmed,
+} from "../utils/network";
+
+describe("isMainnetPassphrase", () => {
+  it("detects public mainnet passphrase", () => {
+    expect(isMainnetPassphrase("Public Global Stellar Network ; September 2015")).toBe(true);
+  });
+
+  it("detects testnet as not mainnet", () => {
+    expect(isMainnetPassphrase("Test SDF Network ; September 2015")).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
+    expect(isMainnetPassphrase("")).toBe(false);
+  });
+});
+
+describe("mainnet confirmation persistence", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+  afterEach(() => {
+    sessionStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("isMainnetConfirmed false initially", () => {
+    expect(isMainnetConfirmed()).toBe(false);
+  });
+
+  it("setMainnetConfirmed persists flag", () => {
+    setMainnetConfirmed();
+    expect(isMainnetConfirmed()).toBe(true);
+    expect(sessionStorage.getItem(MAINNET_CONFIRM_KEY)).toBe("true");
+  });
+
+  it("clearMainnetConfirmed removes flag", () => {
+    setMainnetConfirmed();
+    clearMainnetConfirmed();
+    expect(isMainnetConfirmed()).toBe(false);
+  });
+});
+
+describe("ensureMainnetConfirmed", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    vi.restoreAllMocks();
+  });
+  afterEach(() => {
+    sessionStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("allows when not mainnet without prompting", async () => {
+    // By default NETWORK_PASSPHRASE is testnet, so ensureMainnetConfirmed returns true without calling confirmFn
+    const confirmFn = vi.fn(() => false);
+    const result = ensureMainnetConfirmed(confirmFn);
+    expect(result).toBe(true);
+    expect(confirmFn).not.toHaveBeenCalled();
+  });
+
+  it("prompts and persists when mainnet and not yet confirmed (mocked)", async () => {
+    // Simulate mainnet by temporarily mocking isMainnetNetwork via stellar module
+    // We test the confirmFn injection path directly: force mainnet via mock
+    vi.resetModules();
+    // Mock stellar to force mainnet passphrase
+    vi.doMock("../stellar", async () => {
+      const actual = (await vi.importActual("../stellar")) as Record<string, unknown>;
+      return { ...actual, NETWORK_PASSPHRASE: "Public Global Stellar Network ; September 2015" };
+    });
+    const { ensureMainnetConfirmed: ensureMainnetMocked } = await import("../utils/network");
+    sessionStorage.clear();
+    const confirmFn = vi.fn(() => true);
+    const result = ensureMainnetMocked(confirmFn);
+    expect(result).toBe(true);
+    expect(confirmFn).toHaveBeenCalledTimes(1);
+    expect(sessionStorage.getItem(MAINNET_CONFIRM_KEY)).toBe("true");
+    // Second call should not prompt again
+    const confirmFn2 = vi.fn(() => false);
+    const result2 = ensureMainnetMocked(confirmFn2);
+    expect(result2).toBe(true);
+    expect(confirmFn2).not.toHaveBeenCalled();
+  });
+
+  it("returns false when user cancels confirm on mainnet", async () => {
+    vi.resetModules();
+    vi.doMock("../stellar", async () => {
+      const actual = (await vi.importActual("../stellar")) as Record<string, unknown>;
+      return { ...actual, NETWORK_PASSPHRASE: "Public Global Stellar Network ; September 2015" };
+    });
+    const { ensureMainnetConfirmed: ensureMainnetMocked2 } = await import("../utils/network");
+    sessionStorage.clear();
+    const confirmFn = vi.fn(() => false);
+    const result = ensureMainnetMocked2(confirmFn);
+    expect(result).toBe(false);
+    expect(sessionStorage.getItem(MAINNET_CONFIRM_KEY)).toBeNull();
+  });
+});

--- a/frontend/src/__tests__/stellar.dailyLimit.test.ts
+++ b/frontend/src/__tests__/stellar.dailyLimit.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { xdr, Address } from "@stellar/stellar-sdk";
+import { xdr, nativeToScVal } from "@stellar/stellar-sdk";
 
 // Mock rpc Server
 const mockSim = vi.fn();
@@ -18,12 +18,9 @@ vi.mock("@stellar/stellar-sdk/rpc", () => ({
 }));
 
 function makeI128ScVal(n: bigint): xdr.ScVal {
-  // Use nativeToScVal to create proper ScVal
-  const { nativeToScVal } = require("@stellar/stellar-sdk");
   return nativeToScVal(n, { type: "i128" });
 }
 function makeOptionI128ScVal(n: bigint | null): xdr.ScVal {
-  const { nativeToScVal, Address } = require("@stellar/stellar-sdk");
   if (n === null) {
     // Option None is ScVal void
     return xdr.ScVal.scvVoid();
@@ -33,7 +30,6 @@ function makeOptionI128ScVal(n: bigint | null): xdr.ScVal {
   return makeI128ScVal(n);
 }
 function makeU64OptionScVal(n: bigint | null): xdr.ScVal {
-  const { nativeToScVal } = require("@stellar/stellar-sdk");
   if (n === null) return xdr.ScVal.scvVoid();
   return nativeToScVal(n, { type: "u64" });
 }

--- a/frontend/src/__tests__/stellar.dailyLimit.test.ts
+++ b/frontend/src/__tests__/stellar.dailyLimit.test.ts
@@ -1,104 +1,135 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { xdr, nativeToScVal } from "@stellar/stellar-sdk";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { Account, nativeToScVal, xdr } from "@stellar/stellar-sdk";
+import { _clearCacheForTesting } from "../services/rpcCache";
 
-// Mock rpc Server
-const mockSim = vi.fn();
-const mockGetAccount = vi.fn().mockResolvedValue({ id: "mock" } as unknown as never);
+// ── Mock RPC layer — same pattern as stellar.builders.test.ts ────────────────
+//
+// Contract itself is NOT mocked: it's the real @stellar/stellar-sdk class, so
+// `new Contract(CONTRACT_ID)` succeeds and `contract.call(...)` produces real
+// xdr operations. Only the RPC Server is mocked; `simulateTransaction` returns
+// whatever ScVal retval each test stages.
+vi.mock("@stellar/stellar-sdk/rpc", () => {
+  return {
+    Server: class {
+      getEvents = vi.fn();
+      simulateTransaction = vi.fn();
+      getAccount = vi.fn();
+      getHealth = vi.fn();
+      getTransaction = vi.fn();
+      sendTransaction = vi.fn();
+    },
+    assembleTransaction: vi.fn(),
+  };
+});
 
-vi.mock("@stellar/stellar-sdk/rpc", () => ({
-  Server: class {
-    getAccount = mockGetAccount;
-    simulateTransaction = mockSim;
-    getTransaction = vi.fn();
-    getEvents = vi.fn();
-    sendTransaction = vi.fn();
-    getHealth = vi.fn();
-  },
-  assembleTransaction: vi.fn((tx) => tx),
-}));
+// `stellar.ts` reads `import.meta.env.VITE_CONTRACT_ID` exactly once, at
+// module-load time, into the exported `CONTRACT_ID` constant — and
+// `new Contract(CONTRACT_ID)` throws on an empty/invalid contract id. So we
+// must set a syntactically valid contract id *before* "../stellar" is first
+// evaluated. Static imports are hoisted above this statement, so "../stellar"
+// is imported dynamically in `beforeAll` below. See stellar.builders.test.ts
+// for the full rationale and the origin of these valid-format strkeys.
+const MOCK_CONTRACT_ID = "CAAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQC526";
+import.meta.env.VITE_CONTRACT_ID = MOCK_CONTRACT_ID;
+
+// Valid-format strkey addresses (not real deployed/funded accounts).
+const SOURCE = "GABAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEJXA";
+const USER_A = "GABQGAYDAMBQGAYDAMBQGAYDAMBQGAYDAMBQGAYDAMBQGAYDAMBQHGPC";
+const USER_B = "GACAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAJJHP";
+
+// ── ScVal builders ────────────────────────────────────────────────────────────
 
 function makeI128ScVal(n: bigint): xdr.ScVal {
   return nativeToScVal(n, { type: "i128" });
 }
+
 function makeOptionI128ScVal(n: bigint | null): xdr.ScVal {
   if (n === null) {
-    // Option None is ScVal void
+    // Option None arrives as scvVoid on the wire for our decoder
     return xdr.ScVal.scvVoid();
   }
-  // For Option Some, Soroban returns the inner ScVal directly in some SDK versions
-  // Safer to return i128 directly — decoder handles both via decodeOption
+  // For Option Some, Soroban returns the inner ScVal directly in some SDK
+  // versions — the decoder handles both via decodeOption.
   return makeI128ScVal(n);
 }
+
 function makeU64OptionScVal(n: bigint | null): xdr.ScVal {
   if (n === null) return xdr.ScVal.scvVoid();
   return nativeToScVal(n, { type: "u64" });
 }
+
 function makeVoid(): xdr.ScVal {
   return xdr.ScVal.scvVoid();
 }
 
-describe("stellar daily limit helpers (Issue 050)", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockGetAccount.mockResolvedValue({ id: "GABC" } as unknown as never);
-  });
+// ── Module under test (imported after env setup) ─────────────────────────────
 
+let stellar: typeof import("../stellar");
+
+beforeAll(async () => {
+  stellar = await import("../stellar");
+});
+
+const getAccountMock = () => stellar.server.getAccount as unknown as ReturnType<typeof vi.fn>;
+const simulateMock = () =>
+  stellar.server.simulateTransaction as unknown as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // dedupedCall caches successful reads for 5s — reset between tests so each
+  // test's staged retvals are actually consumed.
+  _clearCacheForTesting();
+  // TransactionBuilder.build() needs a real Account-shaped object.
+  getAccountMock().mockResolvedValue(new Account(SOURCE, "0"));
+  simulateMock().mockReset();
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("stellar daily limit helpers (Issue 050)", () => {
   it("getDailyLimit returns Some limit", async () => {
-    const fakeRetval = makeOptionI128ScVal(100_000_000n);
-    mockSim.mockResolvedValue({ result: { retval: fakeRetval } } as never);
-    const { getDailyLimit } = await import("../stellar");
-    const val = await getDailyLimit("GABC0000000000000000000000000000000000000000000000000000");
+    simulateMock().mockResolvedValue({ result: { retval: makeOptionI128ScVal(100_000_000n) } });
+    const val = await stellar.getDailyLimit(USER_A);
     expect(val).toBe(100_000_000n);
   });
 
   it("getDailyLimit returns null when None", async () => {
-    mockSim.mockResolvedValue({ result: { retval: makeVoid() } } as never);
-    const { getDailyLimit: getLimit2 } = await import("../stellar");
-    // Need fresh import to bypass deduped cache key? Use same function but different user to avoid cache
-    const val = await getLimit2("GDEF0000000000000000000000000000000000000000000000000000");
+    simulateMock().mockResolvedValue({ result: { retval: makeVoid() } });
+    const val = await stellar.getDailyLimit(USER_B);
     expect(val).toBeNull();
   });
 
   it("getDailySpent returns 0 when retval missing", async () => {
-    mockSim.mockResolvedValue({ result: {} } as never);
-    const { getDailySpent } = await import("../stellar");
-    const val = await getDailySpent("GHIJ0000000000000000000000000000000000000000000000000000");
+    simulateMock().mockResolvedValue({ result: {} });
+    const val = await stellar.getDailySpent(USER_A);
     expect(val).toBe(0n);
   });
 
   it("getDailySpent decodes i128", async () => {
-    mockSim.mockResolvedValue({ result: { retval: makeI128ScVal(70_000_000n) } } as never);
-    const { getDailySpent: getSpent2 } = await import("../stellar");
-    const val = await getSpent2("GKLM0000000000000000000000000000000000000000000000000000");
+    simulateMock().mockResolvedValue({ result: { retval: makeI128ScVal(70_000_000n) } });
+    const val = await stellar.getDailySpent(USER_B);
     expect(val).toBe(70_000_000n);
   });
 
   it("getDayStart returns timestamp when Some", async () => {
-    mockSim.mockResolvedValue({ result: { retval: makeU64OptionScVal(123456789n) } } as never);
-    const { getDayStart } = await import("../stellar");
-    const val = await getDayStart("GNOP0000000000000000000000000000000000000000000000000000");
+    simulateMock().mockResolvedValue({ result: { retval: makeU64OptionScVal(123456789n) } });
+    const val = await stellar.getDayStart(USER_A);
     expect(val).toBe(123456789n);
   });
 
   it("getDayStart returns null when None/void", async () => {
-    mockSim.mockResolvedValue({ result: { retval: makeVoid() } } as never);
-    const { getDayStart: getStart2 } = await import("../stellar");
-    const val = await getStart2("GQRS0000000000000000000000000000000000000000000000000000");
+    simulateMock().mockResolvedValue({ result: { retval: makeVoid() } });
+    const val = await stellar.getDayStart(USER_B);
     expect(val).toBeNull();
   });
 
   it("getDailyLimitStatus computes remaining and dayActive", async () => {
-    // Need to mock three sequential simulate calls for getDailyLimit, getDailySpent, getDayStart
-    // getDailyLimit: Some 100M, getDailySpent: 70M, getDayStart: Some timestamp
-    // Use a queue of mock returns in order
-    mockSim
-      .mockResolvedValueOnce({ result: { retval: makeOptionI128ScVal(100_000_000n) } } as never)
-      .mockResolvedValueOnce({ result: { retval: makeI128ScVal(70_000_000n) } } as never)
-      .mockResolvedValueOnce({ result: { retval: makeU64OptionScVal(999n) } } as never);
-    const { getDailyLimitStatus } = await import("../stellar");
-    const status = await getDailyLimitStatus(
-      "GTUV0000000000000000000000000000000000000000000000000000"
-    );
+    // Stages (in call order): getDailyLimit → getDailySpent → getDayStart
+    simulateMock()
+      .mockResolvedValueOnce({ result: { retval: makeOptionI128ScVal(100_000_000n) } })
+      .mockResolvedValueOnce({ result: { retval: makeI128ScVal(70_000_000n) } })
+      .mockResolvedValueOnce({ result: { retval: makeU64OptionScVal(999n) } });
+    const status = await stellar.getDailyLimitStatus(USER_A);
     expect(status.limit).toBe(100_000_000n);
     expect(status.spent).toBe(70_000_000n);
     expect(status.remaining).toBe(30_000_000n);
@@ -107,12 +138,11 @@ describe("stellar daily limit helpers (Issue 050)", () => {
   });
 
   it("getDailyLimitStatus remaining null when no limit", async () => {
-    mockSim
-      .mockResolvedValueOnce({ result: { retval: makeVoid() } } as never)
-      .mockResolvedValueOnce({ result: { retval: makeI128ScVal(5_000_000n) } } as never)
-      .mockResolvedValueOnce({ result: { retval: makeVoid() } } as never);
-    const { getDailyLimitStatus: getStatus2 } = await import("../stellar");
-    const status = await getStatus2("GWXY0000000000000000000000000000000000000000000000000000");
+    simulateMock()
+      .mockResolvedValueOnce({ result: { retval: makeVoid() } })
+      .mockResolvedValueOnce({ result: { retval: makeI128ScVal(5_000_000n) } })
+      .mockResolvedValueOnce({ result: { retval: makeVoid() } });
+    const status = await stellar.getDailyLimitStatus(USER_B);
     expect(status.limit).toBeNull();
     expect(status.remaining).toBeNull();
     expect(status.dayActive).toBe(false);

--- a/frontend/src/__tests__/stellar.dailyLimit.test.ts
+++ b/frontend/src/__tests__/stellar.dailyLimit.test.ts
@@ -96,7 +96,9 @@ describe("stellar daily limit helpers (Issue 050)", () => {
       .mockResolvedValueOnce({ result: { retval: makeI128ScVal(70_000_000n) } } as never)
       .mockResolvedValueOnce({ result: { retval: makeU64OptionScVal(999n) } } as never);
     const { getDailyLimitStatus } = await import("../stellar");
-    const status = await getDailyLimitStatus("GTUV0000000000000000000000000000000000000000000000000000");
+    const status = await getDailyLimitStatus(
+      "GTUV0000000000000000000000000000000000000000000000000000"
+    );
     expect(status.limit).toBe(100_000_000n);
     expect(status.spent).toBe(70_000_000n);
     expect(status.remaining).toBe(30_000_000n);

--- a/frontend/src/__tests__/stellar.dailyLimit.test.ts
+++ b/frontend/src/__tests__/stellar.dailyLimit.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { xdr, Address } from "@stellar/stellar-sdk";
+
+// Mock rpc Server
+const mockSim = vi.fn();
+const mockGetAccount = vi.fn().mockResolvedValue({ id: "mock" } as unknown as never);
+
+vi.mock("@stellar/stellar-sdk/rpc", () => ({
+  Server: class {
+    getAccount = mockGetAccount;
+    simulateTransaction = mockSim;
+    getTransaction = vi.fn();
+    getEvents = vi.fn();
+    sendTransaction = vi.fn();
+    getHealth = vi.fn();
+  },
+  assembleTransaction: vi.fn((tx) => tx),
+}));
+
+function makeI128ScVal(n: bigint): xdr.ScVal {
+  // Use nativeToScVal to create proper ScVal
+  const { nativeToScVal } = require("@stellar/stellar-sdk");
+  return nativeToScVal(n, { type: "i128" });
+}
+function makeOptionI128ScVal(n: bigint | null): xdr.ScVal {
+  const { nativeToScVal, Address } = require("@stellar/stellar-sdk");
+  if (n === null) {
+    // Option None is ScVal void
+    return xdr.ScVal.scvVoid();
+  }
+  // For Option Some, Soroban returns the inner ScVal directly in some SDK versions
+  // Safer to return i128 directly — decoder handles both via decodeOption
+  return makeI128ScVal(n);
+}
+function makeU64OptionScVal(n: bigint | null): xdr.ScVal {
+  const { nativeToScVal } = require("@stellar/stellar-sdk");
+  if (n === null) return xdr.ScVal.scvVoid();
+  return nativeToScVal(n, { type: "u64" });
+}
+function makeVoid(): xdr.ScVal {
+  return xdr.ScVal.scvVoid();
+}
+
+describe("stellar daily limit helpers (Issue 050)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAccount.mockResolvedValue({ id: "GABC" } as unknown as never);
+  });
+
+  it("getDailyLimit returns Some limit", async () => {
+    const fakeRetval = makeOptionI128ScVal(100_000_000n);
+    mockSim.mockResolvedValue({ result: { retval: fakeRetval } } as never);
+    const { getDailyLimit } = await import("../stellar");
+    const val = await getDailyLimit("GABC0000000000000000000000000000000000000000000000000000");
+    expect(val).toBe(100_000_000n);
+  });
+
+  it("getDailyLimit returns null when None", async () => {
+    mockSim.mockResolvedValue({ result: { retval: makeVoid() } } as never);
+    const { getDailyLimit: getLimit2 } = await import("../stellar");
+    // Need fresh import to bypass deduped cache key? Use same function but different user to avoid cache
+    const val = await getLimit2("GDEF0000000000000000000000000000000000000000000000000000");
+    expect(val).toBeNull();
+  });
+
+  it("getDailySpent returns 0 when retval missing", async () => {
+    mockSim.mockResolvedValue({ result: {} } as never);
+    const { getDailySpent } = await import("../stellar");
+    const val = await getDailySpent("GHIJ0000000000000000000000000000000000000000000000000000");
+    expect(val).toBe(0n);
+  });
+
+  it("getDailySpent decodes i128", async () => {
+    mockSim.mockResolvedValue({ result: { retval: makeI128ScVal(70_000_000n) } } as never);
+    const { getDailySpent: getSpent2 } = await import("../stellar");
+    const val = await getSpent2("GKLM0000000000000000000000000000000000000000000000000000");
+    expect(val).toBe(70_000_000n);
+  });
+
+  it("getDayStart returns timestamp when Some", async () => {
+    mockSim.mockResolvedValue({ result: { retval: makeU64OptionScVal(123456789n) } } as never);
+    const { getDayStart } = await import("../stellar");
+    const val = await getDayStart("GNOP0000000000000000000000000000000000000000000000000000");
+    expect(val).toBe(123456789n);
+  });
+
+  it("getDayStart returns null when None/void", async () => {
+    mockSim.mockResolvedValue({ result: { retval: makeVoid() } } as never);
+    const { getDayStart: getStart2 } = await import("../stellar");
+    const val = await getStart2("GQRS0000000000000000000000000000000000000000000000000000");
+    expect(val).toBeNull();
+  });
+
+  it("getDailyLimitStatus computes remaining and dayActive", async () => {
+    // Need to mock three sequential simulate calls for getDailyLimit, getDailySpent, getDayStart
+    // getDailyLimit: Some 100M, getDailySpent: 70M, getDayStart: Some timestamp
+    // Use a queue of mock returns in order
+    mockSim
+      .mockResolvedValueOnce({ result: { retval: makeOptionI128ScVal(100_000_000n) } } as never)
+      .mockResolvedValueOnce({ result: { retval: makeI128ScVal(70_000_000n) } } as never)
+      .mockResolvedValueOnce({ result: { retval: makeU64OptionScVal(999n) } } as never);
+    const { getDailyLimitStatus } = await import("../stellar");
+    const status = await getDailyLimitStatus("GTUV0000000000000000000000000000000000000000000000000000");
+    expect(status.limit).toBe(100_000_000n);
+    expect(status.spent).toBe(70_000_000n);
+    expect(status.remaining).toBe(30_000_000n);
+    expect(status.dayActive).toBe(true);
+    expect(status.dayStart).toBe(999n);
+  });
+
+  it("getDailyLimitStatus remaining null when no limit", async () => {
+    mockSim
+      .mockResolvedValueOnce({ result: { retval: makeVoid() } } as never)
+      .mockResolvedValueOnce({ result: { retval: makeI128ScVal(5_000_000n) } } as never)
+      .mockResolvedValueOnce({ result: { retval: makeVoid() } } as never);
+    const { getDailyLimitStatus: getStatus2 } = await import("../stellar");
+    const status = await getStatus2("GWXY0000000000000000000000000000000000000000000000000000");
+    expect(status.limit).toBeNull();
+    expect(status.remaining).toBeNull();
+    expect(status.dayActive).toBe(false);
+  });
+});

--- a/frontend/src/__tests__/txQueue.persistence.test.ts
+++ b/frontend/src/__tests__/txQueue.persistence.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import * as txQueue from "../services/txQueue";
+
+describe("txQueue persistence (Issue 052)", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+    txQueue._reset();
+  });
+
+  it("persists enqueued entries to localStorage", () => {
+    const id = txQueue.enqueue("Subscribe");
+    const raw = localStorage.getItem(txQueue.TX_QUEUE_STORAGE_KEY);
+    expect(raw).not.toBeNull();
+    const parsed = JSON.parse(raw!);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].operation).toBe("Subscribe");
+    expect(parsed[0].id).toBe(id);
+    expect(parsed[0].status).toBe("pending");
+    expect(parsed[0].hash).toBeNull();
+  });
+
+  it("pending items survive reload via _rehydrate", () => {
+    const id1 = txQueue.enqueue("Subscribe");
+    const id2 = txQueue.enqueue("Pay Per Use");
+    txQueue.markSubmitted(id1, "abc123hash000000000000000000000000");
+    // Simulate reload: clear in-memory but keep localStorage, then rehydrate
+    // Do NOT call _reset (which clears storage); instead manually wipe memory via _rehydrate after _reset without clearing storage
+    // We'll snapshot storage, reset (clears), then restore snapshot and rehydrate
+    const snapshot = localStorage.getItem(txQueue.TX_QUEUE_STORAGE_KEY);
+    const panelSnapshot = localStorage.getItem(txQueue.TX_PANEL_STORAGE_KEY);
+    // _reset already cleared storage, so restore
+    if (snapshot) localStorage.setItem(txQueue.TX_QUEUE_STORAGE_KEY, snapshot);
+    if (panelSnapshot) localStorage.setItem(txQueue.TX_PANEL_STORAGE_KEY, panelSnapshot);
+    txQueue._rehydrate();
+    const entries = txQueue.getEntries();
+    expect(entries).toHaveLength(2);
+    expect(entries.find((e) => e.id === id1)?.hash).toBe("abc123hash000000000000000000000000");
+    expect(entries.find((e) => e.id === id2)?.status).toBe("pending");
+  });
+
+  it("removeEntry discards and updates persisted storage", () => {
+    const id = txQueue.enqueue("Subscribe");
+    expect(txQueue.getEntries()).toHaveLength(1);
+    txQueue.removeEntry(id);
+    expect(txQueue.getEntries()).toHaveLength(0);
+    const raw = localStorage.getItem(txQueue.TX_QUEUE_STORAGE_KEY);
+    const parsed = raw ? JSON.parse(raw) : [];
+    expect(parsed).toHaveLength(0);
+  });
+
+  it("retry callback is not persisted (function dropped) but entry remains", () => {
+    const retry = vi.fn().mockResolvedValue(undefined);
+    const id = txQueue.enqueue("Subscribe", retry);
+    const entries = txQueue.getEntries();
+    expect(entries[0].retry).toBe(retry);
+    const raw = localStorage.getItem(txQueue.TX_QUEUE_STORAGE_KEY);
+    const parsed = JSON.parse(raw!);
+    expect(parsed[0].retry).toBeUndefined();
+    // After rehydrate, retry is null (safe to discard or rebuild)
+    const snap = localStorage.getItem(txQueue.TX_QUEUE_STORAGE_KEY)!;
+    const panel = localStorage.getItem(txQueue.TX_PANEL_STORAGE_KEY);
+    txQueue._reset();
+    localStorage.setItem(txQueue.TX_QUEUE_STORAGE_KEY, snap);
+    if (panel) localStorage.setItem(txQueue.TX_PANEL_STORAGE_KEY, panel);
+    txQueue._rehydrate();
+    const rehydrated = txQueue.getEntries();
+    expect(rehydrated[0].retry).toBeNull();
+    expect(rehydrated[0].operation).toBe("Subscribe");
+  });
+
+  it("markFailed + setRetry enables resume with simulation re-check", () => {
+    const id = txQueue.enqueue("Pay Per Use");
+    txQueue.markFailed(id, "Freighter closed");
+    const retry = vi.fn().mockResolvedValue(undefined);
+    txQueue.setRetry(id, retry);
+    const entry = txQueue.getEntries().find((e) => e.id === id);
+    expect(entry?.status).toBe("failed");
+    expect(entry?.error).toBe("Freighter closed");
+    expect(entry?.retry).toBe(retry);
+  });
+
+  it("panel open state persists", () => {
+    txQueue.enqueue("Subscribe");
+    expect(localStorage.getItem(txQueue.TX_PANEL_STORAGE_KEY)).toBe("true");
+    txQueue.setPanelOpen(false);
+    expect(localStorage.getItem(txQueue.TX_PANEL_STORAGE_KEY)).toBe("false");
+    // Rehydrate should restore false
+    const snap = localStorage.getItem(txQueue.TX_QUEUE_STORAGE_KEY)!;
+    const panel = localStorage.getItem(txQueue.TX_PANEL_STORAGE_KEY)!;
+    txQueue._reset();
+    localStorage.setItem(txQueue.TX_QUEUE_STORAGE_KEY, snap);
+    localStorage.setItem(txQueue.TX_PANEL_STORAGE_KEY, panel);
+    txQueue._rehydrate();
+    expect(txQueue.isPanelOpen()).toBe(false);
+  });
+});

--- a/frontend/src/__tests__/txQueue.persistence.test.ts
+++ b/frontend/src/__tests__/txQueue.persistence.test.ts
@@ -51,7 +51,7 @@ describe("txQueue persistence (Issue 052)", () => {
 
   it("retry callback is not persisted (function dropped) but entry remains", () => {
     const retry = vi.fn().mockResolvedValue(undefined);
-    const id = txQueue.enqueue("Subscribe", retry);
+    txQueue.enqueue("Subscribe", retry);
     const entries = txQueue.getEntries();
     expect(entries[0].retry).toBe(retry);
     const raw = localStorage.getItem(txQueue.TX_QUEUE_STORAGE_KEY);

--- a/frontend/src/__tests__/useNetworkCheck.mainnet.test.tsx
+++ b/frontend/src/__tests__/useNetworkCheck.mainnet.test.tsx
@@ -1,0 +1,129 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+describe("useNetworkCheck mainnet confirmation (testnet unaffected, mainnet requires confirm)", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    vi.restoreAllMocks();
+  });
+  afterEach(() => {
+    sessionStorage.clear();
+    vi.resetModules();
+    vi.restoreAllMocks();
+    delete (window as unknown as Record<string, unknown>).freighter;
+  });
+
+  function TestHarness() {
+    // Dynamically import to respect mocked stellar
+    const { useNetworkCheck } = require("../hooks/useNetworkCheck");
+    const { isMainnet, isMainnetConfirmed, requiresMainnetConfirm, confirmMainnet, networkMatch, walletNetwork } =
+      useNetworkCheck();
+    return (
+      <div>
+        <span data-testid="isMainnet">{String(isMainnet)}</span>
+        <span data-testid="isMainnetConfirmed">{String(isMainnetConfirmed)}</span>
+        <span data-testid="requiresMainnetConfirm">{String(requiresMainnetConfirm)}</span>
+        <span data-testid="networkMatch">{String(networkMatch)}</span>
+        <span data-testid="walletNetwork">{walletNetwork}</span>
+        <button onClick={confirmMainnet} data-testid="confirm-btn">
+          confirm
+        </button>
+      </div>
+    );
+  }
+
+  it("testnet: isMainnet false, requiresMainnetConfirm false", async () => {
+    vi.doMock("../stellar", async () => {
+      const actual = (await vi.importActual("../stellar")) as Record<string, unknown>;
+      return { ...actual, NETWORK_PASSPHRASE: "Test SDF Network ; September 2015" };
+    });
+    // need to re-import after mock — use dynamic import inside test
+    vi.resetModules();
+    const { useNetworkCheck: useNetworkCheckFresh } = await import("../hooks/useNetworkCheck");
+    function FreshHarness() {
+      const v = useNetworkCheckFresh();
+      return (
+        <div>
+          <span data-testid="isMainnet">{String(v.isMainnet)}</span>
+          <span data-testid="requiresMainnetConfirm">{String(v.requiresMainnetConfirm)}</span>
+        </div>
+      );
+    }
+    render(<FreshHarness />);
+    await waitFor(() => {
+      expect(screen.getByTestId("isMainnet")).toHaveTextContent("false");
+    });
+    expect(screen.getByTestId("requiresMainnetConfirm")).toHaveTextContent("false");
+  });
+
+  it("mainnet: requires confirmation initially, then confirmed after confirmMainnet (once per session)", async () => {
+    vi.resetModules();
+    vi.doMock("../stellar", async () => {
+      const actual = (await vi.importActual("../stellar")) as Record<string, unknown>;
+      return { ...actual, NETWORK_PASSPHRASE: "Public Global Stellar Network ; September 2015" };
+    });
+    const { useNetworkCheck: useNetworkCheckMainnet } = await import("../hooks/useNetworkCheck");
+    function Harness() {
+      const v = useNetworkCheckMainnet();
+      return (
+        <div>
+          <span data-testid="isMainnet">{String(v.isMainnet)}</span>
+          <span data-testid="isMainnetConfirmed">{String(v.isMainnetConfirmed)}</span>
+          <span data-testid="requiresMainnetConfirm">{String(v.requiresMainnetConfirm)}</span>
+          <button onClick={v.confirmMainnet} data-testid="confirm-btn">
+            confirm
+          </button>
+        </div>
+      );
+    }
+    render(<Harness />);
+    await waitFor(() => expect(screen.getByTestId("isMainnet")).toHaveTextContent("true"));
+    expect(screen.getByTestId("isMainnetConfirmed")).toHaveTextContent("false");
+    expect(screen.getByTestId("requiresMainnetConfirm")).toHaveTextContent("true");
+
+    await userEvent.click(screen.getByTestId("confirm-btn"));
+
+    await waitFor(() => expect(screen.getByTestId("isMainnetConfirmed")).toHaveTextContent("true"));
+    expect(screen.getByTestId("requiresMainnetConfirm")).toHaveTextContent("false");
+    expect(sessionStorage.getItem("flowpay_mainnet_confirmed")).toBe("true");
+
+    // Remount should stay confirmed (session persistence)
+    const { useNetworkCheck: secondImport } = await import("../hooks/useNetworkCheck");
+    function SecondHarness() {
+      const v = secondImport();
+      return <span data-testid="second-requires">{String(v.requiresMainnetConfirm)}</span>;
+    }
+    render(<SecondHarness />);
+    await waitFor(() => expect(screen.getByTestId("second-requires")).toHaveTextContent("false"));
+  });
+
+  it("badge visible via App shell: App renders network badge always", async () => {
+    // Mock wallet/state so App renders header
+    vi.doMock("../hooks/useWallet", () => ({
+      useWallet: () => ({
+        publicKey: null,
+        connect: vi.fn(),
+        disconnect: vi.fn(),
+        signAndSubmit: vi.fn(),
+        error: null,
+        connecting: false,
+        activeAdapter: null,
+      }),
+      AVAILABLE_WALLETS: [],
+    }));
+    vi.doMock("../hooks/useNetworkCheck", async () => {
+      const actual = (await vi.importActual("../hooks/useNetworkCheck")) as Record<string, unknown>;
+      return actual;
+    });
+    vi.doMock("../stellar", async () => {
+      const actual = (await vi.importActual("../stellar")) as Record<string, unknown>;
+      return { ...actual, NETWORK_PASSPHRASE: "Test SDF Network ; September 2015" };
+    });
+    vi.resetModules();
+    const { default: App } = await import("../App");
+    render(<App />);
+    expect(screen.getByTestId("network-badge")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/useNetworkCheck.mainnet.test.tsx
+++ b/frontend/src/__tests__/useNetworkCheck.mainnet.test.tsx
@@ -15,25 +15,6 @@ describe("useNetworkCheck mainnet confirmation (testnet unaffected, mainnet requ
     delete (window as unknown as Record<string, unknown>).freighter;
   });
 
-  function TestHarness() {
-    // Dynamically import to respect mocked stellar
-    const { useNetworkCheck } = require("../hooks/useNetworkCheck");
-    const { isMainnet, isMainnetConfirmed, requiresMainnetConfirm, confirmMainnet, networkMatch, walletNetwork } =
-      useNetworkCheck();
-    return (
-      <div>
-        <span data-testid="isMainnet">{String(isMainnet)}</span>
-        <span data-testid="isMainnetConfirmed">{String(isMainnetConfirmed)}</span>
-        <span data-testid="requiresMainnetConfirm">{String(requiresMainnetConfirm)}</span>
-        <span data-testid="networkMatch">{String(networkMatch)}</span>
-        <span data-testid="walletNetwork">{walletNetwork}</span>
-        <button onClick={confirmMainnet} data-testid="confirm-btn">
-          confirm
-        </button>
-      </div>
-    );
-  }
-
   it("testnet: isMainnet false, requiresMainnetConfirm false", async () => {
     vi.doMock("../stellar", async () => {
       const actual = (await vi.importActual("../stellar")) as Record<string, unknown>;

--- a/frontend/src/__tests__/useTransaction.mainnet.test.tsx
+++ b/frontend/src/__tests__/useTransaction.mainnet.test.tsx
@@ -1,5 +1,7 @@
-import { renderHook, act } from "@testing-library/react";
+import { renderHook, act, waitFor } from "@testing-library/react";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { Mock } from "vitest";
+import { ensureMainnetConfirmed } from "../utils/network";
 
 const mockEnqueueTransaction = vi.fn();
 
@@ -11,39 +13,61 @@ vi.mock("../stellar", () => ({
   },
 }));
 
-// Mock txQueue
+// Mock txQueue — useTransaction also touches the persisted UI entry lifecycle
 vi.mock("../services/txQueue", () => ({
   enqueueTransaction: (...args: unknown[]) => mockEnqueueTransaction(...args),
+  enqueue: vi.fn(() => 1),
+  markSubmitted: vi.fn(),
+  markConfirmed: vi.fn(),
+  markFailed: vi.fn(),
+  setRetry: vi.fn(),
 }));
 
-// Mock rpc health
+// Controllable rpc-health state so the circuit test needs no module resets
+const rpcHealthState = { circuitOpen: false };
 vi.mock("../context/RpcHealthContext", () => ({
-  useRpcHealthContext: () => ({ circuitOpen: false }),
+  useRpcHealthContext: () => rpcHealthState,
 }));
 
-// Mock utils/network for mainnet scenarios via manual mock switching
-vi.mock("../utils/network", async () => {
-  const actual = (await vi.importActual("../utils/network")) as Record<string, unknown>;
+// Partial mock: keep real network utils, override the gate for deterministic tests
+vi.mock("../utils/network", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../utils/network")>();
   return {
     ...actual,
     ensureMainnetConfirmed: vi.fn(() => true),
   };
 });
 
+const ensureMock = ensureMainnetConfirmed as unknown as Mock;
+
+async function submitCaught(
+  result: { current: { submit: (fn: () => Promise<string>) => Promise<string> } },
+  buildAndSign: () => Promise<string> = async () => "hash123"
+): Promise<Error | null> {
+  let caught: Error | null = null;
+  await act(async () => {
+    try {
+      await result.current.submit(buildAndSign);
+    } catch (e) {
+      caught = e as Error;
+    }
+  });
+  return caught;
+}
+
 describe("useTransaction mainnet safety gate", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     sessionStorage.clear();
+    rpcHealthState.circuitOpen = false;
     mockEnqueueTransaction.mockResolvedValue("hash123");
+    ensureMock.mockReturnValue(true);
   });
   afterEach(() => {
-    vi.clearAllMocks();
     sessionStorage.clear();
   });
 
   it("testnet: does not block and calls enqueueTransaction", async () => {
-    const { ensureMainnetConfirmed } = await import("../utils/network");
-    (ensureMainnetConfirmed as ReturnType<typeof vi.fn>).mockReturnValue(true);
     const { useTransaction } = await import("../hooks/useTransaction");
     const { result } = renderHook(() => useTransaction());
 
@@ -53,73 +77,51 @@ describe("useTransaction mainnet safety gate", () => {
     });
 
     expect(mockEnqueueTransaction).toHaveBeenCalledTimes(1);
-    expect(result.current.status).toBe("success");
+    await waitFor(() => expect(result.current.status).toBe("success"));
   });
 
   it("mainnet: blocks when ensureMainnetConfirmed returns false and sets failed state", async () => {
-    const { ensureMainnetConfirmed } = await import("../utils/network");
-    (ensureMainnetConfirmed as ReturnType<typeof vi.fn>).mockReturnValue(false);
+    ensureMock.mockReturnValue(false);
     const { useTransaction } = await import("../hooks/useTransaction");
     const { result } = renderHook(() => useTransaction());
 
-    await expect(
-      act(async () => {
-        await result.current.submit(async () => "hash123");
-      })
-    ).rejects.toThrow("Mainnet transaction cancelled");
+    const caught = await submitCaught(result);
 
-    expect(result.current.status).toBe("failed");
+    expect(caught?.message).toBe("Mainnet transaction cancelled");
+    await waitFor(() => expect(result.current.status).toBe("failed"));
     expect(result.current.error).toBe("Mainnet transaction cancelled");
     expect(mockEnqueueTransaction).not.toHaveBeenCalled();
   });
 
   it("mainnet: requires confirmation only once per session (second submit skips prompt)", async () => {
-    const networkMod = await import("../utils/network");
-    const ensureMock = networkMod.ensureMainnetConfirmed as ReturnType<typeof vi.fn>;
-    // first call: not confirmed -> prompt shown, user confirms, returns false then true on retry?
-    // Instead simulate: first call returns false (cancelled), second returns true after flag set
-    // For this integration, we test that after failed cancel, next confirm succeeds
+    // First call cancelled, second call confirmed
     ensureMock.mockReturnValueOnce(false).mockReturnValueOnce(true);
     const { useTransaction } = await import("../hooks/useTransaction");
     const { result } = renderHook(() => useTransaction());
 
-    // First attempt cancelled
-    await expect(
-      act(async () => {
-        await result.current.submit(async () => "hash123");
-      })
-    ).rejects.toThrow("Mainnet transaction cancelled");
+    const caught = await submitCaught(result);
+    expect(caught?.message).toBe("Mainnet transaction cancelled");
 
     // Second attempt now confirmed -> succeeds
     await act(async () => {
       await result.current.submit(async () => "hash123");
     });
+
     expect(mockEnqueueTransaction).toHaveBeenCalledTimes(1);
+    expect(ensureMock).toHaveBeenCalledTimes(2);
   });
 
   it("circuitOpen blocks before mainnet check", async () => {
-    vi.resetModules();
-    vi.doMock("../context/RpcHealthContext", () => ({
-      useRpcHealthContext: () => ({ circuitOpen: true }),
-    }));
-    vi.doMock("../stellar", () => ({
-      NETWORK_PASSPHRASE: "Test SDF Network ; September 2015",
-      server: { getTransaction: vi.fn().mockResolvedValue({ status: "SUCCESS" }) },
-    }));
-    vi.doMock("../services/txQueue", () => ({
-      enqueueTransaction: vi.fn(),
-    }));
-    vi.doMock("../utils/network", async () => {
-      const actual = (await vi.importActual("../utils/network")) as Record<string, unknown>;
-      return { ...actual, ensureMainnetConfirmed: vi.fn(() => false) };
-    });
-    const { useTransaction: useTxCircuit } = await import("../hooks/useTransaction");
-    const { result } = renderHook(() => useTxCircuit());
-    await expect(
-      act(async () => {
-        await result.current.submit(async () => "hash123");
-      })
-    ).rejects.toThrow("RPC unavailable");
+    rpcHealthState.circuitOpen = true;
+    const { useTransaction } = await import("../hooks/useTransaction");
+    const { result } = renderHook(() => useTransaction());
+
+    const caught = await submitCaught(result);
+
+    expect(caught?.message).toBe("RPC unavailable");
+    await waitFor(() => expect(result.current.status).toBe("failed"));
     expect(result.current.error).toBe("RPC unavailable");
+    expect(ensureMock).not.toHaveBeenCalled();
+    expect(mockEnqueueTransaction).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/__tests__/useTransaction.mainnet.test.tsx
+++ b/frontend/src/__tests__/useTransaction.mainnet.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { renderHook, act } from "@testing-library/react";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 

--- a/frontend/src/__tests__/useTransaction.mainnet.test.tsx
+++ b/frontend/src/__tests__/useTransaction.mainnet.test.tsx
@@ -1,0 +1,126 @@
+import React from "react";
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+const mockEnqueueTransaction = vi.fn();
+
+// Mock stellar
+vi.mock("../stellar", () => ({
+  NETWORK_PASSPHRASE: "Test SDF Network ; September 2015",
+  server: {
+    getTransaction: vi.fn().mockResolvedValue({ status: "SUCCESS" }),
+  },
+}));
+
+// Mock txQueue
+vi.mock("../services/txQueue", () => ({
+  enqueueTransaction: (...args: unknown[]) => mockEnqueueTransaction(...args),
+}));
+
+// Mock rpc health
+vi.mock("../context/RpcHealthContext", () => ({
+  useRpcHealthContext: () => ({ circuitOpen: false }),
+}));
+
+// Mock utils/network for mainnet scenarios via manual mock switching
+vi.mock("../utils/network", async () => {
+  const actual = (await vi.importActual("../utils/network")) as Record<string, unknown>;
+  return {
+    ...actual,
+    ensureMainnetConfirmed: vi.fn(() => true),
+  };
+});
+
+describe("useTransaction mainnet safety gate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionStorage.clear();
+    mockEnqueueTransaction.mockResolvedValue("hash123");
+  });
+  afterEach(() => {
+    vi.clearAllMocks();
+    sessionStorage.clear();
+  });
+
+  it("testnet: does not block and calls enqueueTransaction", async () => {
+    const { ensureMainnetConfirmed } = await import("../utils/network");
+    (ensureMainnetConfirmed as ReturnType<typeof vi.fn>).mockReturnValue(true);
+    const { useTransaction } = await import("../hooks/useTransaction");
+    const { result } = renderHook(() => useTransaction());
+
+    await act(async () => {
+      const hash = await result.current.submit(async () => "hash123");
+      expect(hash).toBe("hash123");
+    });
+
+    expect(mockEnqueueTransaction).toHaveBeenCalledTimes(1);
+    expect(result.current.status).toBe("success");
+  });
+
+  it("mainnet: blocks when ensureMainnetConfirmed returns false and sets failed state", async () => {
+    const { ensureMainnetConfirmed } = await import("../utils/network");
+    (ensureMainnetConfirmed as ReturnType<typeof vi.fn>).mockReturnValue(false);
+    const { useTransaction } = await import("../hooks/useTransaction");
+    const { result } = renderHook(() => useTransaction());
+
+    await expect(
+      act(async () => {
+        await result.current.submit(async () => "hash123");
+      })
+    ).rejects.toThrow("Mainnet transaction cancelled");
+
+    expect(result.current.status).toBe("failed");
+    expect(result.current.error).toBe("Mainnet transaction cancelled");
+    expect(mockEnqueueTransaction).not.toHaveBeenCalled();
+  });
+
+  it("mainnet: requires confirmation only once per session (second submit skips prompt)", async () => {
+    const networkMod = await import("../utils/network");
+    const ensureMock = networkMod.ensureMainnetConfirmed as ReturnType<typeof vi.fn>;
+    // first call: not confirmed -> prompt shown, user confirms, returns false then true on retry?
+    // Instead simulate: first call returns false (cancelled), second returns true after flag set
+    // For this integration, we test that after failed cancel, next confirm succeeds
+    ensureMock.mockReturnValueOnce(false).mockReturnValueOnce(true);
+    const { useTransaction } = await import("../hooks/useTransaction");
+    const { result } = renderHook(() => useTransaction());
+
+    // First attempt cancelled
+    await expect(
+      act(async () => {
+        await result.current.submit(async () => "hash123");
+      })
+    ).rejects.toThrow("Mainnet transaction cancelled");
+
+    // Second attempt now confirmed -> succeeds
+    await act(async () => {
+      await result.current.submit(async () => "hash123");
+    });
+    expect(mockEnqueueTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("circuitOpen blocks before mainnet check", async () => {
+    vi.resetModules();
+    vi.doMock("../context/RpcHealthContext", () => ({
+      useRpcHealthContext: () => ({ circuitOpen: true }),
+    }));
+    vi.doMock("../stellar", () => ({
+      NETWORK_PASSPHRASE: "Test SDF Network ; September 2015",
+      server: { getTransaction: vi.fn().mockResolvedValue({ status: "SUCCESS" }) },
+    }));
+    vi.doMock("../services/txQueue", () => ({
+      enqueueTransaction: vi.fn(),
+    }));
+    vi.doMock("../utils/network", async () => {
+      const actual = (await vi.importActual("../utils/network")) as Record<string, unknown>;
+      return { ...actual, ensureMainnetConfirmed: vi.fn(() => false) };
+    });
+    const { useTransaction: useTxCircuit } = await import("../hooks/useTransaction");
+    const { result } = renderHook(() => useTxCircuit());
+    await expect(
+      act(async () => {
+        await result.current.submit(async () => "hash123");
+      })
+    ).rejects.toThrow("RPC unavailable");
+    expect(result.current.error).toBe("RPC unavailable");
+  });
+});

--- a/frontend/src/components/DailyLimitCard.tsx
+++ b/frontend/src/components/DailyLimitCard.tsx
@@ -46,8 +46,10 @@ export default function DailyLimitCard({ userKey, refreshTrigger, onOpen }: Prop
 
   const remaining = dailyLimit !== null && dailySpent !== null ? dailyLimit - dailySpent : null;
   const dayActive = dayStart !== null;
-  const progress = dailyLimit !== null && dailySpent !== null ? dailyLimitProgress(dailySpent, dailyLimit) : 0;
-  const isUncappedWithWindow = dailyLimit === null && dayActive && dailySpent !== null && dailySpent > 0n;
+  const progress =
+    dailyLimit !== null && dailySpent !== null ? dailyLimitProgress(dailySpent, dailyLimit) : 0;
+  const isUncappedWithWindow =
+    dailyLimit === null && dayActive && dailySpent !== null && dailySpent > 0n;
 
   if (loading) {
     return (
@@ -100,7 +102,10 @@ export default function DailyLimitCard({ userKey, refreshTrigger, onOpen }: Prop
                   : "—"
               }
             />
-            <Row label="Day window" value={dayActive ? "Active — resets ~24h after first spend" : "Inactive"} />
+            <Row
+              label="Day window"
+              value={dayActive ? "Active — resets ~24h after first spend" : "Inactive"}
+            />
           </div>
 
           {dailyLimit !== null && dailySpent !== null && (
@@ -122,20 +127,29 @@ export default function DailyLimitCard({ userKey, refreshTrigger, onOpen }: Prop
                   style={{
                     width: `${progress}%`,
                     height: "100%",
-                    background: progress >= 100 ? "var(--color-danger)" : progress >= 80 ? "#f59e0b" : "var(--color-primary)",
+                    background:
+                      progress >= 100
+                        ? "var(--color-danger)"
+                        : progress >= 80
+                          ? "#f59e0b"
+                          : "var(--color-primary)",
                     transition: "width 0.2s ease",
                   }}
                 />
               </div>
               <p className="text-xs text-muted" style={{ marginTop: 6 }}>
-                {progress}% used — {dayActive ? "Resets about 24 hours after your first spend today." : "Window starts on first pay-per-use."}
+                {progress}% used —{" "}
+                {dayActive
+                  ? "Resets about 24 hours after your first spend today."
+                  : "Window starts on first pay-per-use."}
               </p>
             </div>
           )}
 
           {isUncappedWithWindow && (
             <p className="text-xs" style={{ marginTop: 8, color: "#f59e0b" }} role="status">
-              Limit expired but window still active — spending is currently uncapped until you set a new limit.
+              Limit expired but window still active — spending is currently uncapped until you set a
+              new limit.
             </p>
           )}
 

--- a/frontend/src/components/DailyLimitCard.tsx
+++ b/frontend/src/components/DailyLimitCard.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useCallback } from "react";
-import { getDailyLimit, getDailySpent } from "../stellar";
+import { getDailyLimit, getDailySpent, getDayStart } from "../stellar";
 import { useAmountDisplay } from "../hooks/useAmountDisplay";
+import { dailyLimitProgress } from "../utils/format";
 import Spinner from "./Spinner";
 
 interface Props {
@@ -12,6 +13,7 @@ interface Props {
 export default function DailyLimitCard({ userKey, refreshTrigger, onOpen }: Props) {
   const [dailyLimit, setDailyLimit] = useState<bigint | null>(null);
   const [dailySpent, setDailySpent] = useState<bigint | null>(null);
+  const [dayStart, setDayStart] = useState<bigint | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const { displayCurrentAmount } = useAmountDisplay();
@@ -20,13 +22,19 @@ export default function DailyLimitCard({ userKey, refreshTrigger, onOpen }: Prop
     setLoading(true);
     setError(null);
     try {
-      const [limit, spent] = await Promise.all([getDailyLimit(userKey), getDailySpent(userKey)]);
+      const [limit, spent, start] = await Promise.all([
+        getDailyLimit(userKey),
+        getDailySpent(userKey),
+        getDayStart(userKey),
+      ]);
       setDailyLimit(limit);
       setDailySpent(spent);
+      setDayStart(start);
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : String(e));
       setDailyLimit(null);
       setDailySpent(null);
+      setDayStart(null);
     } finally {
       setLoading(false);
     }
@@ -37,6 +45,9 @@ export default function DailyLimitCard({ userKey, refreshTrigger, onOpen }: Prop
   }, [loadData, refreshTrigger]);
 
   const remaining = dailyLimit !== null && dailySpent !== null ? dailyLimit - dailySpent : null;
+  const dayActive = dayStart !== null;
+  const progress = dailyLimit !== null && dailySpent !== null ? dailyLimitProgress(dailySpent, dailyLimit) : 0;
+  const isUncappedWithWindow = dailyLimit === null && dayActive && dailySpent !== null && dailySpent > 0n;
 
   if (loading) {
     return (
@@ -69,26 +80,71 @@ export default function DailyLimitCard({ userKey, refreshTrigger, onOpen }: Prop
           <p>{error}</p>
         </div>
       ) : (
-        <div className="subscription-rows">
-          <Row
-            label="Daily limit"
-            value={dailyLimit !== null ? displayCurrentAmount(dailyLimit) : "Not set"}
-          />
-          <Row
-            label="Today's spend"
-            value={dailySpent !== null ? displayCurrentAmount(dailySpent) : "—"}
-          />
-          <Row
-            label="Remaining"
-            value={
-              remaining !== null
-                ? remaining >= 0n
-                  ? displayCurrentAmount(remaining)
-                  : "Exceeded"
-                : "—"
-            }
-          />
-        </div>
+        <>
+          <div className="subscription-rows">
+            <Row
+              label="Daily limit"
+              value={dailyLimit !== null ? displayCurrentAmount(dailyLimit) : "Not set"}
+            />
+            <Row
+              label="Today's spend"
+              value={dailySpent !== null ? displayCurrentAmount(dailySpent) : "—"}
+            />
+            <Row
+              label="Remaining"
+              value={
+                remaining !== null
+                  ? remaining >= 0n
+                    ? displayCurrentAmount(remaining)
+                    : "Exceeded"
+                  : "—"
+              }
+            />
+            <Row label="Day window" value={dayActive ? "Active — resets ~24h after first spend" : "Inactive"} />
+          </div>
+
+          {dailyLimit !== null && dailySpent !== null && (
+            <div style={{ marginTop: 12 }}>
+              <div
+                role="progressbar"
+                aria-label="Daily limit usage"
+                aria-valuenow={progress}
+                aria-valuemin={0}
+                aria-valuemax={100}
+                style={{
+                  height: 8,
+                  background: "var(--color-surface-overlay)",
+                  borderRadius: 999,
+                  overflow: "hidden",
+                }}
+              >
+                <div
+                  style={{
+                    width: `${progress}%`,
+                    height: "100%",
+                    background: progress >= 100 ? "var(--color-danger)" : progress >= 80 ? "#f59e0b" : "var(--color-primary)",
+                    transition: "width 0.2s ease",
+                  }}
+                />
+              </div>
+              <p className="text-xs text-muted" style={{ marginTop: 6 }}>
+                {progress}% used — {dayActive ? "Resets about 24 hours after your first spend today." : "Window starts on first pay-per-use."}
+              </p>
+            </div>
+          )}
+
+          {isUncappedWithWindow && (
+            <p className="text-xs" style={{ marginTop: 8, color: "#f59e0b" }} role="status">
+              Limit expired but window still active — spending is currently uncapped until you set a new limit.
+            </p>
+          )}
+
+          {dailyLimit === null && !dayActive && (
+            <p className="text-xs text-muted" style={{ marginTop: 8 }}>
+              No cap set — pay-per-use is uncapped. Set a limit to protect against unexpected spend.
+            </p>
+          )}
+        </>
       )}
     </div>
   );

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -1,6 +1,9 @@
-import React, { useState, useRef, useCallback, lazy, Suspense } from "react";
+import React, { useState, useRef, useCallback, useEffect, lazy, Suspense } from "react";
 import {
   buildPayPerUseTx,
+  getDailyLimit,
+  getDailySpent,
+  getDayStart,
   ChargeSimResult,
   chargeSimBlocksPay,
   payBlockedReason,
@@ -64,6 +67,42 @@ export default function Dashboard({
   const [allowanceRefresh, setAllowanceRefresh] = useState(0);
   const [dailyLimitRefresh, setDailyLimitRefresh] = useState(0);
   const ppuInputRef = useRef<HTMLInputElement>(null);
+  const [dailyLimit, setDailyLimit] = useState<bigint | null>(null);
+  const [dailySpent, setDailySpent] = useState<bigint | null>(null);
+  const [dayStart, setDayStart] = useState<bigint | null>(null);
+  const [dailyLimitLoading, setDailyLimitLoading] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function loadLimitForForm() {
+      if (!sub?.active) return;
+      setDailyLimitLoading(true);
+      try {
+        const [limit, spent, start] = await Promise.all([
+          getDailyLimit(userKey),
+          getDailySpent(userKey),
+          getDayStart(userKey),
+        ]);
+        if (!cancelled) {
+          setDailyLimit(limit);
+          setDailySpent(spent);
+          setDayStart(start);
+        }
+      } catch {
+        if (!cancelled) {
+          setDailyLimit(null);
+          setDailySpent(null);
+          setDayStart(null);
+        }
+      } finally {
+        if (!cancelled) setDailyLimitLoading(false);
+      }
+    }
+    loadLimitForForm();
+    return () => {
+      cancelled = true;
+    };
+  }, [userKey, sub?.active, dailyLimitRefresh, ppuTx.status]);
 
   usePolling({ callback: refresh, interval: 30000, enabled: !!sub?.active });
 
@@ -225,6 +264,10 @@ export default function Dashboard({
                 disabled={subscriptionHealthBlocksPay(subHealth) || chargeSimBlocksPay(simResult)}
                 disabledReason={payBlockedReason(subHealth, simResult) ?? undefined}
                 warningReason={payWarningReason(subHealth, simResult) ?? undefined}
+                dailyLimit={dailyLimit}
+                dailySpent={dailySpent}
+                dayActive={dayStart !== null}
+                isLimitLoading={dailyLimitLoading}
               />
               {ppuPending && (
                 <p className="status-text status-text--pending">Confirming payment…</p>

--- a/frontend/src/components/NetworkBadge.tsx
+++ b/frontend/src/components/NetworkBadge.tsx
@@ -1,16 +1,26 @@
 import React from "react";
+import { isMainnetPassphrase } from "../utils/network";
 import { NETWORK_PASSPHRASE } from "../stellar";
 
 /**
  * NetworkBadge: displays Testnet or Mainnet label derived from NETWORK_PASSPHRASE (#59)
  * Uses .badge-testnet / .badge-mainnet CSS classes — zero inline styles.
+ * Always visible (App shell + WalletBar) so users can tell network at a glance.
+ * Mainnet badge uses danger styling to draw attention per SECURITY.md caution.
  */
 export default function NetworkBadge() {
   const passphrase = NETWORK_PASSPHRASE;
-  const isMainnet = passphrase.includes("Public Global");
+  const isMainnet = isMainnetPassphrase(passphrase);
   const networkName = isMainnet ? "Mainnet" : "Testnet";
 
   return (
-    <span className={`badge ${isMainnet ? "badge-mainnet" : "badge-testnet"}`}>{networkName}</span>
+    <span
+      data-testid="network-badge"
+      aria-label={`Network: ${networkName}`}
+      title={isMainnet ? "Mainnet — real funds at risk" : "Testnet"}
+      className={`badge ${isMainnet ? "badge-mainnet" : "badge-testnet"}`}
+    >
+      {networkName}
+    </span>
   );
 }

--- a/frontend/src/components/PayPerUseForm.tsx
+++ b/frontend/src/components/PayPerUseForm.tsx
@@ -106,7 +106,7 @@ const PayPerUseForm = forwardRef<HTMLInputElement, PayPerUseFormProps>(
     const limitBlocked = remaining !== null && remaining <= 0n;
     const limitError = exceedsRemaining
       ? `Exceeds remaining daily budget (${displayCurrentAmount(remaining!)} remaining).`
-      : limitBlocked && amount
+      : limitBlocked
         ? "Daily limit reached — wait ~24h after first spend or raise limit."
         : null;
 

--- a/frontend/src/components/PayPerUseForm.tsx
+++ b/frontend/src/components/PayPerUseForm.tsx
@@ -3,6 +3,8 @@ import Spinner from "./Spinner";
 import { validateStroopAmount } from "../hooks/useFormValidation";
 import { STROOPS_PER_XLM, MIN_STROOPS, MAX_STROOPS, CONTRACT_LIMITS } from "../constants";
 import { useDebounce } from "../hooks/useDebounce";
+import { useAmountDisplay } from "../hooks/useAmountDisplay";
+import { dailyLimitProgress } from "../utils/format";
 
 interface PayPerUseFormProps {
   onPay: (amount: bigint) => Promise<void>;
@@ -11,6 +13,11 @@ interface PayPerUseFormProps {
   disabled?: boolean;
   disabledReason?: string;
   warningReason?: string;
+  /** Daily limit state for proactive validation before wallet prompt */
+  dailyLimit?: bigint | null;
+  dailySpent?: bigint | null;
+  dayActive?: boolean;
+  isLimitLoading?: boolean;
 }
 
 function validate(raw: string): { stroops: bigint | null; error: string | null } {
@@ -33,12 +40,27 @@ function validate(raw: string): { stroops: bigint | null; error: string | null }
 }
 
 const PayPerUseForm = forwardRef<HTMLInputElement, PayPerUseFormProps>(
-  ({ onPay, loading, isPaused = false, disabled = false, disabledReason, warningReason }, ref) => {
+  (
+    {
+      onPay,
+      loading,
+      isPaused = false,
+      disabled = false,
+      disabledReason,
+      warningReason,
+      dailyLimit = null,
+      dailySpent = null,
+      dayActive = false,
+      isLimitLoading = false,
+    },
+    ref
+  ) => {
     const [amount, setAmount] = useState("");
     const [error, setError] = useState<string | null>(null);
     const [lastValue, setLastValue] = useState(amount);
     const debouncedValue = useDebounce(amount, 300);
     const [convertedStroops, setConvertedStroops] = useState<bigint | null>(null);
+    const { displayCurrentAmount } = useAmountDisplay();
 
     useEffect(() => {
       if (amount !== lastValue) {
@@ -67,11 +89,37 @@ const PayPerUseForm = forwardRef<HTMLInputElement, PayPerUseFormProps>(
       return validateStroopAmount(amount, CONTRACT_LIMITS.MAX_PAY_PER_USE_AMOUNT);
     }, [amount]);
 
-    const payDisabled = loading || isPaused || disabled;
+    // Daily limit remaining logic — block submit when amount would exceed remaining budget
+    const remaining = dailyLimit !== null && dailySpent !== null ? dailyLimit - dailySpent : null;
+    const amountStroopsForLimit = useMemo(() => {
+      if (!amount) return null;
+      const parsed = parseFloat(amount);
+      if (Number.isNaN(parsed) || parsed <= 0) return null;
+      try {
+        return BigInt(Math.round(parsed * STROOPS_PER_XLM));
+      } catch {
+        return null;
+      }
+    }, [amount]);
+    const exceedsRemaining =
+      remaining !== null && amountStroopsForLimit !== null && amountStroopsForLimit > remaining;
+    const limitBlocked = remaining !== null && remaining <= 0n;
+    const limitError = exceedsRemaining
+      ? `Exceeds remaining daily budget (${displayCurrentAmount(remaining!)} remaining).`
+      : limitBlocked && amount
+        ? "Daily limit reached — wait ~24h after first spend or raise limit."
+        : null;
+
+    const payDisabled = loading || isPaused || disabled || exceedsRemaining || limitBlocked;
 
     async function handleSubmit() {
-      if (!validationResult.valid || payDisabled) return;
+      if (!validationResult.valid || payDisabled || exceedsRemaining) return;
       const stroops = BigInt(Math.round(parseFloat(amount) * 10_000_000));
+      // Extra guard: re-check before wallet prompt
+      if (remaining !== null && stroops > remaining) {
+        setError(`Amount exceeds remaining daily budget. Remaining: ${displayCurrentAmount(remaining)}`);
+        return;
+      }
       await onPay(stroops);
       setAmount("");
       setError(null);
@@ -84,9 +132,34 @@ const PayPerUseForm = forwardRef<HTMLInputElement, PayPerUseFormProps>(
         ? "Pay now (unavailable during maintenance)"
         : undefined;
 
+    const progress = dailyLimit !== null && dailySpent !== null ? dailyLimitProgress(dailySpent, dailyLimit) : 0;
+
     return (
       <div className="card">
         <h3 className="ppu-card__title">Pay-per-use</h3>
+        {(dailyLimit !== null || isLimitLoading) && (
+          <div style={{ marginBottom: 12, padding: 10, background: "var(--color-surface-overlay)", borderRadius: 8, border: "1px solid var(--color-border)" }}>
+            {isLimitLoading ? (
+              <span className="text-xs text-muted">Loading daily spending limit…</span>
+            ) : (
+              <>
+                <div style={{ display: "flex", justifyContent: "space-between", gap: 8, flexWrap: "wrap" }}>
+                  <span className="text-xs text-muted">Limit: {displayCurrentAmount(dailyLimit!)}</span>
+                  <span className="text-xs text-muted">Spent: {displayCurrentAmount(dailySpent!)}</span>
+                  <span className="text-xs" style={{ fontWeight: 600, color: remaining !== null && remaining <= 0n ? "var(--color-danger)" : "var(--color-success)" }}>
+                    Remaining: {remaining !== null ? displayCurrentAmount(remaining) : "—"}
+                  </span>
+                </div>
+                <div style={{ marginTop: 8, height: 6, background: "var(--color-border)", borderRadius: 999, overflow: "hidden" }}>
+                  <div style={{ width: `${progress}%`, height: "100%", background: progress >= 100 ? "var(--color-danger)" : "var(--color-primary)", transition: "width 0.2s" }} />
+                </div>
+                <p className="text-xs text-muted" style={{ marginTop: 6 }}>
+                  {dayActive ? "Resets about 24 hours after your first spend today." : "Window starts on first pay-per-use."} {progress}% used.
+                </p>
+              </>
+            )}
+          </div>
+        )}
         <div className="ppu-card__row">
           <div style={{ flex: 1, display: "flex", flexDirection: "column" }}>
             <input
@@ -123,6 +196,11 @@ const PayPerUseForm = forwardRef<HTMLInputElement, PayPerUseFormProps>(
         {!disabled && warningReason && (
           <p className="text-sm text-muted" data-testid="ppu-warning-reason" role="status">
             {warningReason}
+          </p>
+        )}
+        {limitError && (
+          <p className="text-error" data-testid="ppu-limit-error" role="alert">
+            {limitError}
           </p>
         )}
         {validationResult.error && <span className="text-error">{validationResult.error}</span>}

--- a/frontend/src/components/PayPerUseForm.tsx
+++ b/frontend/src/components/PayPerUseForm.tsx
@@ -117,7 +117,9 @@ const PayPerUseForm = forwardRef<HTMLInputElement, PayPerUseFormProps>(
       const stroops = BigInt(Math.round(parseFloat(amount) * 10_000_000));
       // Extra guard: re-check before wallet prompt
       if (remaining !== null && stroops > remaining) {
-        setError(`Amount exceeds remaining daily budget. Remaining: ${displayCurrentAmount(remaining)}`);
+        setError(
+          `Amount exceeds remaining daily budget. Remaining: ${displayCurrentAmount(remaining)}`
+        );
         return;
       }
       await onPay(stroops);
@@ -132,29 +134,76 @@ const PayPerUseForm = forwardRef<HTMLInputElement, PayPerUseFormProps>(
         ? "Pay now (unavailable during maintenance)"
         : undefined;
 
-    const progress = dailyLimit !== null && dailySpent !== null ? dailyLimitProgress(dailySpent, dailyLimit) : 0;
+    const progress =
+      dailyLimit !== null && dailySpent !== null ? dailyLimitProgress(dailySpent, dailyLimit) : 0;
 
     return (
       <div className="card">
         <h3 className="ppu-card__title">Pay-per-use</h3>
         {(dailyLimit !== null || isLimitLoading) && (
-          <div style={{ marginBottom: 12, padding: 10, background: "var(--color-surface-overlay)", borderRadius: 8, border: "1px solid var(--color-border)" }}>
+          <div
+            style={{
+              marginBottom: 12,
+              padding: 10,
+              background: "var(--color-surface-overlay)",
+              borderRadius: 8,
+              border: "1px solid var(--color-border)",
+            }}
+          >
             {isLimitLoading ? (
               <span className="text-xs text-muted">Loading daily spending limit…</span>
             ) : (
               <>
-                <div style={{ display: "flex", justifyContent: "space-between", gap: 8, flexWrap: "wrap" }}>
-                  <span className="text-xs text-muted">Limit: {displayCurrentAmount(dailyLimit!)}</span>
-                  <span className="text-xs text-muted">Spent: {displayCurrentAmount(dailySpent!)}</span>
-                  <span className="text-xs" style={{ fontWeight: 600, color: remaining !== null && remaining <= 0n ? "var(--color-danger)" : "var(--color-success)" }}>
+                <div
+                  style={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    gap: 8,
+                    flexWrap: "wrap",
+                  }}
+                >
+                  <span className="text-xs text-muted">
+                    Limit: {displayCurrentAmount(dailyLimit!)}
+                  </span>
+                  <span className="text-xs text-muted">
+                    Spent: {displayCurrentAmount(dailySpent!)}
+                  </span>
+                  <span
+                    className="text-xs"
+                    style={{
+                      fontWeight: 600,
+                      color:
+                        remaining !== null && remaining <= 0n
+                          ? "var(--color-danger)"
+                          : "var(--color-success)",
+                    }}
+                  >
                     Remaining: {remaining !== null ? displayCurrentAmount(remaining) : "—"}
                   </span>
                 </div>
-                <div style={{ marginTop: 8, height: 6, background: "var(--color-border)", borderRadius: 999, overflow: "hidden" }}>
-                  <div style={{ width: `${progress}%`, height: "100%", background: progress >= 100 ? "var(--color-danger)" : "var(--color-primary)", transition: "width 0.2s" }} />
+                <div
+                  style={{
+                    marginTop: 8,
+                    height: 6,
+                    background: "var(--color-border)",
+                    borderRadius: 999,
+                    overflow: "hidden",
+                  }}
+                >
+                  <div
+                    style={{
+                      width: `${progress}%`,
+                      height: "100%",
+                      background: progress >= 100 ? "var(--color-danger)" : "var(--color-primary)",
+                      transition: "width 0.2s",
+                    }}
+                  />
                 </div>
                 <p className="text-xs text-muted" style={{ marginTop: 6 }}>
-                  {dayActive ? "Resets about 24 hours after your first spend today." : "Window starts on first pay-per-use."} {progress}% used.
+                  {dayActive
+                    ? "Resets about 24 hours after your first spend today."
+                    : "Window starts on first pay-per-use."}{" "}
+                  {progress}% used.
                 </p>
               </>
             )}

--- a/frontend/src/components/TxQueuePanel.tsx
+++ b/frontend/src/components/TxQueuePanel.tsx
@@ -141,7 +141,7 @@ function TxEntryRow({ entry }: TxEntryRowProps) {
               className="btn-secondary tx-queue-entry__retry"
               onClick={handleRetry}
               disabled={retrying}
-              aria-label={`Retry ${entry.operation}`}
+              aria-label={`${isInterrupted ? "Resume" : "Retry"} ${entry.operation}`}
               title="Re-simulates before resubmitting to catch allowance/daily-limit errors"
             >
               {retrying ? "Retrying…" : isInterrupted ? "Resume" : "Retry"}

--- a/frontend/src/components/TxQueuePanel.tsx
+++ b/frontend/src/components/TxQueuePanel.tsx
@@ -58,18 +58,19 @@ interface TxEntryRowProps {
 
 function TxEntryRow({ entry }: TxEntryRowProps) {
   const [retrying, setRetrying] = useState(false);
+  const retryCallback = entry.retry;
 
   const handleRetry = useCallback(async () => {
-    if (!entry.retry) return;
+    if (!retryCallback) return;
     setRetrying(true);
     try {
       // Re-simulation is performed inside the stored retry callback where available.
       // The UI warns about double-submit before invoking it.
-      await entry.retry();
+      await retryCallback();
     } finally {
       setRetrying(false);
     }
-  }, [entry.retry]);
+  }, [retryCallback]);
 
   const handleDiscard = useCallback(() => {
     removeEntry(entry.id);

--- a/frontend/src/components/TxQueuePanel.tsx
+++ b/frontend/src/components/TxQueuePanel.tsx
@@ -7,7 +7,13 @@
  * Issue #658
  */
 import React, { useEffect, useState, useCallback } from "react";
-import { addListener, setPanelOpen, type TxEntry } from "../services/txQueue";
+import {
+  addListener,
+  setPanelOpen,
+  removeEntry,
+  clearAllEntries,
+  type TxEntry,
+} from "../services/txQueue";
 import { explorerTxUrl } from "../stellar";
 import CopyButton from "./CopyButton";
 
@@ -57,11 +63,20 @@ function TxEntryRow({ entry }: TxEntryRowProps) {
     if (!entry.retry) return;
     setRetrying(true);
     try {
+      // Re-simulation is performed inside the stored retry callback where available.
+      // The UI warns about double-submit before invoking it.
       await entry.retry();
     } finally {
       setRetrying(false);
     }
   }, [entry.retry]);
+
+  const handleDiscard = useCallback(() => {
+    removeEntry(entry.id);
+  }, [entry.id]);
+
+  const isInterrupted = entry.status === "pending" && !entry.hash;
+  const showRecovery = isInterrupted || entry.status === "failed";
 
   return (
     <li className="tx-queue-entry" aria-label={`Transaction: ${entry.operation}`}>
@@ -96,20 +111,50 @@ function TxEntryRow({ entry }: TxEntryRowProps) {
         )}
       </div>
 
+      {isInterrupted && (
+        <div className="tx-queue-entry__error" role="alert" style={{ background: "#451a03", borderColor: "#92400e" }}>
+          <span className="text-sm" style={{ color: "#fbbf24" }}>
+            Interrupted — wallet closed before confirmation. Check explorer; if no recent tx, you may
+            retry. Retrying will re-simulate before submitting.
+          </span>
+        </div>
+      )}
+
       {entry.status === "failed" && (
         <div className="tx-queue-entry__error" role="alert">
           <span className="text-sm text-error">{entry.error ?? "Unknown error"}</span>
-          {entry.retry && (
+        </div>
+      )}
+
+      {showRecovery && (
+        <div className="tx-queue-entry__actions" style={{ display: "flex", gap: 8, marginTop: 8, flexWrap: "wrap" }}>
+          {entry.retry ? (
             <button
               className="btn-secondary tx-queue-entry__retry"
               onClick={handleRetry}
               disabled={retrying}
               aria-label={`Retry ${entry.operation}`}
+              title="Re-simulates before resubmitting to catch allowance/daily-limit errors"
             >
-              {retrying ? "Retrying…" : "Retry"}
+              {retrying ? "Retrying…" : isInterrupted ? "Resume" : "Retry"}
             </button>
-          )}
+          ) : isInterrupted ? (
+            <span className="text-sm text-muted">No retry available — rebuild the transaction and try again.</span>
+          ) : null}
+          <button
+            className="btn-secondary tx-queue-entry__discard"
+            onClick={handleDiscard}
+            aria-label={`Discard ${entry.operation}`}
+          >
+            Discard
+          </button>
         </div>
+      )}
+
+      {(isInterrupted || entry.status === "pending") && (
+        <p className="text-xs text-muted" style={{ marginTop: 4 }}>
+          ⚠ Double-submit risk: only retry if explorer shows no matching recent transaction.
+        </p>
       )}
     </li>
   );
@@ -136,6 +181,10 @@ export default function TxQueuePanel() {
 
   const handleClose = useCallback(() => {
     setPanelOpen(false);
+  }, []);
+
+  const handleClearAll = useCallback(() => {
+    clearAllEntries();
   }, []);
 
   // Don't render if there are no transactions yet
@@ -175,7 +224,14 @@ export default function TxQueuePanel() {
       {/* Entry list */}
       {open && (
         <div className="tx-queue-panel__body">
-          <div className="tx-queue-panel__actions">
+          <div className="tx-queue-panel__actions" style={{ display: "flex", gap: 8 }}>
+            <button
+              className="btn-secondary tx-queue-panel__close"
+              onClick={handleClearAll}
+              aria-label="Clear all transactions"
+            >
+              Clear all
+            </button>
             <button
               className="btn-secondary tx-queue-panel__close"
               onClick={handleClose}
@@ -184,6 +240,9 @@ export default function TxQueuePanel() {
               Close
             </button>
           </div>
+          <p className="text-xs text-muted" style={{ padding: "8px 16px 0", margin: 0 }}>
+            Pending items survive reload. Interrupted signings stay pending until you resume or discard.
+          </p>
           <ul id="tx-queue-list" className="tx-queue-list" aria-label="Recent transactions">
             {entries.map((entry) => (
               <TxEntryRow key={entry.id} entry={entry} />

--- a/frontend/src/components/TxQueuePanel.tsx
+++ b/frontend/src/components/TxQueuePanel.tsx
@@ -113,10 +113,14 @@ function TxEntryRow({ entry }: TxEntryRowProps) {
       </div>
 
       {isInterrupted && (
-        <div className="tx-queue-entry__error" role="alert" style={{ background: "#451a03", borderColor: "#92400e" }}>
+        <div
+          className="tx-queue-entry__error"
+          role="alert"
+          style={{ background: "#451a03", borderColor: "#92400e" }}
+        >
           <span className="text-sm" style={{ color: "#fbbf24" }}>
-            Interrupted — wallet closed before confirmation. Check explorer; if no recent tx, you may
-            retry. Retrying will re-simulate before submitting.
+            Interrupted — wallet closed before confirmation. Check explorer; if no recent tx, you
+            may retry. Retrying will re-simulate before submitting.
           </span>
         </div>
       )}
@@ -128,7 +132,10 @@ function TxEntryRow({ entry }: TxEntryRowProps) {
       )}
 
       {showRecovery && (
-        <div className="tx-queue-entry__actions" style={{ display: "flex", gap: 8, marginTop: 8, flexWrap: "wrap" }}>
+        <div
+          className="tx-queue-entry__actions"
+          style={{ display: "flex", gap: 8, marginTop: 8, flexWrap: "wrap" }}
+        >
           {entry.retry ? (
             <button
               className="btn-secondary tx-queue-entry__retry"
@@ -140,7 +147,9 @@ function TxEntryRow({ entry }: TxEntryRowProps) {
               {retrying ? "Retrying…" : isInterrupted ? "Resume" : "Retry"}
             </button>
           ) : isInterrupted ? (
-            <span className="text-sm text-muted">No retry available — rebuild the transaction and try again.</span>
+            <span className="text-sm text-muted">
+              No retry available — rebuild the transaction and try again.
+            </span>
           ) : null}
           <button
             className="btn-secondary tx-queue-entry__discard"
@@ -242,7 +251,8 @@ export default function TxQueuePanel() {
             </button>
           </div>
           <p className="text-xs text-muted" style={{ padding: "8px 16px 0", margin: 0 }}>
-            Pending items survive reload. Interrupted signings stay pending until you resume or discard.
+            Pending items survive reload. Interrupted signings stay pending until you resume or
+            discard.
           </p>
           <ul id="tx-queue-list" className="tx-queue-list" aria-label="Recent transactions">
             {entries.map((entry) => (

--- a/frontend/src/hooks/useNetworkCheck.ts
+++ b/frontend/src/hooks/useNetworkCheck.ts
@@ -1,9 +1,19 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { NETWORK_PASSPHRASE } from "../stellar";
+import {
+  isMainnetPassphrase,
+  MAINNET_CONFIRM_KEY,
+  isMainnetConfirmed as getMainnetConfirmed,
+  setMainnetConfirmed,
+} from "../utils/network";
 
 interface NetworkCheckResult {
   networkMatch: boolean;
   walletNetwork: string;
+  isMainnet: boolean;
+  isMainnetConfirmed: boolean;
+  requiresMainnetConfirm: boolean;
+  confirmMainnet: () => void;
 }
 
 /**
@@ -12,7 +22,22 @@ interface NetworkCheckResult {
  * Re-runs whenever the component mounts.
  */
 export function useNetworkCheck(): NetworkCheckResult {
-  const [result, setResult] = useState<NetworkCheckResult>({
+  const isMainnet = isMainnetPassphrase(NETWORK_PASSPHRASE);
+  const [isMainnetConfirmed, setIsMainnetConfirmed] = useState<boolean>(() => {
+    if (!isMainnet) return true;
+    try {
+      return getMainnetConfirmed();
+    } catch {
+      return false;
+    }
+  });
+
+  const confirmMainnet = useCallback(() => {
+    setMainnetConfirmed();
+    setIsMainnetConfirmed(true);
+  }, []);
+
+  const [result, setResult] = useState<Omit<NetworkCheckResult, "isMainnet" | "isMainnetConfirmed" | "requiresMainnetConfirm" | "confirmMainnet">>({
     networkMatch: true, // optimistic default — no false warning before check completes
     walletNetwork: "",
   });
@@ -21,7 +46,7 @@ export function useNetworkCheck(): NetworkCheckResult {
     let cancelled = false;
 
     async function check() {
-      if (!window.freighter) return;
+      if (typeof window === "undefined" || !window.freighter) return;
 
       try {
         const { network, networkPassphrase } = await window.freighter.getNetwork();
@@ -43,5 +68,28 @@ export function useNetworkCheck(): NetworkCheckResult {
     };
   }, []);
 
-  return result;
+  // Keep confirmed state in sync with sessionStorage across remounts/storage events
+  useEffect(() => {
+    if (!isMainnet) return;
+    function onStorage(e: StorageEvent) {
+      if (e.key === MAINNET_CONFIRM_KEY) {
+        try {
+          setIsMainnetConfirmed(sessionStorage.getItem(MAINNET_CONFIRM_KEY) === "true");
+        } catch {
+          // ignore
+        }
+      }
+    }
+    // sessionStorage does not fire storage events in same tab, but listen for completeness
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
+  }, [isMainnet]);
+
+  return {
+    ...result,
+    isMainnet,
+    isMainnetConfirmed,
+    requiresMainnetConfirm: isMainnet && !isMainnetConfirmed,
+    confirmMainnet,
+  };
 }

--- a/frontend/src/hooks/useNetworkCheck.ts
+++ b/frontend/src/hooks/useNetworkCheck.ts
@@ -36,7 +36,12 @@ export function useNetworkCheck(): NetworkCheckResult {
     setIsMainnetConfirmed(true);
   }, []);
 
-  const [result, setResult] = useState<Omit<NetworkCheckResult, "isMainnet" | "isMainnetConfirmed" | "requiresMainnetConfirm" | "confirmMainnet">>({
+  const [result, setResult] = useState<
+    Omit<
+      NetworkCheckResult,
+      "isMainnet" | "isMainnetConfirmed" | "requiresMainnetConfirm" | "confirmMainnet"
+    >
+  >({
     networkMatch: true, // optimistic default — no false warning before check completes
     walletNetwork: "",
   });

--- a/frontend/src/hooks/useNetworkCheck.ts
+++ b/frontend/src/hooks/useNetworkCheck.ts
@@ -2,7 +2,6 @@ import { useEffect, useState, useCallback } from "react";
 import { NETWORK_PASSPHRASE } from "../stellar";
 import {
   isMainnetPassphrase,
-  MAINNET_CONFIRM_KEY,
   isMainnetConfirmed as getMainnetConfirmed,
   setMainnetConfirmed,
 } from "../utils/network";
@@ -67,23 +66,6 @@ export function useNetworkCheck(): NetworkCheckResult {
       cancelled = true;
     };
   }, []);
-
-  // Keep confirmed state in sync with sessionStorage across remounts/storage events
-  useEffect(() => {
-    if (!isMainnet) return;
-    function onStorage(e: StorageEvent) {
-      if (e.key === MAINNET_CONFIRM_KEY) {
-        try {
-          setIsMainnetConfirmed(sessionStorage.getItem(MAINNET_CONFIRM_KEY) === "true");
-        } catch {
-          // ignore
-        }
-      }
-    }
-    // sessionStorage does not fire storage events in same tab, but listen for completeness
-    window.addEventListener("storage", onStorage);
-    return () => window.removeEventListener("storage", onStorage);
-  }, [isMainnet]);
 
   return {
     ...result,

--- a/frontend/src/hooks/useTransaction.ts
+++ b/frontend/src/hooks/useTransaction.ts
@@ -28,7 +28,15 @@
 import { useState, useCallback, useRef } from "react";
 import { server } from "../stellar";
 import { useRpcHealthContext } from "../context/RpcHealthContext";
-import { enqueueTransaction } from "../services/txQueue";
+import {
+  enqueueTransaction,
+  enqueue,
+  markSubmitted,
+  markConfirmed,
+  markFailed,
+  setRetry,
+} from "../services/txQueue";
+import { ensureMainnetConfirmed } from "../utils/network";
 
 export type TxStatus = "idle" | "pending" | "success" | "failed";
 
@@ -36,7 +44,7 @@ export interface UseTransactionResult {
   status: TxStatus;
   hash: string | null;
   error: string | null;
-  submit: (buildAndSign: () => Promise<string>) => Promise<string>;
+  submit: (buildAndSign: () => Promise<string>, label?: string) => Promise<string>;
 }
 
 const POLL_INTERVAL_MS = 2000;
@@ -50,9 +58,16 @@ export function useTransaction(): UseTransactionResult {
   const { circuitOpen } = useRpcHealthContext();
 
   const submit = useCallback(
-    async (buildAndSign: () => Promise<string>): Promise<string> => {
+    async (buildAndSign: () => Promise<string>, label = "Transaction"): Promise<string> => {
       if (circuitOpen) {
         const msg = "RPC unavailable";
+        setError(msg);
+        setStatus("failed");
+        throw new Error(msg);
+      }
+      // Mainnet safety gate — require explicit confirmation once per session before any mutating tx
+      if (!ensureMainnetConfirmed()) {
+        const msg = "Mainnet transaction cancelled";
         setError(msg);
         setStatus("failed");
         throw new Error(msg);
@@ -61,16 +76,36 @@ export function useTransaction(): UseTransactionResult {
       setHash(null);
       setError(null);
 
+      // Create a persisted UI queue entry so interrupted signings survive reload.
+      // The retry callback re-simulates before resubmitting (caller rebuilds XDR with simulate).
+      const uiId = enqueue(label, null);
+      const retryFn = async () => {
+        // Re-run the original buildAndSign with a fresh simulation; useTransaction will re-enter its own queue
+        await submit(buildAndSign, label);
+      };
+      setRetry(uiId, retryFn);
+
       let txHash: string;
       try {
-        txHash = await enqueueTransaction(buildAndSign, "Transaction");
+        txHash = await enqueueTransaction(buildAndSign, label);
       } catch (e) {
         const msg = e instanceof Error ? e.message : String(e);
+        // Distinguish Freighter close / user reject (interrupted) from other failures
+        const isInterrupted = /close|reject|cancel|dismiss/i.test(msg);
+        // Keep pending entry as failed but retain retry; panel will show Resume/Discard + warning
+        markFailed(uiId, msg);
+        // Preserve retry for interrupted states so user can resume safely (re-simulates)
+        if (isInterrupted) {
+          setRetry(uiId, retryFn);
+        }
         setError(msg);
         setStatus("failed");
         throw e;
       }
 
+      markSubmitted(uiId, txHash);
+      // Retry stays available until confirmed, so user can resume if polling is lost
+      setRetry(uiId, retryFn);
       setHash(txHash);
 
       // Poll until confirmed or timed out
@@ -79,7 +114,9 @@ export function useTransaction(): UseTransactionResult {
       await new Promise<void>((resolve) => {
         function poll() {
           if (Date.now() > deadline) {
-            setError("Transaction confirmation timed out");
+            const timeoutMsg = "Transaction confirmation timed out";
+            markFailed(uiId, timeoutMsg);
+            setError(timeoutMsg);
             setStatus("failed");
             resolve();
             return;
@@ -89,10 +126,13 @@ export function useTransaction(): UseTransactionResult {
             .getTransaction(txHash)
             .then((result) => {
               if (result.status === "SUCCESS") {
+                markConfirmed(uiId);
                 setStatus("success");
                 resolve();
               } else if (result.status === "FAILED") {
-                setError("Transaction failed on-chain");
+                const failMsg = "Transaction failed on-chain";
+                markFailed(uiId, failMsg);
+                setError(failMsg);
                 setStatus("failed");
                 resolve();
               } else {

--- a/frontend/src/hooks/useWallet.ts
+++ b/frontend/src/hooks/useWallet.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback, useEffect } from "react";
 import { Transaction } from "@stellar/stellar-sdk";
 import { NETWORK_PASSPHRASE, server } from "../stellar";
+import { ensureMainnetConfirmed } from "../utils/network";
 import { WalletAdapter } from "../services/wallets/WalletAdapter";
 import { FreighterAdapter } from "../services/wallets/FreighterAdapter";
 import { XBullAdapter } from "../services/wallets/XBullAdapter";
@@ -102,6 +103,10 @@ export function useWallet() {
   const signAndSubmit = useCallback(
     async (xdr: string): Promise<string> => {
       if (!activeAdapter) throw new Error("No wallet connected");
+      // Defense-in-depth mainnet gate for direct sign paths (e.g., SubscribeForm that bypasses useTransaction)
+      if (!ensureMainnetConfirmed()) {
+        throw new Error("Mainnet transaction cancelled");
+      }
       const signed = await activeAdapter.signTransaction(xdr, NETWORK_PASSPHRASE);
       const tx = new Transaction(signed, NETWORK_PASSPHRASE);
       const result = await server.sendTransaction(tx);

--- a/frontend/src/services/txQueue.ts
+++ b/frontend/src/services/txQueue.ts
@@ -29,15 +29,71 @@ export interface TxEntry {
 export type TxQueueListener = (entries: TxEntry[], open: boolean) => void;
 
 const MAX_ENTRIES = 10;
+export const TX_QUEUE_STORAGE_KEY = "flowpay_tx_queue";
+export const TX_PANEL_STORAGE_KEY = "flowpay_tx_panel_open";
 
-let nextId = 1;
-let entries: TxEntry[] = [];
-let panelOpen = false;
+export interface PersistedTxEntry {
+  id: number;
+  operation: string;
+  hash: string | null;
+  timestamp: string;
+  status: TxEntryStatus;
+  error: string | null;
+}
+
+function loadPersisted(): { entries: TxEntry[]; panelOpen: boolean; nextId: number } {
+  if (typeof window === "undefined" || !window.localStorage) {
+    return { entries: [], panelOpen: false, nextId: 1 };
+  }
+  try {
+    const raw = window.localStorage.getItem(TX_QUEUE_STORAGE_KEY);
+    const panelRaw = window.localStorage.getItem(TX_PANEL_STORAGE_KEY);
+    if (!raw) return { entries: [], panelOpen: panelRaw === "true", nextId: 1 };
+    const parsed = JSON.parse(raw) as PersistedTxEntry[];
+    if (!Array.isArray(parsed)) return { entries: [], panelOpen: false, nextId: 1 };
+    const restored: TxEntry[] = parsed.map((e) => ({
+      ...e,
+      retry: null,
+    }));
+    const maxId = restored.reduce((m, e) => Math.max(m, e.id), 0);
+    return {
+      entries: restored.slice(0, MAX_ENTRIES),
+      panelOpen: panelRaw === "true" ? true : restored.length > 0,
+      nextId: maxId + 1,
+    };
+  } catch {
+    return { entries: [], panelOpen: false, nextId: 1 };
+  }
+}
+
+function persist() {
+  if (typeof window === "undefined" || !window.localStorage) return;
+  try {
+    const toPersist: PersistedTxEntry[] = entries.map(({ id, operation, hash, timestamp, status, error }) => ({
+      id,
+      operation,
+      hash,
+      timestamp,
+      status,
+      error,
+    }));
+    window.localStorage.setItem(TX_QUEUE_STORAGE_KEY, JSON.stringify(toPersist));
+    window.localStorage.setItem(TX_PANEL_STORAGE_KEY, JSON.stringify(panelOpen));
+  } catch {
+    // localStorage unavailable or quota exceeded
+  }
+}
+
+const _loaded = loadPersisted();
+let nextId = _loaded.nextId;
+let entries: TxEntry[] = _loaded.entries;
+let panelOpen = _loaded.panelOpen;
 const listeners = new Set<TxQueueListener>();
 
 function notify() {
   const snapshot = [...entries];
   const open = panelOpen;
+  persist();
   listeners.forEach((fn) => fn(snapshot, open));
 }
 
@@ -53,6 +109,25 @@ export function addListener(fn: TxQueueListener): () => void {
 export function setPanelOpen(open: boolean): void {
   panelOpen = open;
   notify();
+}
+
+/** Remove a single entry (discard). Used for interrupted/failed tx recovery. */
+export function removeEntry(id: number): void {
+  entries = entries.filter((e) => e.id !== id);
+  if (entries.length === 0) panelOpen = false;
+  notify();
+}
+
+/** Clear all entries and close panel. */
+export function clearAllEntries(): void {
+  entries = [];
+  panelOpen = false;
+  notify();
+}
+
+/** Return only pending/submitted (in-flight or interrupted) entries. */
+export function getPendingEntries(): TxEntry[] {
+  return entries.filter((e) => e.status === "pending" || e.status === "submitted");
 }
 
 /**
@@ -112,12 +187,38 @@ export function isPanelOpen(): boolean {
   return panelOpen;
 }
 
-/** Reset queue state — used in tests. */
+/** Reset queue state — used in tests. Clears persisted storage as well. */
 export function _reset(): void {
   nextId = 1;
   entries = [];
   panelOpen = false;
   listeners.clear();
+  try {
+    if (typeof window !== "undefined" && window.localStorage) {
+      window.localStorage.removeItem(TX_QUEUE_STORAGE_KEY);
+      window.localStorage.removeItem(TX_PANEL_STORAGE_KEY);
+    }
+  } catch {
+    // ignore
+  }
+  // Also clear queue serialization state
+  queuePromise = Promise.resolve();
+  queueDepth = 0;
+  pendingLabel = null;
+  queueStateListeners.clear();
+  queueListeners.clear();
+}
+
+/**
+ * Re-hydrate from localStorage after a simulated reload (test helper).
+ * Used to verify persistence across refresh without a full page reload.
+ */
+export function _rehydrate(): void {
+  const loaded = loadPersisted();
+  nextId = loaded.nextId;
+  entries = loaded.entries;
+  panelOpen = loaded.panelOpen;
+  notify();
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/services/txQueue.ts
+++ b/frontend/src/services/txQueue.ts
@@ -69,14 +69,16 @@ function loadPersisted(): { entries: TxEntry[]; panelOpen: boolean; nextId: numb
 function persist() {
   if (typeof window === "undefined" || !window.localStorage) return;
   try {
-    const toPersist: PersistedTxEntry[] = entries.map(({ id, operation, hash, timestamp, status, error }) => ({
-      id,
-      operation,
-      hash,
-      timestamp,
-      status,
-      error,
-    }));
+    const toPersist: PersistedTxEntry[] = entries.map(
+      ({ id, operation, hash, timestamp, status, error }) => ({
+        id,
+        operation,
+        hash,
+        timestamp,
+        status,
+        error,
+      })
+    );
     window.localStorage.setItem(TX_QUEUE_STORAGE_KEY, JSON.stringify(toPersist));
     window.localStorage.setItem(TX_PANEL_STORAGE_KEY, JSON.stringify(panelOpen));
   } catch {

--- a/frontend/src/services/txQueue.ts
+++ b/frontend/src/services/txQueue.ts
@@ -56,9 +56,12 @@ function loadPersisted(): { entries: TxEntry[]; panelOpen: boolean; nextId: numb
       retry: null,
     }));
     const maxId = restored.reduce((m, e) => Math.max(m, e.id), 0);
+    // Respect an explicit persisted panel state; only auto-open when the key
+    // was never written (legacy/first run with existing entries).
+    const panelOpenRestored = panelRaw === null ? restored.length > 0 : panelRaw === "true";
     return {
       entries: restored.slice(0, MAX_ENTRIES),
-      panelOpen: panelRaw === "true" ? true : restored.length > 0,
+      panelOpen: panelOpenRestored,
       nextId: maxId + 1,
     };
   } catch {

--- a/frontend/src/stellar.ts
+++ b/frontend/src/stellar.ts
@@ -310,6 +310,63 @@ export function getDailySpent(user: string): Promise<bigint> {
   });
 }
 
+export function getDayStart(user: string): Promise<bigint | null> {
+  return dedupedCall(`getDayStart:${user}`, async () => {
+    const contract = new Contract(CONTRACT_ID);
+    const account = await server.getAccount(user);
+
+    const tx = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: NETWORK_PASSPHRASE,
+    })
+      .addOperation(contract.call("get_day_start", addressVal(user)))
+      .setTimeout(30)
+      .build();
+
+    const result = await server.simulateTransaction(tx);
+    if ("error" in result) throw new Error((result as { error: string }).error);
+
+    const retval = (result as { result?: { retval?: xdr.ScVal } }).result?.retval;
+    if (!retval || retval.switch().name === "scvVoid") return null;
+
+    // Contract returns Option<u64> (timestamp of window start). Some deployments may return bool.
+    const type = retval.switch().name;
+    if (type === "scvBool") {
+      return retval.b() ? 1n : null;
+    }
+    try {
+      const decoded = ScValDecoder.decodeOption(retval, ScValDecoder.decodeU64);
+      return decoded;
+    } catch {
+      // Fallback: try direct u64
+      try {
+        return ScValDecoder.decodeU64(retval);
+      } catch {
+        return null;
+      }
+    }
+  });
+}
+
+export interface DailyLimitStatus {
+  limit: bigint | null;
+  spent: bigint;
+  remaining: bigint | null;
+  dayActive: boolean;
+  dayStart: bigint | null;
+}
+
+export async function getDailyLimitStatus(user: string): Promise<DailyLimitStatus> {
+  const [limit, spent, dayStart] = await Promise.all([
+    getDailyLimit(user),
+    getDailySpent(user),
+    getDayStart(user),
+  ]);
+  const dayActive = dayStart !== null;
+  const remaining = limit !== null ? (limit > spent ? limit - spent : 0n) : null;
+  return { limit, spent, remaining, dayActive, dayStart };
+}
+
 export async function buildApproveTx(
   user: string,
   tokenId: string,

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -55,10 +55,7 @@ export function dailyLimitProgress(spent: bigint, limit: bigint | null): number 
 /**
  * Whether a pay-per-use amount would exceed the remaining daily budget.
  */
-export function exceedsRemaining(
-  amount: bigint | null,
-  remaining: bigint | null
-): boolean {
+export function exceedsRemaining(amount: bigint | null, remaining: bigint | null): boolean {
   if (amount === null || remaining === null) return false;
   return amount > remaining;
 }

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -42,3 +42,23 @@ export function displayAmount(stroops: string | number | bigint, unit: AmountUni
   // STROOP: raw integer with comma separators
   return `${stroopsNum.toLocaleString("en-US")} STROOP`;
 }
+
+/**
+ * Progress percentage for daily limit (0-100). Returns 0 when limit is null or zero.
+ */
+export function dailyLimitProgress(spent: bigint, limit: bigint | null): number {
+  if (limit === null || limit <= 0n) return 0;
+  const pct = Number((spent * 100n) / limit);
+  return Math.min(100, Math.max(0, pct));
+}
+
+/**
+ * Whether a pay-per-use amount would exceed the remaining daily budget.
+ */
+export function exceedsRemaining(
+  amount: bigint | null,
+  remaining: bigint | null
+): boolean {
+  if (amount === null || remaining === null) return false;
+  return amount > remaining;
+}

--- a/frontend/src/utils/network.ts
+++ b/frontend/src/utils/network.ts
@@ -1,0 +1,68 @@
+import { NETWORK_PASSPHRASE } from "../stellar";
+
+export const MAINNET_CONFIRM_KEY = "flowpay_mainnet_confirmed";
+
+/**
+ * Returns true when the given passphrase corresponds to Stellar Public Network (Mainnet).
+ * Matches the same heuristic as NetworkBadge: presence of "Public Global".
+ */
+export function isMainnetPassphrase(passphrase: string): boolean {
+  return passphrase.includes("Public Global");
+}
+
+/** Whether the app's configured NETWORK_PASSPHRASE points at Mainnet. */
+export function isMainnetNetwork(): boolean {
+  return isMainnetPassphrase(NETWORK_PASSPHRASE);
+}
+
+/** Whether the user has confirmed mainnet usage in this session. */
+export function isMainnetConfirmed(): boolean {
+  try {
+    return sessionStorage.getItem(MAINNET_CONFIRM_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+/** Persist mainnet confirmation for the current session. */
+export function setMainnetConfirmed(): void {
+  try {
+    sessionStorage.setItem(MAINNET_CONFIRM_KEY, "true");
+  } catch {
+    // sessionStorage unavailable (SSR/test) — no-op
+  }
+}
+
+/**
+ * Clears mainnet confirmation. Exported for tests and for manual reset flows.
+ */
+export function clearMainnetConfirmed(): void {
+  try {
+    sessionStorage.removeItem(MAINNET_CONFIRM_KEY);
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * Guard helper for mutating transactions. When on mainnet and not yet confirmed,
+ * prompts the user via window.confirm. Returns true if allowed to proceed, false if cancelled.
+ * Persists confirmation on accept so subsequent calls in the same session skip the prompt.
+ *
+ * Testable: `confirmFn` injection avoids window.confirm in unit tests.
+ */
+export function ensureMainnetConfirmed(
+  confirmFn: () => boolean = () =>
+    typeof window !== "undefined" && typeof window.confirm === "function"
+      ? window.confirm(
+          "You are about to transact on Mainnet with real funds. " +
+            "Please confirm you intend to use Mainnet. This will be remembered for this session."
+        )
+      : false
+): boolean {
+  if (!isMainnetNetwork()) return true;
+  if (isMainnetConfirmed()) return true;
+  const ok = confirmFn();
+  if (ok) setMainnetConfirmed();
+  return ok;
+}


### PR DESCRIPTION
# feat: mainnet safety gate, tx recovery, daily limit UX + security review (#846, #847, #845, #793)

## Overview
Single PR implementing four issues in one branch `feat/issues-846-847-845-793` as requested in `task.md`.

- **#846 (051) — Mainnet/Testnet safety gate** — explicit confirmation once per session when `VITE_NETWORK_PASSPHRASE` points at Mainnet before any mutating tx (subscribe/pay/admin), persistent badge in shell.
- **#847 (052) — Transaction lifecycle recovery** — interrupted wallet submissions (Freighter close mid-sign) now have resume/discard with re-simulation, queue persists across refresh via `localStorage`, double-submit warning.
- **#845 (050) — Daily spending limit UX** — `PayPerUseForm` + `DailyLimitCard` show `limit / spent / remaining` + reset timing via `getDayStart`, block submit when `amount > remaining`, handle loading/empty.
- **#793 — Security Review** — static HTML `docs/SECURITY-REVIEW.html` with top 3 findings, impact, and mitigations (not a formal audit).

Target upstream: `https://github.com/SiLioLabs/PayFlow.git`

Closes #846
Closes #847
Closes #845
Closes #793

---

## 1) #846 — Mainnet/Testnet safety gate

### Problem
Misconfigured `VITE_NETWORK_PASSPHRASE`/`VITE_RPC_URL` could point a production build at Mainnet without user confirmation.

### Changes
- **`frontend/src/utils/network.ts` (new)** — helpers `isMainnetPassphrase`, `isMainnetNetwork`, `MAINNET_CONFIRM_KEY`, `isMainnetConfirmed`, `setMainnetConfirmed`, `clearMainnetConfirmed`, `ensureMainnetConfirmed(confirmFn)`. Uses `sessionStorage` for once-per-session confirmation.
- **`frontend/src/hooks/useNetworkCheck.ts`** — now exposes `isMainnet`, `isMainnetConfirmed`, `requiresMainnetConfirm`, `confirmMainnet()` alongside existing `networkMatch`/`walletNetwork`. Syncs with `sessionStorage`.
- **`frontend/src/components/NetworkBadge.tsx`** — uses `isMainnetPassphrase`, adds `data-testid="network-badge"`, `aria-label`, `title` for a11y, keeps `.badge-mainnet`/`.badge-testnet` classes.
- **`frontend/src/hooks/useTransaction.ts`** — gate before `enqueueTransaction`: calls `ensureMainnetConfirmed()` (which uses `window.confirm`); on cancel sets `failed` state and throws `Mainnet transaction cancelled`. Testnet unaffected.
- **`frontend/src/hooks/useWallet.ts`** — defense-in-depth gate in `signAndSubmit` for direct `onSign` paths (e.g., `SubscribeForm`) that bypass `useTransaction`.
- **`frontend/src/App.tsx`** — `NetworkBadge` now always visible in header (persistent), plus `isMainnet && requiresMainnetConfirm` banner with `data-testid="confirm-mainnet-btn"` to confirm once per session.

### Acceptance
- [x] Mainnet confirmation required once per session
- [x] Testnet unaffected
- [x] Badge visible in shell (header) + WalletBar
- [x] Tests: `network.test.ts`, `NetworkBadge.test.tsx`, `useNetworkCheck.mainnet.test.tsx`, `useTransaction.mainnet.test.tsx`

### How to test
```bash
cd frontend
npm run test -- network
npm run test -- NetworkBadge
npm run test -- useNetworkCheck
npm run test -- useTransaction.mainnet
```
- Mock `NETWORK_PASSPHRASE` to `Public Global …` → verify `window.confirm` called once, second submit skips, cancel throws. Testnet path never prompts.

---

## 2) #847 — Transaction lifecycle recovery

### Problem
Freighter closed mid-sign leaves `pending` with no hash; user unsure to resubmit, duplicate `subscribe` risk.

### Changes
- **`frontend/src/services/txQueue.ts`** — adds `TX_QUEUE_STORAGE_KEY`/`TX_PANEL_STORAGE_KEY` persistence, `loadPersisted`/`persist`, rehydrate on module init. Entries persisted without `retry` fn (JSON-safe), `nextId` restored, `panelOpen` persisted. New APIs: `removeEntry(id)`, `clearAllEntries()`, `getPendingEntries()`, `_rehydrate()`. `_reset()` now clears storage + queue serialization state.
- **`frontend/src/hooks/useTransaction.ts`** — now creates a persisted UI entry (`enqueue(label)`) before signing, stores `retry` callback that re-simulates (re-runs `buildAndSign`), marks `markSubmitted`/`markConfirmed`/`markFailed` accordingly, distinguishes interrupted (`close|reject|cancel`) for resume, keeps double-submit warning. Accepts optional `label` param.
- **`frontend/src/components/TxQueuePanel.tsx`** — adds `Discard`/`Resume` + `Clear all`, interrupted pending (`pending` with no hash) shows amber warning “Interrupted — wallet closed … Check explorer … Retry will re-simulate”, double-submit risk note, `Pending items survive reload` hint, simulation re-check title.
- **Persistence** — via `localStorage` (spec says `useLocalStorage` pattern; service directly uses `localStorage` for singleton consistency).

### Acceptance
- [x] Pending items survive reload (`_rehydrate` + tests)
- [x] User can discard or retry safely (retry re-simulates before submit)
- [x] UI explains double-submit risk
- [x] Tests: `txQueue.persistence.test.ts`, `TxQueuePanel.recovery.test.tsx`

### How to test
```bash
cd frontend
npm run test -- txQueue
npm run test -- TxQueuePanel
```
- Verify `localStorage` JSON after `enqueue`, reload via `_rehydrate`, discard removes entry, retry calls stored callback.

---

## 3) #845 — Daily spending limit UX

### Problem
Spend remaining vs limit easy to miss; users hit `DailyLimitExceeded (code 24)` without proactive UX.

### Changes
- **`frontend/src/stellar.ts`** — adds `getDayStart(user): Promise<bigint|null>` (decodes `Option<u64>` with fallback for bool, uses `dedupedCall`), plus `DailyLimitStatus` and `getDailyLimitStatus(user)` composite (`limit/spent/remaining/dayActive/dayStart`).
- **`frontend/src/utils/format.ts`** — adds `dailyLimitProgress(spent, limit)` and `exceedsRemaining(amount, remaining)`.
- **`frontend/src/components/DailyLimitCard.tsx`** — now fetches `getDayStart` in parallel, computes `remaining = limit - spent`, `progress`, `dayActive`, `isUncappedWithWindow`. Renders limit/spent/remaining + `Day window: Active — resets ~24h after first spend` row, progress bar (`role="progressbar"`), 80/100 color thresholds, warnings for expired-but-active window and uncapped state, loading + error states.
- **`frontend/src/components/PayPerUseForm.tsx`** — new props `dailyLimit`, `dailySpent`, `dayActive`, `isLimitLoading`. Computes `remaining`, `exceedsRemaining`, `limitBlocked`, `limitError`. Shows inline limit panel with remaining + progress when limit set, disables Pay button and shows `data-testid="ppu-limit-error"` when `amount > remaining`, validates before wallet prompt (`Remaining: …`), displays reset timing.
- **`frontend/src/components/Dashboard.tsx`** — fetches `getDailyLimit`+`getDailySpent`+`getDayStart` for form (with `dailyLimitLoading` state), passes to `PayPerUseForm`, keeps `DailyLimitCard` self-fetching but shares `dailyLimitRefresh` trigger.

### Acceptance
- [x] Remaining displayed (Card + Form)
- [x] Block submit when `amount > remaining`
- [x] Loading/empty handled
- [x] Tests: `stellar.dailyLimit.test.ts`, `DailyLimitCard.test.tsx`, `PayPerUseForm.limit.test.tsx`

### How to test
```bash
cd frontend
npm run test -- stellar.dailyLimit
npm run test -- DailyLimitCard
npm run test -- PayPerUseForm.limit
```
- Card: 10 XLM limit, 7 spent → remaining 3, 70% progress, active window. No limit → `Not set`. Manual check on testnet if available: set limit, pay, verify remaining updates.

---

## 4) #793 — Security Review (Top 3)

### Added
- **`docs/SECURITY-REVIEW.html`** — self-contained, no-external-deps, accessible, print-friendly HTML report. Covers:
  1. **Overly broad allowance without mandatory daily cap** (High) — `pay_per_use` arbitrary pulls, shared pool, fee handling. Mitigation: proactive limit UX added.
  2. **Single admin key with broad powers** (High) — pause/fee/whitelist/upgrade. Mitigation: two-step flows, multisig/timelock roadmap.
  3. **Storage TTL expiry & keeper liveness** (Medium) — temporary `Daily*` TTL 17,280 ledgers, `Subscription` persistent TTL, keeper dependency. Mitigation: TTL warnings, `extend_subscription_ttl`, keepers.
- Sections: summary table, location, impact, static reproduction, recommendation, status, methodology, verification commands, disclosure (`security@payflow.dev`), revision `2026-08-28`.

Open directly: `docs/SECURITY-REVIEW.html`

---

## Validation
- Per `task.md`: code changes only, no builds run in this PR.
- Vitest suites added for each issue; run:
  ```bash
  cd frontend
  npm run test -- network DailyLimit stellar.dailyLimit TxQueuePanel txQueue useNetworkCheck useTransaction PayPerUseForm
  ```
- Manual: App shell shows `NetworkBadge` always; mainnet banner appears only when `VITE_NETWORK_PASSPHRASE` contains `Public Global`; pay-per-use form blocks over-remaining amounts before wallet opens.

## Files changed
- `frontend/src/utils/network.ts` (new)
- `frontend/src/hooks/useNetworkCheck.ts`
- `frontend/src/components/NetworkBadge.tsx`
- `frontend/src/hooks/useTransaction.ts`
- `frontend/src/hooks/useWallet.ts`
- `frontend/src/App.tsx`
- `frontend/src/services/txQueue.ts`
- `frontend/src/components/TxQueuePanel.tsx`
- `frontend/src/stellar.ts`
- `frontend/src/utils/format.ts`
- `frontend/src/components/DailyLimitCard.tsx`
- `frontend/src/components/PayPerUseForm.tsx`
- `frontend/src/components/Dashboard.tsx`
- `frontend/src/__tests__/network.test.ts` (new)
- `frontend/src/__tests__/NetworkBadge.test.tsx` (new)
- `frontend/src/__tests__/useNetworkCheck.mainnet.test.tsx` (new)
- `frontend/src/__tests__/useTransaction.mainnet.test.tsx` (new)
- `frontend/src/__tests__/txQueue.persistence.test.ts` (new)
- `frontend/src/__tests__/TxQueuePanel.recovery.test.tsx` (new)
- `frontend/src/__tests__/DailyLimitCard.test.tsx` (new)
- `frontend/src/__tests__/PayPerUseForm.limit.test.tsx` (new)
- `frontend/src/__tests__/stellar.dailyLimit.test.ts` (new)
- `docs/SECURITY-REVIEW.html` (new)

## Checklist
- [x] One branch, one PR for all issues
- [x] Safety gate + tests
- [x] Recovery UX + persistence tests
- [x] Limit UX + tests
- [x] Security review HTML
- [x] No disallowed builds (task.md constraint respected)
