### PR TITLE
Enhance pre-upgrade checks with snapshot thresholds and reports

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -587,3 +587,39 @@ across all scripts:
 - Mainnet gates: [`docs/MAINNET-DEPLOYMENT.md`](../docs/MAINNET-DEPLOYMENT.md)
 - Keeper handbook: [`docs/KEEPER.md`](../docs/KEEPER.md)
 - Contract API (`batch_charge`, health, estimates): [`docs/API.md`](../docs/API.md)
+## Contract Upgrades (Ops Section)
+
+When upgrading the FlowPay smart contract, it is crucial to ensure that the internal state remains safe and consistent. The \pre-upgrade-check.ts\ tool, along with snapshots and migration scripts, provides a robust automated runbook for safe upgrades.
+
+### Upgrade Runbook
+
+1. **Take a Pre-Upgrade Snapshot**
+   Capture the exact state of all subscriptions before any migration takes place:
+   \\\ash
+   npx tsx scripts/subscription-snapshot.ts --out before-upgrade.json
+   \\\
+
+2. **Run Automated Pre-Upgrade Checks**
+   Verify the schema version, fee configurations, and active_count drift against your snapshot:
+   \\\ash
+   CONTRACT_ID=<C...> npx tsx scripts/pre-upgrade-check.ts \
+     --snapshot before-upgrade.json \
+     --max-drift 0 \
+     --report pre-upgrade-report.json \
+     --wasm ./target/wasm32-unknown-unknown/release/flowpay.wasm
+   \\\
+   - **Schema Version**: Ensures the existing on-chain schema is safe to upgrade to the new version.
+   - **Active Count Drift**: Cross-checks \get_active_count()\ with the snapshot \count\. Fails (CI-like exit code \1\) if the drift exceeds \--max-drift\.
+   - **Fee Config**: Asserts the fee configurations remain intact.
+   - **Report Artifact**: A \pre-upgrade-report.json\ file is generated, which can be saved in CI artifacts.
+
+3. **Migrate the Contract**
+   If \pre-upgrade-check.ts\ passes successfully, proceed with the actual WASM upgrade and migration step (e.g. via \migrate-contract.ts\).
+
+4. **Verify Post-Upgrade State**
+   Take another snapshot and compare the differences:
+   \\\ash
+   npx tsx scripts/subscription-snapshot.ts --out after-upgrade.json
+   npx tsx scripts/snapshot-diff.ts before-upgrade.json after-upgrade.json
+   \\\
+   This will fail with an exit code \1\ if unexpected changes occurred.

--- a/scripts/pre-upgrade-check.ts
+++ b/scripts/pre-upgrade-check.ts
@@ -25,7 +25,7 @@
  *   }
  */
 
