### PR TITLE
Wire EventDedupCache into indexer with layered DB dedup (#873)

### DIFF
--- a/scripts/indexer.ts
+++ b/scripts/indexer.ts
@@ -26,6 +26,19 @@
  *   POLL_INTERVAL_MS   Optional. Polling interval in ms (default: 10000).
  *   START_LEDGER       Optional. Ledger to start from on first run (default: latest).
  *   LOG_LEVEL          Optional. "debug" | "info" | "error" (default: info).
+ *   EVENT_DEDUP_CACHE_SIZE  Optional. Max EventDedupCache entries (default: 1000).
+ *   EVENT_DEDUP_TTL_MS      Optional. EventDedupCache entry TTL in ms (default: 0 = no TTL).
+ *
+ * Deduplication
+ * ─────────────
+ * Events are deduplicated with a two-layer strategy (see event-dedup.ts):
+ *   1. In-memory EventDedupCache — skips redundant DB writes for events seen
+ *      earlier in the same process's uptime (cheap, but lost on restart).
+ *   2. SQLite `ON CONFLICT(id)` upsert, keyed on tx_hash+event_name — the
+ *      durable guarantee. Restart safety comes from this layer plus the
+ *      `last_ledger` cursor in the `meta` table, not from the in-memory cache.
+ * Dedup stats (hits/misses/evictions) are logged periodically and, when
+ * metrics-server.ts is wired in by the caller, exported as Prometheus counters.
  *
  * Exit codes:
  *   0 — graceful shutdown (SIGINT / SIGTERM)
@@ -35,11 +48,13 @@
 import { DatabaseSync } from "node:sqlite";
 import { mkdirSync } from "node:fs";
 import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { Server } from "@stellar/stellar-sdk/rpc";
+import { EventDedupCache, type DedupStats } from "./event-dedup.js";
+import { recordIndexerDedupStats } from "./metrics-server.js";
 
 // ── Configuration ─────────────────────────────────────────────────────────────
 
-const CONTRACT_ID = process.env.CONTRACT_ID ?? "";
 const RPC_URL = process.env.RPC_URL ?? "https://soroban-testnet.stellar.org";
 const POLL_INTERVAL_MS = parseInt(process.env.POLL_INTERVAL_MS ?? "10000", 10);
 const LOG_LEVEL = (process.env.LOG_LEVEL ?? "info") as
@@ -51,11 +66,16 @@ const DB_FILE = process.env.DB_FILE ?? resolve(DATA_DIR, "events.db");
 /** Schema version — increment when adding columns or new tables. */
 const SCHEMA_VERSION = 1;
 
-if (!CONTRACT_ID) {
-  console.error("Error: CONTRACT_ID environment variable is required.");
-  console.error("Usage: CONTRACT_ID=<id> tsx indexer.ts");
-  process.exit(1);
-}
+/**
+ * Number of unique events processed between periodic dedup-stats log lines
+ * and metrics-server snapshots.
+ */
+const DEDUP_STATS_LOG_INTERVAL = 100;
+
+// CONTRACT_ID is read here but only validated inside main() — this lets the
+// module be imported (e.g. by tests) without requiring the env var or
+// exiting the process.
+const CONTRACT_ID = process.env.CONTRACT_ID ?? "";
 
 // ── Logging ───────────────────────────────────────────────────────────────────
 
@@ -95,7 +115,7 @@ interface IndexedEvent {
 
 // ── Database Setup ────────────────────────────────────────────────────────────
 
-function openDatabase(filePath: string): DatabaseSync {
+export function openDatabase(filePath: string): DatabaseSync {
   // Ensure the parent directory exists.
   mkdirSync(dirname(filePath), { recursive: true });
   const db = new DatabaseSync(filePath);
@@ -112,7 +132,7 @@ function openDatabase(filePath: string): DatabaseSync {
  * Create tables and apply migrations if the schema version has changed.
  * Adding new columns/tables here is the only required migration step.
  */
-function initSchema(db: DatabaseSync): void {
+export function initSchema(db: DatabaseSync): void {
   // meta table — key/value pairs for indexer state.
   db.exec(`
     CREATE TABLE IF NOT EXISTS meta (
@@ -157,13 +177,13 @@ function initSchema(db: DatabaseSync): void {
 
 // ── Meta Key/Value Helpers ────────────────────────────────────────────────────
 
-function getMeta(db: DatabaseSync, key: string): string | null {
+export function getMeta(db: DatabaseSync, key: string): string | null {
   const row = db.prepare("SELECT value FROM meta WHERE key = ?").get(key) as
     { value: string } | undefined;
   return row?.value ?? null;
 }
 
-function setMeta(db: DatabaseSync, key: string, value: string): void {
+export function setMeta(db: DatabaseSync, key: string, value: string): void {
   db.prepare(
     "INSERT INTO meta(key, value) VALUES(?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value",
   ).run(key, value);
@@ -210,7 +230,7 @@ function parseTimestamp(event: Record<string, unknown>): number {
  * Convert a raw RPC event object into an IndexedEvent.
  * Returns null if the event cannot be meaningfully parsed (malformed topic).
  */
-function parseEvent(raw: Record<string, unknown>): IndexedEvent | null {
+export function parseEvent(raw: Record<string, unknown>): IndexedEvent | null {
   const topic = raw["topic"] as unknown[] | undefined;
   if (!Array.isArray(topic) || topic.length < 1) return null;
 
@@ -263,7 +283,7 @@ const INSERT_SQL = `
  * Upsert a batch of events inside a single transaction for throughput.
  * Returns the number of rows actually written (new inserts + updates).
  */
-function upsertEvents(db: DatabaseSync, events: IndexedEvent[]): number {
+export function upsertEvents(db: DatabaseSync, events: IndexedEvent[]): number {
   if (events.length === 0) return 0;
   const stmt = db.prepare(INSERT_SQL);
   db.exec("BEGIN");
@@ -288,15 +308,102 @@ function upsertEvents(db: DatabaseSync, events: IndexedEvent[]): number {
   return events.length;
 }
 
+// ── Deduplication ────────────────────────────────────────────────────────────
+
+/** Result of running a batch of raw events through the layered dedup pipeline. */
+export interface DedupIndexResult {
+  /** Rows actually written to the DB (new inserts + updates to changed rows). */
+  written: number;
+  /** Events skipped because the in-memory EventDedupCache had already seen them. */
+  duplicatesSkipped: number;
+  /** Events that failed to parse (malformed topic) and were dropped. */
+  unparsed: number;
+}
+
+/**
+ * Parse raw RPC events, filter out duplicates via the in-memory
+ * EventDedupCache, and upsert the remaining unique events into the DB.
+ *
+ * This is the layered dedup strategy from issue #078:
+ *   - Layer 1 (in-memory): `dedup.checkAndRecord` skips a DB write entirely
+ *     for events already seen earlier in this process's uptime.
+ *   - Layer 2 (DB): `upsertEvents`'s `ON CONFLICT(id)` still guards against
+ *     duplicates that layer 1 misses — e.g. right after a restart, when the
+ *     in-memory cache is empty but the DB already has the row.
+ *
+ * Kept separate from `pollOnce` so it can be exercised directly in tests
+ * without going through the RPC client.
+ */
+export function indexEvents(
+  db: DatabaseSync,
+  dedup: EventDedupCache,
+  rawEvents: Record<string, unknown>[],
+): DedupIndexResult {
+  const parsed: IndexedEvent[] = [];
+  let duplicatesSkipped = 0;
+  let unparsed = 0;
+
+  for (const raw of rawEvents) {
+    const event = parseEvent(raw);
+    if (!event) {
+      unparsed++;
+      continue;
+    }
+
+    // checkAndRecord returns true when this (tx_hash, event_name, ledger)
+    // combination is already in the cache — skip the redundant DB write.
+    if (dedup.checkAndRecord(event.tx_hash, event.event_name, event.ledger)) {
+      duplicatesSkipped++;
+      continue;
+    }
+
+    parsed.push(event);
+  }
+
+  const written = upsertEvents(db, parsed);
+  return { written, duplicatesSkipped, unparsed };
+}
+
 // ── Polling Loop ──────────────────────────────────────────────────────────────
 
 const server = new Server(RPC_URL);
 
+/** Unique events processed since the last dedup-stats log/metrics snapshot. */
+let eventsSinceLastStatsLog = 0;
+
 /**
- * Fetch one page of events starting from `fromLedger`, parse them, upsert
- * into the DB, and return the new cursor ledger to resume from next time.
+ * Log a periodic dedup-stats line and push a snapshot to metrics-server,
+ * throttled to roughly every `DEDUP_STATS_LOG_INTERVAL` unique events.
  */
-async function pollOnce(db: DatabaseSync, fromLedger: number): Promise<number> {
+function maybeReportDedupStats(dedup: EventDedupCache, forceLog = false): void {
+  const stats: DedupStats = dedup.stats;
+
+  // metrics-server counters are cheap in-memory updates — safe to call
+  // every poll regardless of the log throttle below.
+  recordIndexerDedupStats(stats);
+
+  if (!forceLog && eventsSinceLastStatsLog < DEDUP_STATS_LOG_INTERVAL) return;
+  eventsSinceLastStatsLog = 0;
+
+  log(
+    "info",
+    `[dedup] ${stats.deduplicatedTotal} duplicates skipped, ` +
+      `${stats.totalProcessed} unique processed, ` +
+      `${stats.size}/${stats.maxSize} cache entries, ` +
+      `${stats.evictions} evictions`,
+  );
+}
+
+/**
+ * Fetch one page of events starting from `fromLedger`, deduplicate and
+ * upsert them into the DB, and return the new cursor ledger to resume from
+ * next time.
+ */
+async function pollOnce(
+  db: DatabaseSync,
+  fromLedger: number,
+  dedup: EventDedupCache,
+): Promise<number> {
   log("debug", `Polling from ledger ${fromLedger}...`);
 
   let response: Awaited<ReturnType<typeof server.getEvents>>;
@@ -316,17 +423,20 @@ async function pollOnce(db: DatabaseSync, fromLedger: number): Promise<number> {
   }
 
   const rawEvents = response.events as unknown as Record<string, unknown>[];
-  const parsed: IndexedEvent[] = [];
+  const { written, duplicatesSkipped, unparsed } = indexEvents(db, dedup, rawEvents);
 
-  for (const raw of rawEvents) {
-    const event = parseEvent(raw);
-    if (event) parsed.push(event);
+  if (written > 0 || duplicatesSkipped > 0) {
+    log(
+      "info",
+      `Ledger ${fromLedger}: upserted ${written} event(s), ` +
+        `skipped ${duplicatesSkipped} duplicate(s)` +
+        (unparsed > 0 ? `, dropped ${unparsed} unparsable` : "") +
+        ".",
+    );
   }
 
-  if (parsed.length > 0) {
-    const written = upsertEvents(db, parsed);
-    log("info", `Ledger ${fromLedger}: upserted ${written} event(s).`);
-  }
+  eventsSinceLastStatsLog += written + duplicatesSkipped;
+  maybeReportDedupStats(dedup);
 
   // Advance cursor to latestLedger + 1 so the next poll only sees new ledgers.
   // If the RPC returned no events it still advances, preventing stuck cursors.
@@ -350,6 +460,12 @@ async function resolveStartLedger(): Promise<number> {
 }
 
 async function main(): Promise<void> {
+  if (!CONTRACT_ID) {
+    console.error("Error: CONTRACT_ID environment variable is required.");
+    console.error("Usage: CONTRACT_ID=<id> tsx indexer.ts");
+    process.exit(1);
+  }
+
   log("info", "FlowPay Event Indexer starting.");
   log("info", `RPC:      ${RPC_URL}`);
   log("info", `Contract: ${CONTRACT_ID}`);
@@ -358,6 +474,13 @@ async function main(): Promise<void> {
 
   const db = openDatabase(DB_FILE);
   initSchema(db);
+
+  const dedup = new EventDedupCache();
+  log(
+    "info",
+    `Dedup cache: ${dedup.stats.maxSize} entries` +
+      (process.env.EVENT_DEDUP_TTL_MS ? `, TTL: ${process.env.EVENT_DEDUP_TTL_MS}ms` : ""),
+  );
 
   // Determine the ledger to resume from.
   const savedLedger = getMeta(db, "last_ledger");
@@ -386,7 +509,7 @@ async function main(): Promise<void> {
   log("info", "Indexer running. Press Ctrl-C to stop.");
 
   while (!shutdown) {
-    const nextLedger = await pollOnce(db, currentLedger);
+    const nextLedger = await pollOnce(db, currentLedger, dedup);
 
     if (nextLedger !== currentLedger) {
       currentLedger = nextLedger;
@@ -400,14 +523,25 @@ async function main(): Promise<void> {
     }
   }
 
+  // Final stats line so the last stretch of activity (< DEDUP_STATS_LOG_INTERVAL
+  // events) still gets reported before the process exits.
+  maybeReportDedupStats(dedup, /* forceLog */ true);
+
   db.close();
   log("info", `Indexer stopped. Last indexed ledger: ${currentLedger}.`);
   process.exit(0);
 }
 
-main().catch((err: unknown) => {
-  console.error(
-    `Fatal error: ${err instanceof Error ? err.message : String(err)}`,
-  );
-  process.exit(1);
-});
+// ESM entrypoint guard: only auto-run main() when this file is executed
+// directly (`tsx indexer.ts`), not when it's imported — e.g. by tests, which
+// import parseEvent/upsertEvents/indexEvents/etc. without wanting a live
+// RPC-polling process or a CONTRACT_ID requirement.
+const isMain = process.argv[1] === fileURLToPath(import.meta.url);
+if (isMain) {
+  main().catch((err: unknown) => {
+    console.error(
+      `Fatal error: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    process.exit(1);
+  });
+}

--- a/scripts/metrics-server.ts
+++ b/scripts/metrics-server.ts
@@ -21,6 +21,9 @@
  *   keeper_active_subscribers            — Gauge, current active subscriber count
  *   keeper_batch_size                    — Gauge, addresses per batch
  *   keeper_cycles_total                  — Counter, total charge cycles run
+ *   indexer_duplicate_events_total       — Counter, duplicate events skipped by EventDedupCache
+ *   indexer_dedup_cache_size             — Gauge, current EventDedupCache entry count
+ *   indexer_dedup_evictions_total        — Counter, LRU evictions from EventDedupCache
  */
 
 import http from "node:http";
@@ -85,6 +88,27 @@ const cyclesTotal = new Counter({
   registers: [registry],
 });
 
+/** Total duplicate events skipped by an EventDedupCache (indexer, watch-events, etc.). */
+const indexerDuplicatesTotal = new Counter({
+  name: "indexer_duplicate_events_total",
+  help: "Total number of duplicate events skipped via EventDedupCache",
+  registers: [registry],
+});
+
+/** Current number of entries held in the EventDedupCache. */
+const indexerDedupCacheSize = new Gauge({
+  name: "indexer_dedup_cache_size",
+  help: "Current entry count of the EventDedupCache",
+  registers: [registry],
+});
+
+/** Total LRU evictions performed by the EventDedupCache. */
+const indexerDedupEvictionsTotal = new Counter({
+  name: "indexer_dedup_evictions_total",
+  help: "Total number of LRU evictions performed by the EventDedupCache",
+  registers: [registry],
+});
+
 // ── Public API for the keeper run loop ───────────────────────────────────────
 
 /**
@@ -137,6 +161,34 @@ export function incrementCycles(): void {
 /** Record a batch_charge duration manually. */
 export function observeBatchDuration(durationMs: number): void {
   batchDurationSeconds.observe(durationMs / 1000);
+}
+
+// Prometheus Counters only support incrementing by a delta, but
+// EventDedupCache.stats reports cumulative totals — track the last-seen
+// cumulative values here so repeated calls only add the difference.
+let lastDedupHits = 0;
+let lastDedupEvictions = 0;
+
+/**
+ * Record a snapshot of `EventDedupCache.stats` (hits/evictions/size) into the
+ * Prometheus registry. Safe to call repeatedly (e.g. once per poll cycle) —
+ * counters are incremented by the delta since the last call, and the size
+ * gauge is set to the current value.
+ */
+export function recordIndexerDedupStats(stats: {
+  hits: number;
+  evictions: number;
+  size: number;
+}): void {
+  const hitsDelta = stats.hits - lastDedupHits;
+  if (hitsDelta > 0) indexerDuplicatesTotal.inc(hitsDelta);
+  lastDedupHits = stats.hits;
+
+  const evictionsDelta = stats.evictions - lastDedupEvictions;
+  if (evictionsDelta > 0) indexerDedupEvictionsTotal.inc(evictionsDelta);
+  lastDedupEvictions = stats.evictions;
+
+  indexerDedupCacheSize.set(stats.size);
 }
 
 /**

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -15,7 +15,8 @@
     "pre-upgrade-check": "tsx pre-upgrade-check.ts",
     "subscriber-health": "tsx subscriber-health-dashboard.ts",
     "typecheck": "tsc --noEmit",
-    "lint": "tsc --noEmit --strict --noUnusedLocals --noUnusedParameters"
+    "lint": "tsc --noEmit --strict --noUnusedLocals --noUnusedParameters",
+    "test:event-dedup": "tsx test-event-dedup-integration.ts"
   },
   "dependencies": {
     "@stellar/stellar-sdk": "^12.0.0",

--- a/scripts/test-event-dedup-integration.ts
+++ b/scripts/test-event-dedup-integration.ts
@@ -1,0 +1,238 @@
+#!/usr/bin/env tsx
+/**
+ * test-event-dedup-integration.ts — Tests for EventDedupCache integration
+ * into the indexer pipeline (issue #078).
+ *
+ * Covers:
+ *   1. EventDedupCache core semantics (hits/misses/evictions/stats).
+ *   2. Layer 1 — in-memory dedup: indexEvents() collapses duplicate raw
+ *      events within/across polls into a single DB write.
+ *   3. Layer 2 — DB dedup: even with a cold (post-restart) in-memory cache,
+ *      the SQLite `ON CONFLICT` upsert still prevents duplicate rows.
+ *   4. metrics-server.ts counters reflect cumulative dedup stats correctly.
+ *
+ * Run directly: tsx test-event-dedup-integration.ts
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { EventDedupCache, createCacheKey } from "./event-dedup.js";
+import {
+  openDatabase,
+  initSchema,
+  indexEvents,
+  parseEvent,
+} from "./indexer.js";
+import { recordIndexerDedupStats, metricsText } from "./metrics-server.js";
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) {
+    throw new Error(`Assertion failed: ${message}`);
+  }
+}
+
+function assertEqual<T>(actual: T, expected: T, message: string): void {
+  assert(
+    actual === expected,
+    `${message} (expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)})`,
+  );
+}
+
+/** Build a raw RPC-shaped event object like the Soroban SDK returns. */
+function rawEvent(opts: {
+  txHash: string;
+  eventName: string;
+  ledger: number;
+  address?: string;
+  amount?: number;
+}): Record<string, unknown> {
+  return {
+    topic: [opts.eventName, opts.address ?? "GADDRESS"],
+    ledger: opts.ledger,
+    txHash: opts.txHash,
+    ledgerClosedAt: new Date().toISOString(),
+    value: opts.amount !== undefined ? { amount: opts.amount } : {},
+  };
+}
+
+// ── 1. EventDedupCache core semantics ───────────────────────────────────────
+
+function testDedupCacheCore(): void {
+  console.log("Testing EventDedupCache core semantics...");
+
+  const cache = new EventDedupCache(3, 0);
+
+  assertEqual(cache.checkAndRecord("tx1", "charged", 100), false, "first sighting is a miss");
+  assertEqual(cache.checkAndRecord("tx1", "charged", 100), true, "second sighting is a hit");
+  assertEqual(cache.stats.hits, 1, "one hit recorded");
+  assertEqual(cache.stats.misses, 1, "one miss recorded");
+
+  // Different ledger for the same tx/event is a distinct entry.
+  assertEqual(cache.checkAndRecord("tx1", "charged", 101), false, "different ledger is a new entry");
+
+  // Fill to capacity (3) and force an eviction.
+  cache.checkAndRecord("tx2", "charged", 102); // size now 3
+  assertEqual(cache.stats.size, 3, "cache at capacity");
+  cache.checkAndRecord("tx3", "charged", 103); // evicts tx1@100 (LRU)
+  assertEqual(cache.stats.evictions, 1, "eviction occurred at capacity");
+  assertEqual(
+    cache.checkAndRecord("tx1", "charged", 100),
+    false,
+    "evicted entry is treated as new again",
+  );
+
+  console.log("  OK");
+}
+
+// ── 2 & 3. Layered dedup: in-memory + DB ────────────────────────────────────
+
+function testLayeredDedup(): void {
+  console.log("Testing layered dedup (in-memory cache + DB upsert)...");
+
+  const dir = mkdtempSync(join(tmpdir(), "payflow-dedup-test-"));
+  const dbFile = join(dir, "events.db");
+
+  try {
+    // ── First process lifetime ──────────────────────────────────────────
+    const db = openDatabase(dbFile);
+    initSchema(db);
+    const dedup = new EventDedupCache();
+
+    const events = [
+      rawEvent({ txHash: "txA", eventName: "charged", ledger: 500, amount: 100 }),
+      rawEvent({ txHash: "txA", eventName: "charged", ledger: 500, amount: 100 }), // exact duplicate
+      rawEvent({ txHash: "txB", eventName: "subscribed", ledger: 500 }),
+    ];
+
+    const result1 = indexEvents(db, dedup, events);
+    assertEqual(result1.written, 2, "two unique events written on first batch");
+    assertEqual(result1.duplicatesSkipped, 1, "one duplicate skipped by in-memory cache");
+    assertEqual(dedup.stats.deduplicatedTotal, 1, "dedup cache stats reflect the hit");
+
+    // Same event arrives again in a later poll within the same process
+    // (e.g. RPC returned overlapping ledger range) — layer 1 catches it.
+    const result2 = indexEvents(db, dedup, [
+      rawEvent({ txHash: "txA", eventName: "charged", ledger: 500, amount: 100 }),
+    ]);
+    assertEqual(result2.written, 0, "in-memory cache skips the repeat, no DB write");
+    assertEqual(result2.duplicatesSkipped, 1, "counted as a duplicate");
+
+    const rowCountAfterFirstLifetime = (
+      db.prepare("SELECT COUNT(*) as n FROM events").get() as { n: number }
+    ).n;
+    assertEqual(rowCountAfterFirstLifetime, 2, "exactly 2 distinct rows in the DB");
+
+    db.close();
+
+    // ── Simulated restart: fresh process, fresh (cold) in-memory cache ──
+    const dbAfterRestart = openDatabase(dbFile);
+    initSchema(dbAfterRestart);
+    const dedupAfterRestart = new EventDedupCache(); // cold — no memory of prior events
+
+    // The same txA/charged/500 event is reprocessed (e.g. indexer resumed
+    // from a ledger slightly before its stored cursor). The in-memory cache
+    // has no record of it, but the DB's ON CONFLICT(id) must still prevent
+    // a duplicate row — this is the "restart safety via SQLite meta ledger"
+    // acceptance criterion.
+    const result3 = indexEvents(dbAfterRestart, dedupAfterRestart, [
+      rawEvent({ txHash: "txA", eventName: "charged", ledger: 500, amount: 100 }),
+    ]);
+    assertEqual(result3.written, 1, "cold cache treats it as new and re-upserts (UPDATE, not duplicate row)");
+    assertEqual(result3.duplicatesSkipped, 0, "cold cache reports no in-memory duplicate");
+
+    const rowCountAfterRestart = (
+      dbAfterRestart.prepare("SELECT COUNT(*) as n FROM events").get() as { n: number }
+    ).n;
+    assertEqual(rowCountAfterRestart, 2, "row count unchanged — DB layer absorbed the repeat as an UPDATE");
+
+    dbAfterRestart.close();
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+
+  console.log("  OK");
+}
+
+// ── 4. Malformed events are dropped, not mistaken for duplicates ───────────
+
+function testUnparsableEventsDoNotCountAsDuplicates(): void {
+  console.log("Testing that unparsable events are dropped, not deduped...");
+
+  const dir = mkdtempSync(join(tmpdir(), "payflow-dedup-test-"));
+  const dbFile = join(dir, "events.db");
+
+  try {
+    const db = openDatabase(dbFile);
+    initSchema(db);
+    const dedup = new EventDedupCache();
+
+    const result = indexEvents(db, dedup, [
+      { topic: [] }, // no event name -> unparsable
+      rawEvent({ txHash: "txC", eventName: "cancelled", ledger: 900 }),
+    ]);
+
+    assertEqual(result.unparsed, 1, "malformed event counted as unparsed");
+    assertEqual(result.written, 1, "the valid event is still written");
+    assertEqual(result.duplicatesSkipped, 0, "malformed event never reaches the dedup cache");
+    assertEqual(parseEvent({ topic: [] }), null, "parseEvent itself returns null for malformed topic");
+
+    db.close();
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+
+  console.log("  OK");
+}
+
+// ── 5. metrics-server counters track cumulative dedup stats ────────────────
+
+async function testMetricsIntegration(): Promise<void> {
+  console.log("Testing metrics-server dedup counters...");
+
+  const dedup = new EventDedupCache(10, 0);
+  dedup.checkAndRecord("tx1", "charged", 1);
+  dedup.checkAndRecord("tx1", "charged", 1); // hit #1
+
+  recordIndexerDedupStats(dedup.stats);
+
+  dedup.checkAndRecord("tx1", "charged", 1); // hit #2
+  recordIndexerDedupStats(dedup.stats);
+
+  const text = await metricsText();
+  assert(
+    text.includes("indexer_duplicate_events_total 2"),
+    "indexer_duplicate_events_total should reflect 2 cumulative hits",
+  );
+  assert(
+    text.includes("indexer_dedup_cache_size 1"),
+    "indexer_dedup_cache_size should reflect the current cache size",
+  );
+
+  console.log("  OK");
+}
+
+// ── createCacheKey sanity (used by log lines / debugging) ──────────────────
+
+function testCreateCacheKey(): void {
+  console.log("Testing createCacheKey format...");
+  assertEqual(
+    createCacheKey("txA", "charged", 500),
+    "txA:charged:500",
+    "cache key format is txHash:eventName:ledger",
+  );
+  console.log("  OK");
+}
+
+async function runTests(): Promise<void> {
+  testDedupCacheCore();
+  testCreateCacheKey();
+  testLayeredDedup();
+  testUnparsableEventsDoNotCountAsDuplicates();
+  await testMetricsIntegration();
+  console.log("All event-dedup integration tests passed!");
+}
+
+runTests().catch((err) => {
+  console.error(err instanceof Error ? err.message : err);
+  process.exit(1);
+});


### PR DESCRIPTION
Closes #873

Adds a layered dedup strategy to indexer.ts:

In-memory — EventDedupCache skips redundant DB writes for events already seen in the current process's uptime.
DB — existing SQLite ON CONFLICT upsert stays as the durable guard, so restart safety is unaffected.

Also:

Exposes indexer_duplicate_events_total, indexer_dedup_cache_size, and indexer_dedup_evictions_total counters in metrics-server.ts.
Refactors the parse→dedup→upsert loop into an exported indexEvents() for testability, with an ESM isMain guard so indexer.ts can be imported without requiring CONTRACT_ID or starting a live poll loop.
Adds test-event-dedup-integration.ts covering cache LRU/eviction, duplicate collapsing, restart-safety (cold cache + DB), and metrics counters — run via npm run test:event-dedup.

watch-events.ts already had EventDedupCache wired in prior to this PR; this closes the remaining gap in the indexer.