-import { readFileSync, existsSync, statSync } from "node:fs";
+import { readFileSync, writeFileSync, existsSync, statSync } from "node:fs";
 import { resolve } from "node:path";
 import {
   Contract,
@@ -91,6 +91,9 @@ const WASM_PATH = getArg("--wasm");
 const UPGRADE_CONFIG_PATH =
   getArg("--upgrade-config") ?? process.env.UPGRADE_CONFIG_PATH ?? "";
 const CONFIRM = process.argv.includes("--confirm");
+const SNAPSHOT_PATH = getArg("--snapshot");
+const MAX_DRIFT = parseInt(getArg("--max-drift") ?? "0", 10);
+const REPORT_PATH = getArg("--report") ?? "pre-upgrade-report.json";
 
 function showHelp(): never {
   console.log(`
@@ -101,6 +104,9 @@ Options:
   --upgrade-config <path>    JSON config with expected_schema_version
   --skip-key-check           Skip admin key signing test (e.g. hardware wallet)
   --confirm                  Print ready-to-proceed message when all checks pass
+  --snapshot <path>          Path to a subscription snapshot to check drift against
+  --max-drift <number>       Maximum allowed active_count difference from snapshot (default 0)
+  --report <path>            Path to write the JSON report (default: pre-upgrade-report.json)
   --help, -h                 Show this help
 
 Environment:
@@ -438,14 +444,35 @@ async function runChecks(): Promise<ReadinessReport> {
       });
     } else {
       const count = Number(scValToNative(retval));
+      let status: CheckStatus = count > 0 ? "warn" : "pass";
+      let detail = count > 0
+        ? `${count} active subscription(s) will be affected by storage migration`
+        : "No active subscriptions";
+      let blocking = false;
+
+      if (SNAPSHOT_PATH) {
+        if (existsSync(SNAPSHOT_PATH)) {
+          const snapshotData = JSON.parse(readFileSync(SNAPSHOT_PATH, "utf8"));
+          const snapCount = snapshotData.count ?? 0;
+          const drift = Math.abs(count - snapCount);
+          detail += ` (Snapshot count: ${snapCount}, drift: ${drift})`;
+          if (drift > MAX_DRIFT) {
+            status = "fail";
+            blocking = true;
+            detail += ` - Drift ${drift} exceeds maximum allowed ${MAX_DRIFT}`;
+          }
+        } else {
+          status = "fail";
+          blocking = true;
+          detail = `Snapshot file not found at ${SNAPSHOT_PATH}`;
+        }
+      }
+
       checks.push({
         name: "active_subscription_count",
-        status: count > 0 ? "warn" : "pass",
-        detail:
-          count > 0
-            ? `${count} active subscription(s) will be affected by storage migration`
-            : "No active subscriptions",
-        blocking: false,
+        status,
+        detail,
+        blocking,
       });
     }
   } catch (err) {
@@ -505,33 +532,6 @@ async function runChecks(): Promise<ReadinessReport> {
       "migrate",
       [emptyUsers],
       SKIP_KEY_CHECK ? undefined : ADMIN_SECRET || undefined
-async function main(): Promise<void> {
-  if (!CONTRACT_ID) {
-    logger.error("Error: CONTRACT_ID environment variable is required.");
-    process.exit(1);
-  }
-
-  logger.info("=== FlowPay Pre-Upgrade Check ===");
-  logger.info(`Contract : ${CONTRACT_ID}`);
-  logger.info(`RPC URL  : ${RPC_URL}`);
-  logger.info(`Network  : ${NETWORK_PASSPHRASE}`);
-  logger.info("");
-
-  // 1. Admin address
-  const adminVal = await simulateReadOnly("get_admin");
-  const admin = scValToString(adminVal);
-  logger.info(`Admin address      : ${admin}`);
-
-  // 2. Active subscription count
-  const countVal = await simulateReadOnly("get_active_count");
-  const activeCount = scValToString(countVal);
-  logger.info(`Active subscriptions: ${activeCount}`);
-
-  if (Number(activeCount) > 0) {
-    console.warn(
-      `  ⚠  ${activeCount} active subscription(s) will be affected by a storage migration.`,
-    logger.warn(
-      `  ⚠  ${activeCount} active subscription(s) will be affected by a storage migration.`
     );
     if (error) {
       // Auth failures on empty migrate with dummy source are expected without admin key.
@@ -597,6 +597,11 @@ async function main(): Promise<void> {
   const report = await runChecks();
   printReport(report);
 
+  if (REPORT_PATH) {
+    writeFileSync(REPORT_PATH, JSON.stringify(report, null, 2));
+    console.log(`\nReport written to ${REPORT_PATH}`);
+  }
+
   if (!report.ready) {
     console.error("Pre-upgrade check FAILED — resolve blocking issues before upgrading.");
     process.exit(1);
@@ -607,36 +612,9 @@ async function main(): Promise<void> {
   } else {
     console.log("All checks passed. Re-run with --confirm when you are ready to upgrade.");
   }
-  // 3. Schema version
-  const versionVal = await simulateReadOnly("get_schema_version");
-  const schemaVersion = scValToString(versionVal);
-  logger.info(`Schema version     : ${schemaVersion}`);
-  if (Number(schemaVersion) < 2) {
-    console.warn(
-      "  ⚠  Schema is below current version 2 — run migrate() after upgrading.",
-    );
-    logger.warn("  ⚠  Schema is below current version 2 — run migrate() after upgrading.");
-  }
-
-  logger.info("");
-
-  // 4. Confirmation gate
-  if (!CONFIRM) {
-    console.log(
-      "Checks complete. Re-run with --confirm to proceed with the upgrade.",
-    );
-    logger.info("Checks complete. Re-run with --confirm to proceed with the upgrade.");
-    process.exit(0);
-  }
-
-  logger.info("✔  --confirm flag present. Safe to proceed with upgrade.");
 }
 
 main().catch((err) => {
-  console.error(
-    "Pre-upgrade check failed:",
-    err instanceof Error ? err.message : err,
-  );
-  logger.error("Pre-upgrade check failed:", err instanceof Error ? err.message : err);
+  console.error("Pre-upgrade check failed:", err instanceof Error ? err.message : err);
   process.exit(1);
 });


### PR DESCRIPTION
Closes #885 

### Title: 
**Enhance pre-upgrade checks with snapshot drift thresholds and reports**

### Context & Problem
Currently, our contract upgrade runbooks lack strict, automated safety assertions. During a WASM upgrade, we need to guarantee that the contract's state (specifically the active subscription count, schema versions, and fee configurations) hasn't unexpectedly drifted between the time a snapshot is taken and the migration is executed. Without CI-friendly assertions, we risk executing migrations on an inconsistent state.

### What Does This PR Do?
This PR extends `pre-upgrade-check.ts` to support snapshot thresholds and drift tolerance, allowing it to act as a strict CI gate for upgrades. It also documents the formal upgrade runbook in the operations guide.

**Specific Changes:**
1. **Added Threshold/Drift Assertions**: 
   - Introduced `--snapshot <path>` and `--max-drift <number>` CLI arguments.
   - The script now compares the on-chain `get_active_count` against the provided snapshot's `count`.
   - If the difference exceeds `--max-drift`, the check fails and throws a CI-compatible exit code `1`.
2. **Report Artifact Generation**: 
   - Added a `--report <path>` flag (defaults to `pre-upgrade-report.json`).
   - Automatically writes out the comprehensive JSON validation report to disk, making it easy to store as a CI artifact.
3. **Merge Conflict Cleanup**: 
   - Cleaned up lingering duplicate code and a malformed `migrate` simulation block inside `pre-upgrade-check.ts` caused by a prior bad merge.
4. **Documentation Updates**: 
   - Appended a new **Contract Upgrades** operational guide to `scripts/README.md`. It covers the full runbook: taking a snapshot, running the pre-upgrade checks, migrating, and running post-upgrade `snapshot-diff.ts` validations.

### Acceptance Criteria Met
- [x] Fails on `active_count` mismatch beyond tolerance.
- [x] Checks `schema_version` (existing checks maintained and reported properly).
- [x] Checks fee configuration constraints.
- [x] Writes a report artifact to disk.
- [x] Includes an updated README ops section.

### How to Validate / Test
You can run this locally against test fixtures or a testnet deployment. 

1. Generate a dummy snapshot (or use an existing one):
   ```bash
   npx tsx scripts/subscription-snapshot.ts --out before-upgrade.json
   ```
2. Run the upgraded check with a strict drift tolerance:
   ```bash
   CONTRACT_ID=<YOUR_CONTRACT_ID> npx tsx scripts/pre-upgrade-check.ts \
     --snapshot before-upgrade.json \
     --max-drift 0 \
     --report my-report.json
   ```
3. Verify the console output properly displays the drift metrics and that a `my-report.json` file is successfully created in your working directory.